### PR TITLE
Move private call without arguments inside method

### DIFF
--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -49,7 +49,7 @@ EOF
           @binding = BINDING_QUEUE.pop
 
         when 3	# binding in function on TOPLEVEL_BINDING(default)
-          @binding = eval("self.class.send(:remove_method, :irb_binding) if defined?(irb_binding); def irb_binding; private; binding; end; irb_binding",
+          @binding = eval("self.class.send(:remove_method, :irb_binding) if defined?(irb_binding); private; def irb_binding; binding; end; irb_binding",
                           TOPLEVEL_BINDING,
                           __FILE__,
                           __LINE__ - 3)


### PR DESCRIPTION
This code did not have the desired effect.  I'm not sure if
irb_binding is supposed to be private or not.  If not, the private
call can just be removed.