### PR TITLE
Fix auto indent with closed brace

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -394,6 +394,7 @@ class RubyLex
           spaces_of_nest.pop
           corresponding_token_depth = nil
         end
+        open_brace_on_line -= 1
       when :on_kw
         next if index > 0 and @tokens[index - 1][3].allbits?(Ripper::EXPR_FNAME)
         case t[2]

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -112,5 +112,19 @@ module TestIRB
         assert_indenting(lines, row.new_line_spaces, true)
       end
     end
+
+    def test_a_closed_brace_and_not_closed_brace_in_a_line
+      input_with_correct_indents = [
+        Row.new(%q(p() {), nil, 2),
+        Row.new(%q(}), 0, 0),
+      ]
+
+      lines = []
+      input_with_correct_indents.each do |row|
+        lines << row.content
+        assert_indenting(lines, row.current_line_spaces, false)
+        assert_indenting(lines, row.new_line_spaces, true)
+      end
+    end
   end
 end


### PR DESCRIPTION
A closed brace in auto-indent shouldn't affect the next brace in the same line, but it behaves like below:

```ruby
p() {
  }
```

It's a bug.

This fixes https://github.com/ruby/irb/issues/74#issuecomment-582715608.