### PR TITLE
Allow irb [--] - arg1 arg2 to just ARGV to %w'arg1 arg2'

### DIFF
--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -115,6 +115,10 @@ module IRB
         end
         @io = StdioInputMethod.new unless @io
 
+      when '-'
+        @io = FileInputMethod.new($stdin)
+        @irb_name = '-'
+        @irb_path = '-'
       when String
         @io = FileInputMethod.new(input_method)
         @irb_name = File.basename(input_method)

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -318,9 +318,7 @@ module IRB # :nodoc:
           $0 = opt
         end
         break
-      when '-'
-        # nothing
-      when /^-/
+      when /^-./
         fail UnrecognizedSwitch, opt
       else
         if noscript

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -289,6 +289,10 @@ module IRB # :nodoc:
         @CONF[:PROMPT_MODE] = prompt_mode
       when "--noprompt"
         @CONF[:PROMPT_MODE] = :NULL
+      when "--script"
+        noscript = false
+      when "--noscript"
+        noscript = true
       when "--inf-ruby-mode"
         @CONF[:PROMPT_MODE] = :INF_RUBY
       when "--sample-book-mode", "--simple-prompt"
@@ -309,16 +313,22 @@ module IRB # :nodoc:
         IRB.print_usage
         exit 0
       when "--"
-        if opt = argv.shift
+        if !noscript && (opt = argv.shift)
           @CONF[:SCRIPT] = opt
           $0 = opt
         end
         break
+      when '-'
+        # nothing
       when /^-/
         fail UnrecognizedSwitch, opt
       else
-        @CONF[:SCRIPT] = opt
-        $0 = opt
+        if noscript
+          argv.unshift(opt)
+        else
+          @CONF[:SCRIPT] = opt
+          $0 = opt
+        end
         break
       end
     end

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -137,7 +137,7 @@ module IRB
     # Creates a new input method object
     def initialize(file)
       super
-      @io = IRB::MagicFile.open(file)
+      @io = file.is_a?(IO) ? file : IRB::MagicFile.open(file)
       @external_encoding = @io.external_encoding
     end
     # The file name of this input method, usually given during initialization.

--- a/lib/irb/lc/help-message
+++ b/lib/irb/lc/help-message
@@ -38,6 +38,7 @@ Usage:  irb.rb [options] [programfile] [arguments]
   --sample-book-mode, --simple-prompt
                     Set prompt mode to 'simple'.
   --noprompt        Don't output prompt.
+  --script          Script mode (default, treat first argument as script)
   --noscript        No script mode (leave arguments in argv)
   --single-irb      Share self with sub-irb.
   --tracer          Show stack trace for each command.

--- a/lib/irb/lc/help-message
+++ b/lib/irb/lc/help-message
@@ -38,6 +38,7 @@ Usage:  irb.rb [options] [programfile] [arguments]
   --sample-book-mode, --simple-prompt
                     Set prompt mode to 'simple'.
   --noprompt        Don't output prompt.
+  --noscript        No script mode (leave arguments in argv)
   --single-irb      Share self with sub-irb.
   --tracer          Show stack trace for each command.
   --back-trace-limit n[=16]

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -16,6 +16,7 @@ module TestIRB
     def teardown
       ENV.update(@backup_env)
       FileUtils.rm_rf(@tmpdir)
+      IRB.conf.delete(:SCRIPT)
     end
 
     def test_setup_with_argv_preserves_global_argv
@@ -112,6 +113,23 @@ module TestIRB
       IRB.setup(eval("__FILE__"), argv: argv)
       assert_equal('a', IRB.conf[:SCRIPT])
       assert_equal([], argv)
+    end
+
+    def test_dash
+      argv = %w[-]
+      IRB.setup(eval("__FILE__"), argv: argv)
+      assert_equal('-', IRB.conf[:SCRIPT])
+      assert_equal([], argv)
+
+      argv = %w[-- -]
+      IRB.setup(eval("__FILE__"), argv: argv)
+      assert_equal('-', IRB.conf[:SCRIPT])
+      assert_equal([], argv)
+
+      argv = %w[-- - -f]
+      IRB.setup(eval("__FILE__"), argv: argv)
+      assert_equal('-', IRB.conf[:SCRIPT])
+      assert_equal(['-f'], argv)
     end
 
     private

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -87,6 +87,33 @@ module TestIRB
       IRB.conf[:USE_COLORIZE] = orig_use_colorize
     end
 
+    def test_noscript
+      argv = %w[--noscript -- -f]
+      IRB.setup(eval("__FILE__"), argv: argv)
+      assert_nil IRB.conf[:SCRIPT]
+      assert_equal(['-f'], argv)
+
+      argv = %w[--noscript -- a]
+      IRB.setup(eval("__FILE__"), argv: argv)
+      assert_nil IRB.conf[:SCRIPT]
+      assert_equal(['a'], argv)
+
+      argv = %w[--noscript a]
+      IRB.setup(eval("__FILE__"), argv: argv)
+      assert_nil IRB.conf[:SCRIPT]
+      assert_equal(['a'], argv)
+
+      argv = %w[--script --noscript a]
+      IRB.setup(eval("__FILE__"), argv: argv)
+      assert_nil IRB.conf[:SCRIPT]
+      assert_equal(['a'], argv)
+
+      argv = %w[--noscript --script a]
+      IRB.setup(eval("__FILE__"), argv: argv)
+      assert_equal('a', IRB.conf[:SCRIPT])
+      assert_equal([], argv)
+    end
+
     private
 
     def with_argv(argv)


### PR DESCRIPTION
This treats the "-" argument as an indication that irb should
not attempt to load a program file, it should just treat the
remaining arguments as ARGV to the irb session.

Implements Ruby Feature 15371