### PR TITLE
Don't echo results of assignment expressions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gemspec
+
+gem "parser", "~> 2.6"

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -10,7 +10,6 @@
 #
 #
 require 'parser/current'
-require 'parser/tree_rewriter'
 
 require_relative "workspace"
 require_relative "inspector"


### PR DESCRIPTION
This is a proof of concept for something I'd like to see added to irb. The ability for the interpreter to not echo results of assignment expressions.

I'm guessing this exact patch wouldn't be accepted because:

1. You won't want to pull in another gem, and
2. You might want the semantics of the `IRB.conf[:ECHO]` setting to stay the same (ie `true` always echos and `false` never echos)

As to 1: I'm guessing irb and ruby have other ways of doing expression parsing that maybe could be hooked into instead of using the `parser` gem. I'm just not very familiar with those possible methods, and I found `parser` easy to use to express the functionality I was looking for.

For 2: Would a third value other than `true` or `false` for that setting be acceptable? Like `:non_assignment_expressions`? Or maybe another setting altogether: `IRB.conf[:NO_ECHO_ON_ASSIGNMENT]`? So that only when `IRB.conf[:ECHO]` and `IRB.conf[:NO_ECHO_ON_ASSIGNMENT]` are `true` would the advanced echo/noecho logic be used.