### PR TITLE
CI: Use 2.4.6, 2.5.5, 2.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
-sudo: false
 language: ruby
 rvm:
-  - 2.6.1
-  - 2.5.3
-  - 2.4.5
+  - 2.6.2
+  - 2.5.5
+  - 2.4.6
   - 2.3.8
   - ruby-head
 before_install:


### PR DESCRIPTION
This PR updates the CI matrix.

 - Also: Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration