### PR TITLE
Fix breaking specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ rvm:
 before_install:
   - gem update --system
   - gem install bundler -v 1.16.2
+
+script: rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ language: ruby
 rvm:
   - 2.5.1
   - ruby-head
-before_install: gem install bundler -v 1.16.2
+before_install:
+  - gem update --system
+  - gem install bundler -v 1.16.2

--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -116,7 +116,11 @@ EOF
     end
 
     def code_around_binding
-      file, pos = @binding.source_location
+      if @binding.respond_to?(:source_location)
+        file, pos = @binding.source_location
+      else
+        file, pos = @binding.eval('[__FILE__, __LINE__]')
+      end
 
       unless defined?(::SCRIPT_LINES__[file]) && lines = ::SCRIPT_LINES__[file]
         begin


### PR DESCRIPTION
the test suite is currently only working on Ruby 2.6 because of a
new method on Binding that older versions of Ruby do not have.

This PR fixes the test suite by checking for the method and using the
previous method if it's not available.