### PR TITLE
Avoid warning about unused local variable

### DIFF
--- a/test/irb/test_raise_no_backtrace_exception.rb
+++ b/test/irb/test_raise_no_backtrace_exception.rb
@@ -4,7 +4,7 @@ require 'test/unit'
 module TestIRB
   class TestRaiseNoBacktraceException < Test::Unit::TestCase
     def test_raise_exception
-      status = assert_in_out_err(%w[-rirb -e IRB.start(__FILE__) -- -f --], <<-IRB, /Exception: foo/, [])
+      assert_in_out_err(%w[-rirb -e IRB.start(__FILE__) -- -f --], <<-IRB, /Exception: foo/, [])
       e = Exception.new("foo")
       def e.backtrace; nil; end
       raise e


### PR DESCRIPTION
This PR **avoids warning** output in the **test** runs.

## Before:

```
$ rake test
/home/travis/build/ruby/irb/test/irb/test_raise_no_backtrace_exception.rb:7: warning: assigned but unused variable - status
Run options: 
```

## After:

```
$ rake test
Run options: 
```