### PR TITLE
Detect multiple lines output simplify

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -738,7 +738,7 @@ module IRB
 
     def output_value # :nodoc:
       str = @context.inspect_last_value
-      multiline_p = /\A.*\Z/ !~ str
+      multiline_p = str.include?("\n")
       if multiline_p && @context.newline_before_multiline_output?
         printf @context.return_format, "\n#{str}"
       else


### PR DESCRIPTION
The old implementation performance test code:

```ruby
require 'objspace'
puts "%.5g MB" % (ObjectSpace.memsize_of_all * 0.001 * 0.001)
/\A.*\Z/ !~ ('abc' * 20_000_000)
puts "%.5g MB" % (ObjectSpace.memsize_of_all * 0.001 * 0.001)
```

and run `time test.rb`:

    2.5868 MB
    62.226 MB

    real    0m1.307s
    user    0m0.452s
    sys     0m0.797s

The new implementation performance test code:

```ruby
require 'objspace'
puts "%.5g MB" % (ObjectSpace.memsize_of_all * 0.001 * 0.001)
('abc' * 20_000_000).include?("\n")
puts "%.5g MB" % (ObjectSpace.memsize_of_all * 0.001 * 0.001)
```

and run `time test.rb`:

    2.5861 MB
    62.226 MB

    real    0m0.132s
    user    0m0.088s
    sys     0m0.042s

This fixes https://github.com/ruby/irb/issues/82.