### PR TITLE
Fix for crashes with complex auto indent

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -314,18 +314,26 @@ class RubyLex
 
   def check_newline_depth_difference
     depth_difference = 0
+    skip_til_newline = false
     @tokens.each_with_index do |t, index|
       case t[1]
       when :on_ignored_nl, :on_nl, :on_comment
+        skip_til_newline = false
         next
-      when :on_sp
+      when :on_sp || skip_til_newline
         next
       end
+
+      next if skip_til_newline
+
       case t[1]
       when :on_lbracket, :on_lbrace, :on_lparen
         depth_difference += 1
       when :on_rbracket, :on_rbrace, :on_rparen
         depth_difference -= 1
+      when :on_heredoc_beg
+        depth_difference = 0
+        skip_til_newline = true
       when :on_kw
         next if index > 0 and @tokens[index - 1][3].allbits?(Ripper::EXPR_FNAME)
         case t[2]

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -26,6 +26,11 @@ module TestIRB
         [["(((", ")", ")", ")", ""], 4, 0],
         [["{{{", "}", "}", "}", ""], 4, 0],
         [["[", "  # test", ""], 2, 2],
+        [["<<FOO", ""], 1, 0],
+        [["<<FOO", "bar", ""], 2, 0],
+        [["[<<FOO]", "bar", ""], 2, 0],
+        [["[<<FOO]", "bar", "FOO", ""], 3, 0],
+        [["[<<FOO", "bar", ""], 2, 0],
       ]
 
       input_to_spaces.each do |lines, line_index, space_count|

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -1,0 +1,67 @@
+require 'test/unit'
+
+class MockIO
+  def initialize(params, &assertion)
+    @params = params
+    @assertion = assertion
+  end
+
+  def auto_indent(&block)
+    result = block.call(*@params)
+    @assertion.call(result)
+  end
+end
+
+module TestIRB
+  class TestRubyLex < Test::Unit::TestCase
+    def test_indent_correctly_ending_with_newlines
+      input_to_spaces = [
+        [["[", ""], 1, 2],
+        [["[", "]", ""], 2, 0],
+        [["[[", "]", ""], 2, 2],
+        [["[[", "]", "]", ""], 3, 0],
+        [["[[[", "]", ""], 2, 4],
+        [["[[[", "]", "]", ""], 3, 2],
+        [["[[[", "]", "]", "]", ""], 4, 0],
+        [["(((", ")", ")", ")", ""], 4, 0],
+        [["{{{", "}", "}", "}", ""], 4, 0],
+        [["[", "  # test", ""], 2, 2],
+      ]
+
+      input_to_spaces.each do |lines, line_index, space_count|
+        ruby_lex = RubyLex.new()
+        io = MockIO.new([lines, line_index, nil, true]) do |auto_indent|
+          assert_equal(space_count, auto_indent, "There was an failure parsing #{lines.inspect}")
+        end
+        ruby_lex.set_input(io)
+        context = OpenStruct.new(auto_indent_mode: true)
+        ruby_lex.set_auto_indent(context)
+      end
+    end
+
+    def test_indent_correctly_not_ending_with_newlines
+      input_to_spaces = [
+        [["["], 0, nil],
+        [["[["], 0, nil],
+        [["[[", "    ]"], 1, 2],
+        [["[[", "]"], 1, 2],
+        [["[[", "]", "]"], 2, 0],
+        [["[[", "]", "]"], 2, 0],
+        [["[[["], 0, nil],
+        [["[[[", "      ]"], 1, 4],
+        [["[[[", "]", "]"], 2, 2],
+        [["[[[", "]", "]", "]"], 3, 0],
+      ]
+
+      input_to_spaces.each do |lines, line_index, space_count|
+        ruby_lex = RubyLex.new()
+        io = MockIO.new([lines, line_index, lines.last.length, false]) do |auto_indent|
+          assert_equal(space_count, auto_indent, "There was an failure parsing #{lines.inspect}")
+        end
+        ruby_lex.set_input(io)
+        context = OpenStruct.new(auto_indent_mode: true)
+        ruby_lex.set_auto_indent(context)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix for https://github.com/ruby/irb/issues/55

The issue was that irb would crash if we used 3 braces in a row or used <<FOO syntax inside of braces.

Examples:

```
zerg:irb Ben$ irb
2.7.0 :001 > [[[
2.7.0 :002 >     ]
2.7.0 :003 >   ]
2.7.0 :004 > ]
```

```
zerg:irb Ben$ irb
2.7.0 :001"> [<<TEST]
2.7.0 :002"> foo
2.7.0 :003 > TEST
 => ["foo\n"]
```

This is my first time working on this project. I tried to make good commit messages to explain what I did.

Please let me know if there are any changes I should make, I would be happy to make them.