### PR TITLE
Ignore history file without saving if permissions cannot be changed

### DIFF
--- a/lib/irb/ext/save-history.rb
+++ b/lib/irb/ext/save-history.rb
@@ -93,6 +93,8 @@ module IRB
             File.chmod(0600, history_file)
           end
         rescue Errno::ENOENT
+        rescue Errno::EPERM
+          return
         rescue
           raise
         end


### PR DESCRIPTION
Fixes [Ruby Bug 13907] https://bugs.ruby-lang.org/issues/13907