### PR TITLE
Fix compatibility with rails before 5.2

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -203,7 +203,7 @@ module IRB
         sep = $2
         message = Regexp.quote($3)
 
-        gv = eval("global_variables", bind).collect{|m| m.to_s}.append("true", "false", "nil")
+        gv = eval("global_variables", bind).collect{|m| m.to_s}.push("true", "false", "nil")
         lv = eval("local_variables", bind).collect{|m| m.to_s}
         iv = eval("instance_variables", bind).collect{|m| m.to_s}
         cv = eval("self.class.constants", bind).collect{|m| m.to_s}


### PR DESCRIPTION
Rails before 5.2 added Array#append as an alias to Array#<< ,so that it expects only one argument.
However ruby-2.5 added Array#append as an alias to Array#push which takes any number of arguments.

If irb completion is used in `rails c` (for example `IO.<tab>` ) it fails with:
```
  irb/completion.rb:206:in `<<': wrong number of arguments (given 3, expected 1) (ArgumentError)
```

Using Array#push instead of Array#append fixes compatibility.

I tested this change with rails 5.0.7.2 on ruby-2.5.7 and ruby-2.7.0.