### PR TITLE
Fix error when `inspect` is called but not found in inspector

### DIFF
--- a/lib/irb/inspector.rb
+++ b/lib/irb/inspector.rb
@@ -113,6 +113,7 @@ module IRB # :nodoc:
       result
     rescue NoMethodError
       puts "(Object doesn't support #inspect)"
+      ''
     end
   }
   Inspector.def_inspector([:pp, :pretty_inspect], proc{require "pp"}){|v|

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -98,6 +98,23 @@ module TestIRB
       $VERBOSE = verbose
     end
 
+    def test_eval_object_without_inspect_method
+      verbose, $VERBOSE = $VERBOSE, nil
+      input = TestInputMethod.new([
+        "BasicObject.new\n",
+      ])
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_pattern_list([:*, /\(Object doesn't support #inspect\)/,
+                           :*, /=> \n/,
+                           /\s*/], out)
+    ensure
+      $VERBOSE = verbose
+    end
+
     def test_default_config
       assert_equal(true, @context.use_colorize?)
     end


### PR DESCRIPTION

# Problem

When an object that doesn't have `inspect` method is displayed, it raises an error.

```
irb(main):001:0> BasicObject.new
(Object doesn't support #inspect)
Traceback (most recent call last):
       16: from /home/pocke/.rbenv/versions/trunk/bin/irb:23:in `load'
       15: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/irb-1.2.4/exe/irb:11:in `<top (required)>'
       14: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb.rb:399:in `start'
       13: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb.rb:470:in `run'
       12: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb.rb:470:in `catch'
       11: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb.rb:471:in `block in run'
       10: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb.rb:536:in `eval_input'
        9: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb/ruby-lex.rb:135:in `each_top_level_statement'
        8: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb/ruby-lex.rb:135:in `catch'
        7: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb/ruby-lex.rb:136:in `block in each_top_level_statement'
        6: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb/ruby-lex.rb:136:in `loop'
        5: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb/ruby-lex.rb:151:in `block (2 levels) in each_top_level_statement'
        4: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb.rb:537:in `block in eval_input'
        3: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb.rb:695:in `signal_status'
        2: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb.rb:541:in `block (2 levels) in eval_input'
        1: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.8.0/irb.rb:742:in `output_value'
NoMethodError (undefined method `include?' for nil:NilClass)
Maybe IRB bug!
```

# Solution

Make sure the inspector returns a string.


It will display the following output.

```
irb(main):001:0> BasicObject.new
(Object doesn't support #inspect)
=> 
```

---



Note that it is the same with the previous behavior.

```
irb(main):001:0> RUBY_VERSION
=> "2.6.0"
irb(main):002:0> IRB::VERSION
=> "1.0.0"
irb(main):003:0> BasicObject.new
(Object doesn't support #inspect)
=> 
```