### PR TITLE
Add newline_before_multiline_assignment

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -737,7 +737,7 @@ module IRB
 
     def output_value # :nodoc:
       str = @context.inspect_last_value
-      multiline_p = str.each_line.take(2).length > 1
+      multiline_p = /\A.*\Z/ !~ str
       if multiline_p && @context.newline_before_multiline_output?
         printf @context.return_format, "\n#{str}"
       else

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -736,7 +736,13 @@ module IRB
     end
 
     def output_value # :nodoc:
-      printf @context.return_format, @context.inspect_last_value
+      str = @context.inspect_last_value
+      multiline_p = str.each_line.take(2).length > 1
+      if multiline_p && @context.newline_before_multiline_output?
+        printf @context.return_format, "\n#{str}"
+      else
+        printf @context.return_format, str
+      end
     end
 
     # Outputs the local variables to this current session, including

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -133,6 +133,11 @@ module IRB
       if @echo_on_assignment.nil?
         @echo_on_assignment = false
       end
+
+      @newline_before_multiline_output = IRB.conf[:NEWLINE_BEFORE_MULTILINE_OUTPUT]
+      if @newline_before_multiline_output.nil?
+        @newline_before_multiline_output = true
+      end
     end
 
     # The top-level workspace, see WorkSpace#main
@@ -253,6 +258,20 @@ module IRB
     #     a = "omg"
     #     #=> omg
     attr_accessor :echo_on_assignment
+    # Whether a newline is put before multiline output.
+    #
+    # Uses IRB.conf[:NEWLINE_BEFORE_MULTILINE_OUTPUT] if available,
+    # or defaults to +true+.
+    #
+    #     "abc\ndef"
+    #     #=>
+    #     abc
+    #     def
+    #     IRB.CurrentContext.newline_before_multiline_output = false
+    #     "abc\ndef"
+    #     #=> abc
+    #     def
+    attr_accessor :newline_before_multiline_output
     # Whether verbose messages are displayed or not.
     #
     # A copy of the default <code>IRB.conf[:VERBOSE]</code>
@@ -287,6 +306,7 @@ module IRB
     alias ignore_eof? ignore_eof
     alias echo? echo
     alias echo_on_assignment? echo_on_assignment
+    alias newline_before_multiline_output? newline_before_multiline_output
 
     # Returns whether messages are displayed or not.
     def verbose?

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -216,5 +216,36 @@ module TestIRB
       assert(irb.context.echo?, "echo? should be true by default")
       assert(irb.context.echo_on_assignment?, "echo_on_assignment? should be true when IRB.conf[:ECHO_ON_ASSIGNMENT] is set to true")
     end
+
+    def test_multiline_output_on_default_inspector
+      main = Object.new
+      def main.inspect
+        "abc\ndef"
+      end
+      input = TestInputMethod.new([
+        "self"
+      ])
+      irb = IRB::Irb.new(IRB::WorkSpace.new(main), input)
+      irb.context.return_format = "=> %s\n"
+
+      # The default
+      irb.context.newline_before_multiline_output = true
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("=> \nabc\ndef\n",
+                   out)
+
+      # No newline before multiline output
+      input.reset
+      irb.context.newline_before_multiline_output = false
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("=> abc\ndef\n",
+                   out)
+    end
   end
 end


### PR DESCRIPTION
The current irb displays `=> ` before the echo output like below.

```
irb(main):001:0> 1 + 2
=> 3
```

The leader `=> ` is useful to distinguish expression lines and these results.

However, if a result consists of multiple lines, the leader shifts the first line of the output lines.
It is inconvenient if the output renders a table-like structure.  For example:

```
irb(main):004:0> df = Pandas::DataFrame.new({foo: { x: 100, y: 200 }, bar: { x: 10, z: 30 }, baz: { y: 1, z: 4 }}, {})
irb(main):005:0> df
=>      foo   bar  baz
x  100.0  10.0  NaN
y  200.0   NaN  1.0
z    NaN  30.0  4.0
```

The patch in this pull-request resolves this issue.  After applying this patch, the previous result should change to the below:

```
irb(main):004:0> df = Pandas::DataFrame.new({foo: { x: 100, y: 200 }, bar: { x: 10, z: 30 }, baz: { y: 1, z: 4 }}, {})
irb(main):005:0> df
=> 
     foo   bar  baz
x  100.0  10.0  NaN
y  200.0   NaN  1.0
z    NaN  30.0  4.0
```