### PR TITLE
Suppress warnings

### DIFF
--- a/lib/irb/ext/history.rb
+++ b/lib/irb/ext/history.rb
@@ -22,7 +22,7 @@ module IRB # :nodoc:
     def set_last_value(value)
       _set_last_value(value)
 
-      if @eval_history
+      if defined?(@eval_history) && @eval_history
         @eval_history_values.push @line_no, @last_value
         @workspace.evaluate self, "__ = IRB.CurrentContext.instance_eval{@eval_history_values}"
       end
@@ -30,6 +30,7 @@ module IRB # :nodoc:
       @last_value
     end
 
+    remove_method :eval_history= if method_defined?(:eval_history=)
     # The command result history limit.
     attr_reader :eval_history
     # Sets command result history limit.

--- a/lib/irb/ext/save-history.rb
+++ b/lib/irb/ext/save-history.rb
@@ -27,7 +27,7 @@ module IRB
       IRB.conf[:SAVE_HISTORY]
     end
 
-    remove_method :save_history= if respond_to?(:save_history=)
+    remove_method :save_history= if method_defined?(:save_history=)
     # Sets <code>IRB.conf[:SAVE_HISTORY]</code> to the given +val+ and calls
     # #init_save_history with this context.
     #

--- a/lib/irb/ext/use-loader.rb
+++ b/lib/irb/ext/use-loader.rb
@@ -20,10 +20,12 @@ end
 
 module IRB
   module ExtendCommandBundle
+    remove_method :irb_load if method_defined?(:irb_load)
     # Loads the given file similarly to Kernel#load, see IrbLoader#irb_load
     def irb_load(*opts, &b)
       ExtendCommand::Load.execute(irb_context, *opts, &b)
     end
+    remove_method :irb_require if method_defined?(:irb_require)
     # Loads the given file similarly to Kernel#require
     def irb_require(*opts, &b)
       ExtendCommand::Require.execute(irb_context, *opts, &b)
@@ -44,6 +46,7 @@ module IRB
 
     alias use_loader? use_loader
 
+    remove_method :use_loader= if method_defined?(:use_loader=)
     # Sets IRB.conf[:USE_LOADER]
     #
     # See #use_loader for more information.


### PR DESCRIPTION
IRB displays warnings when it loads extensions.


```console
$ RUBYOPT='-w -Ilib/' exe/irb -f -r irb/ext/history.rb
/home/pocke/ghq/github.com/ruby/irb/lib/irb/ext/history.rb:44: warning: method redefined; discarding old eval_history=
/home/pocke/ghq/github.com/ruby/irb/lib/irb/extend-command.rb:239: warning: previous definition of eval_history= was here
irb(main):001:0> 


$ RUBYOPT='-w -Ilib/' exe/irb -f -r irb/ext/use-loader.rb
/home/pocke/ghq/github.com/ruby/irb/lib/irb/ext/use-loader.rb:24: warning: method redefined; discarding old irb_load
/home/pocke/ghq/github.com/ruby/irb/lib/irb/extend-command.rb:142: warning: previous definition of irb_load was here
/home/pocke/ghq/github.com/ruby/irb/lib/irb/ext/use-loader.rb:28: warning: method redefined; discarding old irb_require
/home/pocke/ghq/github.com/ruby/irb/lib/irb/extend-command.rb:142: warning: previous definition of irb_require was here
/home/pocke/ghq/github.com/ruby/irb/lib/irb/ext/use-loader.rb:50: warning: method redefined; discarding old use_loader=
/home/pocke/ghq/github.com/ruby/irb/lib/irb/extend-command.rb:239: warning: previous definition of use_loader= was here
irb(main):001:0> 


$ RUBYOPT='-w -Ilib/' exe/irb -f -r irb/ext/save-history.rb
/home/pocke/ghq/github.com/ruby/irb/lib/irb/ext/save-history.rb:40: warning: method redefined; discarding old save_history=
/home/pocke/ghq/github.com/ruby/irb/lib/irb/extend-command.rb:239: warning: previous definition of save_history= was here
irb(main):001:0> 
```


This change will suppress the warnings.



Note
===


I cannot load `irb/ext/tracer.rb` because of an error.
So I don't touch the extension.

```bash
$ RUBYOPT='-w -Ilib/' exe/irb -f -r irb/ext/tracer
/home/pocke/ghq/github.com/ruby/irb/lib/irb/ext/tracer.rb:37: warning: method redefined; discarding old use_tracer=
/home/pocke/ghq/github.com/ruby/irb/lib/irb/extend-command.rb:239: warning: previous definition of use_tracer= was here
Traceback (most recent call last):
        12: from exe/irb:11:in `<main>'
        11: from /home/pocke/ghq/github.com/ruby/irb/lib/irb.rb:381:in `start'
        10: from /home/pocke/ghq/github.com/ruby/irb/lib/irb/init.rb:21:in `setup'
         9: from /home/pocke/ghq/github.com/ruby/irb/lib/irb/init.rb:281:in `load_modules'
         8: from /home/pocke/ghq/github.com/ruby/irb/lib/irb/init.rb:281:in `each'
         7: from /home/pocke/ghq/github.com/ruby/irb/lib/irb/init.rb:283:in `block in load_modules'
         6: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:54:in `require'
         5: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:54:in `require'
         4: from /home/pocke/ghq/github.com/ruby/irb/lib/irb/ext/tracer.rb:14:in `<top (required)>'
         3: from /home/pocke/ghq/github.com/ruby/irb/lib/irb/ext/tracer.rb:70:in `<module:IRB>'
         2: from /home/pocke/ghq/github.com/ruby/irb/lib/irb/ext/tracer.rb:19:in `initialize_tracer'
         1: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/tracer.rb:265:in `add_filter'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/tracer.rb:145:in `add_filter': wrong number of arguments (given 1, expected 0) (ArgumentError)
```