### PR TITLE
Check doc namespace correctly

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -265,14 +265,14 @@ module IRB
       end
     end
 
-    PerfectMatchedProc = ->(matched) {
+    PerfectMatchedProc = ->(matched, bind: IRB.conf[:MAIN_CONTEXT].workspace.binding) {
       RDocRIDriver ||= RDoc::RI::Driver.new
       if matched =~ /\A(?:::)?RubyVM/ and not ENV['RUBY_YES_I_AM_NOT_A_NORMAL_USER']
         IRB.send(:easter_egg)
         return
       end
-      namespace = retrieve_completion_data(matched, doc_namespace: true)
-      return unless matched
+      namespace = retrieve_completion_data(matched, bind: bind, doc_namespace: true)
+      return unless namespace
       if namespace.is_a?(Array)
         out = RDoc::Markup::Document.new
         namespace.each do |m|

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -31,5 +31,9 @@ module TestIRB
       assert_include(IRB::InputCompletor.retrieve_completion_data(":a", bind: binding), ":aiueo")
       assert_empty(IRB::InputCompletor.retrieve_completion_data(":abcdefg", bind: binding))
     end
+
+    def test_complete_symbol_failure
+      assert_nil(IRB::InputCompletor::PerfectMatchedProc.(":aiueo", bind: binding))
+    end
   end
 end


### PR DESCRIPTION
`IRB::InputCompletor::PerfectMatchedProc` crashes when doc not found because a variable name was incorrect.