### PR TITLE
Require jruby lib to get JRuby.compile_ir

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -11,6 +11,7 @@
 #
 
 require "ripper"
+require "jruby" if RUBY_ENGINE == "jruby"
 
 # :stopdoc:
 class RubyLex


### PR DESCRIPTION
For 9.3 we have made internal features of the JRuby module (like `compile_ir` accessible only if you `require 'jruby'`, so that's what this PR is for. The `compile_ir` call errors without this:

```
NoMethodError: undefined method `compile_ir' for JRuby:Module
Did you mean?  Complex
          check_code_block at /Users/headius/projects/jruby/lib/ruby/gems/shared/gems/irb-1.2.1/lib/irb/ruby-lex.rb:210
```