### PR TITLE
Add currently supported ruby versions to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.5.1
+  - 2.6.0
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
   - ruby-head
 before_install: gem install bundler -v 1.16.2


### PR DESCRIPTION
I noticed that only ruby 2.5.1 was being tested in travis. We should add all the currently supported versions to travis as well.