### PR TITLE
Generate history file path correctly when $HOME/.irbrc doesn't exist

### DIFF
--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -274,11 +274,11 @@ module IRB # :nodoc:
     if home = ENV["HOME"]
       yield proc{|rc| home+"/.irb#{rc}"}
     end
-    home = Dir.pwd
-    yield proc{|rc| home+"/.irb#{rc}"}
-    yield proc{|rc| home+"/irb#{rc.sub(/\A_?/, '.')}"}
-    yield proc{|rc| home+"/_irb#{rc}"}
-    yield proc{|rc| home+"/$irb#{rc}"}
+    current_dir = Dir.pwd
+    yield proc{|rc| current_dir+"/.irb#{rc}"}
+    yield proc{|rc| current_dir+"/irb#{rc.sub(/\A_?/, '.')}"}
+    yield proc{|rc| current_dir+"/_irb#{rc}"}
+    yield proc{|rc| current_dir+"/$irb#{rc}"}
   end
 
   # loading modules

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: false
 require "test/unit"
 require "irb"
+require "fileutils"
 
 module TestIRB
   class TestInit < Test::Unit::TestCase
@@ -16,6 +17,45 @@ module TestIRB
       orig = $0.dup
       IRB.setup(eval("__FILE__"), argv: %w[-f])
       assert_equal orig, $0
+    end
+
+    def test_rc_file
+      ENV.delete("IRBRC") # This is for RVM...
+      Dir.mktmpdir("test_irb_init_#{$$}") do |tmpdir|
+        backup_home = ENV["HOME"]
+        ENV["HOME"] = tmpdir
+
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        assert_equal(tmpdir+"/.irb#{IRB::IRBRC_EXT}", IRB.rc_file)
+        assert_equal(tmpdir+"/.irb_history", IRB.rc_file("_history"))
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        FileUtils.touch(tmpdir+"/.irb#{IRB::IRBRC_EXT}")
+        assert_equal(tmpdir+"/.irb#{IRB::IRBRC_EXT}", IRB.rc_file)
+        assert_equal(tmpdir+"/.irb_history", IRB.rc_file("_history"))
+
+        ENV["HOME"] = backup_home
+      end
+    end
+
+    def test_rc_file_in_subdir
+      ENV.delete("IRBRC") # This is for RVM...
+      Dir.mktmpdir("test_irb_init_#{$$}") do |tmpdir|
+        backup_home = ENV["HOME"]
+        ENV["HOME"] = tmpdir
+
+        FileUtils.mkdir_p("#{tmpdir}/mydir")
+        Dir.chdir("#{tmpdir}/mydir") do
+          IRB.conf[:RC_NAME_GENERATOR] = nil
+          assert_equal(tmpdir+"/.irb#{IRB::IRBRC_EXT}", IRB.rc_file)
+          assert_equal(tmpdir+"/.irb_history", IRB.rc_file("_history"))
+          IRB.conf[:RC_NAME_GENERATOR] = nil
+          FileUtils.touch(tmpdir+"/.irb#{IRB::IRBRC_EXT}")
+          assert_equal(tmpdir+"/.irb#{IRB::IRBRC_EXT}", IRB.rc_file)
+          assert_equal(tmpdir+"/.irb_history", IRB.rc_file("_history"))
+        end
+
+        ENV["HOME"] = backup_home
+      end
     end
 
     private


### PR DESCRIPTION
This fixes https://github.com/ruby/irb/issues/32.