### PR TITLE
unlock bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ language: ruby
 rvm:
   - 2.5.1
   - ruby-head
-before_install: gem install bundler -v 1.16.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ rvm:
   - ruby-head
 before_install:
   - gem update --system
-  - gem install bundler -v 1.16.2
+
 script: rake test


### PR DESCRIPTION
Bundler does not need to be locked to 1.16.2, the repo doesn't have a `Gemfile.lock`, so we should just install the latest version.