### PR TITLE
Only untaint line on Ruby <2.7

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -526,7 +526,7 @@ module IRB
       @scanner.each_top_level_statement do |line, line_no|
         signal_status(:IN_EVAL) do
           begin
-            line.untaint
+            line.untaint if RUBY_VERSION < '2.7'
             @context.evaluate(line, line_no, exception: exc)
             output_value if @context.echo? && (@context.echo_on_assignment? || !assignment_expression?(line))
           rescue Interrupt => exc


### PR DESCRIPTION
Untaint is deprecated and has no effect on Ruby 2.7+.