### PR TITLE
Add measure command

### DIFF
--- a/lib/irb/cmd/measure.rb
+++ b/lib/irb/cmd/measure.rb
@@ -1,0 +1,34 @@
+require_relative "nop"
+
+# :stopdoc:
+module IRB
+  module ExtendCommand
+    class Measure < Nop
+      def initialize(*args)
+        super(*args)
+      end
+
+      def execute(type = nil, arg = nil)
+        case type
+        when :off
+          IRB.conf[:MEASURE] = nil
+          IRB.unset_measure_callback(arg)
+        when :list
+          IRB.conf[:MEASURE_CALLBACKS].each do |type_name, _|
+            puts "- #{type_name}"
+          end
+        when :on
+          IRB.conf[:MEASURE] = true
+          added = IRB.set_measure_callback(type)
+          puts "#{added.first} is added."
+        else
+          IRB.conf[:MEASURE] = true
+          added = IRB.set_measure_callback(type)
+          puts "#{added.first} is added."
+        end
+        nil
+      end
+    end
+  end
+end
+# :startdoc:

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -125,6 +125,10 @@ module IRB # :nodoc:
         :irb_info, :Info, "irb/cmd/info"
       ],
 
+      [
+        :measure, :Measure, "irb/cmd/measure"
+      ],
+
     ]
 
     # Installs the default irb commands:

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -123,5 +123,149 @@ module TestIRB
       IRB.__send__(:remove_const, :IRBRC_EXT)
       IRB.const_set(:IRBRC_EXT, ext_backup)
     end
+
+    class TestInputMethod < ::IRB::InputMethod
+      attr_reader :list, :line_no
+
+      def initialize(list = [])
+        super("test")
+        @line_no = 0
+        @list = list
+      end
+
+      def gets
+        @list[@line_no]&.tap {@line_no += 1}
+      end
+
+      def eof?
+        @line_no >= @list.size
+      end
+
+      def encoding
+        Encoding.default_external
+      end
+
+      def reset
+        @line_no = 0
+      end
+    end
+
+    def test_measure
+      IRB.init_config(nil)
+      IRB.conf[:PROMPT] = {
+        DEFAULT: {
+          PROMPT_I: '> ',
+          PROMPT_S: '> ',
+          PROMPT_C: '> ',
+          PROMPT_N: '> '
+        }
+      }
+      IRB.conf[:MEASURE] = false
+      input = TestInputMethod.new([
+        "3\n",
+        "measure\n",
+        "3\n",
+        "measure :off\n",
+        "3\n",
+      ])
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      irb.context.return_format = "=> %s\n"
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(/\A=> 3\nTIME is added\.\n=> nil\nprocessing time: .+\n=> 3\n=> nil\n=> 3\n/, out)
+    end
+
+    def test_measure_enabled_by_rc
+      IRB.init_config(nil)
+      IRB.conf[:PROMPT] = {
+        DEFAULT: {
+          PROMPT_I: '> ',
+          PROMPT_S: '> ',
+          PROMPT_C: '> ',
+          PROMPT_N: '> '
+        }
+      }
+      IRB.conf[:MEASURE] = true
+      input = TestInputMethod.new([
+        "3\n",
+        "measure :off\n",
+        "3\n",
+      ])
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      irb.context.return_format = "=> %s\n"
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(/\Aprocessing time: .+\n=> 3\n=> nil\n=> 3\n/, out)
+    end
+
+    def test_measure_enabled_by_rc_with_custom
+      IRB.init_config(nil)
+      IRB.conf[:PROMPT] = {
+        DEFAULT: {
+          PROMPT_I: '> ',
+          PROMPT_S: '> ',
+          PROMPT_C: '> ',
+          PROMPT_N: '> '
+        }
+      }
+      IRB.conf[:MEASURE] = true
+      IRB.conf[:MEASURE_PROC][:CUSTOM] = proc { |line, line_no, &block|
+        time = Time.now
+        result = block.()
+        now = Time.now
+        puts 'custom processing time: %fs' % (Time.now - time) if IRB.conf[:MEASURE]
+        result
+      }
+      input = TestInputMethod.new([
+        "3\n",
+        "measure :off\n",
+        "3\n",
+      ])
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      irb.context.return_format = "=> %s\n"
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(/\Acustom processing time: .+\n=> 3\n=> nil\n=> 3\n/, out)
+    end
+
+    def test_measure_with_custom
+      IRB.init_config(nil)
+      IRB.conf[:PROMPT] = {
+        DEFAULT: {
+          PROMPT_I: '> ',
+          PROMPT_S: '> ',
+          PROMPT_C: '> ',
+          PROMPT_N: '> '
+        }
+      }
+      IRB.conf[:MEASURE] = false
+      IRB.conf[:MEASURE_PROC][:CUSTOM] = proc { |line, line_no, &block|
+        time = Time.now
+        result = block.()
+        now = Time.now
+        puts 'custom processing time: %fs' % (Time.now - time) if IRB.conf[:MEASURE]
+        result
+      }
+      input = TestInputMethod.new([
+        "3\n",
+        "measure\n",
+        "3\n",
+        "measure :off\n",
+        "3\n",
+      ])
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      irb.context.return_format = "=> %s\n"
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(/\A=> 3\nCUSTOM is added\.\n=> nil\ncustom processing time: .+\n=> 3\n=> nil\n=> 3\n/, out)
+    end
   end
 end


### PR DESCRIPTION
You can use `measure` command to check performance in IRB like below:

```
irb(main):001:0> 3
=> 3
irb(main):002:0> measure
TIME is added.
=> nil
irb(main):003:0> 3
processing time: 0.000058s
=> 3
irb(main):004:0> measure :off
=> nil
irb(main):005:0> 3
=> 3
```

You can set `measure :on` by `IRB.conf[:MEASURE] = true` in .irbrc, and, also, set custom performance check method:

```ruby
IRB.conf[:MEASURE_PROC][:CUSTOM] = proc { |context, code, line_no, &block|
  time = Time.now
  result = block.()
  now = Time.now
  puts 'custom processing time: %fs' % (Time.now - time) if IRB.conf[:MEASURE]
  result
}
```