### PR TITLE
handle rescue modifier properly

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -324,7 +324,7 @@ class RubyLex
         when 'def', 'case', 'for', 'begin', 'class', 'module'
           indent += 1
         when 'if', 'unless', 'while', 'until'
-          # postfix if/unless/while/until/rescue must be Ripper::EXPR_LABEL
+          # postfix if/unless/while/until must be Ripper::EXPR_LABEL
           indent += 1 unless t[3].allbits?(Ripper::EXPR_LABEL)
         when 'end'
           indent -= 1
@@ -369,12 +369,12 @@ class RubyLex
           end
         when 'def', 'case', 'for', 'begin', 'class', 'module'
           depth_difference += 1
-        when 'if', 'unless', 'while', 'until'
+        when 'if', 'unless', 'while', 'until', 'rescue'
           # postfix if/unless/while/until/rescue must be Ripper::EXPR_LABEL
           unless t[3].allbits?(Ripper::EXPR_LABEL)
             depth_difference += 1
           end
-        when 'else', 'elsif', 'rescue', 'ensure', 'when', 'in'
+        when 'else', 'elsif', 'ensure', 'when', 'in'
           depth_difference += 1
         end
       end
@@ -420,12 +420,16 @@ class RubyLex
         case t[2]
         when 'def', 'do', 'case', 'for', 'begin', 'class', 'module'
           spaces_of_nest.push(spaces_at_line_head)
+        when 'rescue'
+          unless t[3].allbits?(Ripper::EXPR_LABEL)
+            corresponding_token_depth = spaces_of_nest.last
+          end
         when 'if', 'unless', 'while', 'until'
-          # postfix if/unless/while/until/rescue must be Ripper::EXPR_LABEL
+          # postfix if/unless/while/until must be Ripper::EXPR_LABEL
           unless t[3].allbits?(Ripper::EXPR_LABEL)
             spaces_of_nest.push(spaces_at_line_head)
           end
-        when 'else', 'elsif', 'rescue', 'ensure', 'when', 'in'
+        when 'else', 'elsif', 'ensure', 'when', 'in'
           corresponding_token_depth = spaces_of_nest.last
         when 'end'
           if is_first_printable_of_line

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -178,5 +178,32 @@ module TestIRB
         assert_indenting(lines, row.new_line_spaces, true)
       end
     end
+
+    def test_mixed_rescue
+      input_with_correct_indents = [
+        Row.new(%q(def m), nil, 2),
+        Row.new(%q(  begin), nil, 4),
+        Row.new(%q(    begin), nil, 6),
+        Row.new(%q(      x = a rescue 4), nil, 6),
+        Row.new(%q(      y = [(a rescue 5)]), nil, 6),
+        Row.new(%q(      [x, y]), nil, 6),
+        Row.new(%q(    rescue => e), 4, 6),
+        Row.new(%q(      raise e rescue 8), nil, 6),
+        Row.new(%q(    end), 4, 4),
+        Row.new(%q(  rescue), 2, 4),
+        Row.new(%q(    raise rescue 11), nil, 4),
+        Row.new(%q(  end), 2, 2),
+        Row.new(%q(rescue => e), 0, 2),
+        Row.new(%q(  raise e rescue 14), nil, 2),
+        Row.new(%q(end), 0, 0),
+      ]
+
+      lines = []
+      input_with_correct_indents.each do |row|
+        lines << row.content
+        assert_indenting(lines, row.current_line_spaces, false)
+        assert_indenting(lines, row.new_line_spaces, true)
+      end
+    end
   end
 end


### PR DESCRIPTION
```ruby
irb(main):001:1* def m
irb(main):002:2*   begin
irb(main):003:3*     begin
irb(main):004:3*     x = a rescue 4
irb(main):005:3*       y = [(a rescue 5)]
irb(main):006:3*         [x, y]
irb(main):007:3*     rescue => e
irb(main):008:3*     raise e rescue 8
irb(main):009:2*     end
irb(main):010:2*   rescue
irb(main):011:2*   raise rescue 11
irb(main):012:1*   end
irb(main):013:1* rescue => e
irb(main):014:1* raise e rescue 14
irb(main):015:0> end
```

- each indent in L4, L8, L11 and L14 is short
- indent in L6 is over

This pull-request fixes those behaviors.
