### PR TITLE
Simplify RubyLex.compile_with_errors_suppressed

### DIFF
--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -155,8 +155,8 @@ module IRB # :nodoc:
         pos = [1, 0]
 
         verbose, $VERBOSE = $VERBOSE, nil
-        RubyLex.compile_with_errors_suppressed(code) do |inner_code|
-          lexer = Ripper::Lexer.new(inner_code)
+        RubyLex.compile_with_errors_suppressed(code) do |inner_code, line_no|
+          lexer = Ripper::Lexer.new(inner_code, '(ripper)', line_no)
           if lexer.respond_to?(:scan) # Ruby 2.7+
             lexer.scan.each do |elem|
               str = elem.tok

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -152,5 +152,31 @@ module TestIRB
         assert_indenting(lines, row.new_line_spaces, true)
       end
     end
+
+    def test_incomplete_emacs_coding_magic_comment
+      input_with_correct_indents = [
+        Row.new(%q(# -*- coding: u), nil, 0),
+      ]
+
+      lines = []
+      input_with_correct_indents.each do |row|
+        lines << row.content
+        assert_indenting(lines, row.current_line_spaces, false)
+        assert_indenting(lines, row.new_line_spaces, true)
+      end
+    end
+
+    def test_incomplete_vim_coding_magic_comment
+      input_with_correct_indents = [
+        Row.new(%q(# vim:set fileencoding=u), nil, 0),
+      ]
+
+      lines = []
+      input_with_correct_indents.each do |row|
+        lines << row.content
+        assert_indenting(lines, row.current_line_spaces, false)
+        assert_indenting(lines, row.new_line_spaces, true)
+      end
+    end
   end
 end


### PR DESCRIPTION
nobu-san reviewed,

https://github.com/ruby/irb/pull/106#pullrequestreview-423400033
> How about `lexer = Ripper::Lexer.new(";\n#{code}", nil, 0)`?
> Encoding pragma is effective only at the beginning.
> And the semicolon and newline will be skipped because the position is before the initial `pos`.

I employ the way.