### PR TITLE
Fix and improve version string for IRB

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -356,8 +356,7 @@ module IRB
   def IRB.version
     if v = @CONF[:VERSION] then return v end
 
-    rv = @RELEASE_VERSION.sub(/\.0/, "")
-    @CONF[:VERSION] = format("irb %s(%s)", rv, @LAST_UPDATE_DATE)
+    @CONF[:VERSION] = format("irb %s (%s)", @RELEASE_VERSION, @LAST_UPDATE_DATE)
   end
 
   # The current IRB::Context of the session, see IRB.conf

--- a/lib/irb/version.rb
+++ b/lib/irb/version.rb
@@ -13,5 +13,5 @@
 module IRB # :nodoc:
   VERSION = "0.9.6"
   @RELEASE_VERSION = VERSION
-  @LAST_UPDATE_DATE = "09/06/30"
+  @LAST_UPDATE_DATE = "2009-06-30"
 end


### PR DESCRIPTION
Fix and improve IRB.version and the output of `irb -v` respectively.
For an (assumed) version of e.g. 1.0.1 this changes the generated
version string from `irb 1.1(09/06/30)` to `irb 1.0.1 (2009-06-30)`.

* Fix a bug where any `.0` part is removed from the version string
  (presumably intended for only the "tiny" part of the version);
  instead, always leave the version unmodified.
* Use a better date format (conforming to ISO 8601).
* Add a whitespace between version and date part.

_BTW, the version was not changed since 2009 (!), in spite of numerous changes._