### PR TITLE
Fix crashing when multiple braces per line

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -317,11 +317,13 @@ class RubyLex
 
   def check_newline_depth_difference
     depth_difference = 0
+    open_brace_on_line = 0
     @tokens.each_with_index do |t, index|
       case t[1]
       when :on_ignored_nl, :on_nl, :on_comment
         if index != (@tokens.size - 1)
           depth_difference = 0
+          open_brace_on_line = 0
         end
         next
       when :on_sp
@@ -330,8 +332,9 @@ class RubyLex
       case t[1]
       when :on_lbracket, :on_lbrace, :on_lparen
         depth_difference += 1
+        open_brace_on_line += 1
       when :on_rbracket, :on_rbrace, :on_rparen
-        depth_difference -= 1
+        depth_difference -= 1 if open_brace_on_line > 0
       when :on_kw
         next if index > 0 and @tokens[index - 1][3].allbits?(Ripper::EXPR_FNAME)
         case t[2]

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -368,6 +368,7 @@ class RubyLex
     is_first_printable_of_line = true
     spaces_of_nest = []
     spaces_at_line_head = 0
+    open_brace_on_line = 0
     @tokens.each_with_index do |t, index|
       case t[1]
       when :on_ignored_nl, :on_nl, :on_comment
@@ -375,6 +376,7 @@ class RubyLex
         spaces_at_line_head = 0
         is_first_spaces_of_line = true
         is_first_printable_of_line = true
+        open_brace_on_line = 0
         next
       when :on_sp
         spaces_at_line_head = t[2].count(' ') if is_first_spaces_of_line
@@ -383,7 +385,8 @@ class RubyLex
       end
       case t[1]
       when :on_lbracket, :on_lbrace, :on_lparen
-        spaces_of_nest.push(spaces_at_line_head)
+        spaces_of_nest.push(spaces_at_line_head + open_brace_on_line * 2)
+        open_brace_on_line += 1
       when :on_rbracket, :on_rbrace, :on_rparen
         if is_first_printable_of_line
           corresponding_token_depth = spaces_of_nest.pop

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -90,5 +90,24 @@ module TestIRB
         assert_indenting(lines, row.new_line_spaces, true)
       end
     end
+
+    def test_multiple_braces_in_a_line
+      input_with_correct_indents = [
+        Row.new(%q([[[), nil, 6),
+        Row.new(%q(    ]), 4, 4),
+        Row.new(%q(  ]), 2, 2),
+        Row.new(%q(]), 0, 0),
+        Row.new(%q([<<FOO]), nil, 0),
+        Row.new(%q(hello), nil, 0),
+        Row.new(%q(FOO), nil, 0),
+      ]
+
+      lines = []
+      input_with_correct_indents.each do |row|
+        lines << row.content
+        assert_indenting(lines, row.current_line_spaces, false)
+        assert_indenting(lines, row.new_line_spaces, true)
+      end
+    end
   end
 end

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -70,7 +70,22 @@ module TestIRB
       lines = []
       input_with_correct_indents.each do |row|
         lines << row.content
+        assert_indenting(lines, row.current_line_spaces, false)
+        assert_indenting(lines, row.new_line_spaces, true)
+      end
+    end
 
+    def test_braces_on_thier_own_line
+      input_with_correct_indents = [
+        Row.new(%q(if true), nil, 2),
+        Row.new(%q(  [), nil, 4),
+        Row.new(%q(  ]), 2, 2),
+        Row.new(%q(end), 0, 0),
+      ]
+
+      lines = []
+      input_with_correct_indents.each do |row|
+        lines << row.content
         assert_indenting(lines, row.current_line_spaces, false)
         assert_indenting(lines, row.new_line_spaces, true)
       end


### PR DESCRIPTION
https://github.com/ruby/irb/issues/55

There are two issues in this commit.

Issue 1 multiple open braces on a line:

The first issue is that when we put multiple opening braces on a line the
spaces_of_nest array keeps getting '0' added to it. This means that when
we pop off of this array we are saying that we should be in position zero
for the next line. This is an issue because we don't always want to be
in position 0 after a closing brace.

Example:
```
[[[
]
]
]
```
In the above example the 'spaces_of_nest' array looks like this after
the first line is entered: [0,0,0]. We really want to be indented 4
spaces for the 1st closing brace 2 for the 2nd and 0 for the 3rd. i.e.
we want it to be: [0,2,4].

Issue 2:

We were subtracting from the depth in check_newline_depth_difference on
every open brace. This is the right thing to do if the opening and
closing brace are on the same line. For example in a method definition we
have an opening and closing parentheses we want to add 1 to our depth,
and then remove it.

```
def foo()
end
```

However this isn't the correct behavior when the brace spans multiple
lines. If a brace spans multiple lines we don't want to subtract from
check_newline_depth_difference and we want to treat the braces the same
way as we do `end` and allow check_corresponding_token_depth to pop the
correct depth.

Example of bad behavior:

```
def foo()
  [
  ]
puts 'bar'
end
```

Example of desired behavior:

```
def foo()
  [
  ]
  puts 'bar'
end
```