### PR TITLE
respect NO_COLOR environment variable

### DIFF
--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -44,7 +44,7 @@ module IRB # :nodoc:
     @CONF[:IRB_RC] = nil
 
     @CONF[:USE_SINGLELINE] = false unless defined?(ReadlineInputMethod)
-    @CONF[:USE_COLORIZE] = true
+    @CONF[:USE_COLORIZE] = !ENV['NO_COLOR']
     @CONF[:INSPECT_MODE] = true
     @CONF[:USE_TRACER] = false
     @CONF[:USE_LOADER] = false
@@ -224,11 +224,11 @@ module IRB # :nodoc:
         break
       end
     end
+
     load_path.collect! do |path|
       /\A\.\// =~ path ? path : File.expand_path(path)
     end
     $LOAD_PATH.unshift(*load_path)
-
   end
 
   # running config

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -60,6 +60,22 @@ module TestIRB
       ENV["IRBRC"] = backup_irbrc
     end
 
+    def test_no_color_environment_variable
+      orig = ENV['NO_COLOR']
+
+      assert IRB.conf[:USE_COLORIZE]
+
+      ENV['NO_COLOR'] = 'true'
+      IRB.setup(eval("__FILE__"))
+      refute IRB.conf[:USE_COLORIZE]
+
+      ENV['NO_COLOR'] = nil
+      IRB.setup(eval("__FILE__"))
+      assert IRB.conf[:USE_COLORIZE]
+    ensure
+      ENV['NO_COLOR'] = orig
+    end
+
     private
 
     def with_argv(argv)

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -66,11 +66,11 @@ module TestIRB
       assert IRB.conf[:USE_COLORIZE]
 
       ENV['NO_COLOR'] = 'true'
-      IRB.setup(eval("__FILE__"))
+      IRB.setup(__FILE__)
       refute IRB.conf[:USE_COLORIZE]
 
       ENV['NO_COLOR'] = nil
-      IRB.setup(eval("__FILE__"))
+      IRB.setup(__FILE__)
       assert IRB.conf[:USE_COLORIZE]
     ensure
       ENV['NO_COLOR'] = orig


### PR DESCRIPTION
When `NO_COLOR` is set to any non-nil value, output is not colorized.

See https://no-color.org/