### PR TITLE
fix breaking workspace test on ruby 2.3

### DIFF
--- a/test/irb/test_workspace.rb
+++ b/test/irb/test_workspace.rb
@@ -6,7 +6,7 @@ require 'irb/workspace'
 module TestIRB
   class TestWorkSpace < Test::Unit::TestCase
     def test_code_around_binding
-      Tempfile.create do |f|
+      Tempfile.create('irb') do |f|
         code = <<~RUBY
           # 1
           # 2
@@ -36,7 +36,7 @@ module TestIRB
       skip 'chmod cannot make file unreadable on windows' if windows?
       skip 'skipped in root privilege' if Process.uid == 0
 
-      Tempfile.create do |f|
+      Tempfile.create('irb') do |f|
         code = "IRB::WorkSpace.new(binding)\n"
         f.print(code)
         f.close
@@ -50,7 +50,7 @@ module TestIRB
 
     def test_code_around_binding_with_script_lines__
       with_script_lines do |script_lines|
-        Tempfile.create do |f|
+        Tempfile.create('irb') do |f|
           code = "IRB::WorkSpace.new(binding)\n"
           script_lines[f.path] = code.split(/^/)
 


### PR DESCRIPTION
The test suite is currently not passing on Ruby 2.3 due to `Tempfile.create` requiring an argument. See https://travis-ci.com/ruby/irb/jobs/167607309 for the log, Later Ruby versions do not require any arguments.

This PR fixes the outstanding issue and should have tests passing on all versions 🎉.