### PR TITLE
Fix backtrace filter for context-mode 0

### DIFF
--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -126,7 +126,8 @@ EOF
     def filter_backtrace(bt)
       case IRB.conf[:CONTEXT_MODE]
       when 0
-        return nil if bt =~ /\(irb_local_binding\)/
+        return nil if bt =~ /irb\/.*\.rb/
+        return nil if bt =~ /irb\.rb/
       when 1
         if(bt =~ %r!/tmp/irb-binding! or
             bt =~ %r!irb/.*\.rb! or

--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -124,22 +124,12 @@ EOF
 
     # error message manipulator
     def filter_backtrace(bt)
+      return nil if bt =~ /irb\/.*\.rb/
+      return nil if bt =~ /irb\.rb/
       case IRB.conf[:CONTEXT_MODE]
-      when 0
-        return nil if bt =~ /irb\/.*\.rb/
-        return nil if bt =~ /irb\.rb/
       when 1
-        if(bt =~ %r!/tmp/irb-binding! or
-            bt =~ %r!irb/.*\.rb! or
-            bt =~ /irb\.rb/)
-          return nil
-        end
-      when 2
-        return nil if bt =~ /irb\/.*\.rb/
-        return nil if bt =~ /irb\.rb/
+        return nil if bt =~ %r!/tmp/irb-binding!
       when 3
-        return nil if bt =~ /irb\/.*\.rb/
-        return nil if bt =~ /irb\.rb/
         bt = bt.sub(/:\s*in `irb_binding'/, '')
       end
       bt


### PR DESCRIPTION
Before:
```
$ irb --context-mode 0
irb(main):001:0> foo
Traceback (most recent call last):
       16: from /usr/local/lib/ruby/2.7.0/irb.rb:460:in `run'
       15: from /usr/local/lib/ruby/2.7.0/irb.rb:460:in `catch'
       14: from /usr/local/lib/ruby/2.7.0/irb.rb:461:in `block in run'
       13: from /usr/local/lib/ruby/2.7.0/irb.rb:526:in `eval_input'
       12: from /usr/local/lib/ruby/2.7.0/irb/ruby-lex.rb:125:in `each_top_level_statement'
       11: from /usr/local/lib/ruby/2.7.0/irb/ruby-lex.rb:125:in `catch'
       10: from /usr/local/lib/ruby/2.7.0/irb/ruby-lex.rb:126:in `block in each_top_level_statement'
        9: from /usr/local/lib/ruby/2.7.0/irb/ruby-lex.rb:126:in `loop'
        8: from /usr/local/lib/ruby/2.7.0/irb/ruby-lex.rb:141:in `block (2 levels) in each_top_level_statement'
        7: from /usr/local/lib/ruby/2.7.0/irb.rb:527:in `block in eval_input'
        6: from /usr/local/lib/ruby/2.7.0/irb.rb:684:in `signal_status'
        5: from /usr/local/lib/ruby/2.7.0/irb.rb:530:in `block (2 levels) in eval_input'
        4: from /usr/local/lib/ruby/2.7.0/irb/context.rb:419:in `evaluate'
        3: from /usr/local/lib/ruby/2.7.0/irb/workspace.rb:114:in `evaluate'
        2: from /usr/local/lib/ruby/2.7.0/irb/workspace.rb:114:in `eval'
        1: from (irb):1:in `block in <main>'
NameError (undefined local variable or method `foo' for main:Object)
```


After:
```
$ irb --context-mode 0
irb(main):001:0> foo
Traceback (most recent call last):
        4: from /usr/local/bin/irb:23:in `<main>'
        3: from /usr/local/bin/irb:23:in `load'
        2: from /usr/local/lib/ruby/gems/2.7.0/gems/irb-1.1.0.pre.3/exe/irb:11:in `<top (required)>'
        1: from (irb):1:in `block in <main>'
NameError (undefined local variable or method `foo' for main:Object)
```
