### PR TITLE
Add OMIT_ON_ASSIGNMENT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ rvm:
 before_install:
   - yes | gem update --system
 
-script: bundle exec rake test
+script:
+  - bundle install
+  - bundle exec rake test

--- a/irb.gemspec
+++ b/irb.gemspec
@@ -78,7 +78,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5")
 
-  spec.add_dependency "reline", ">= 0.0.1"
+  spec.add_dependency "reline", ">= 0.1.5"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -131,7 +131,12 @@ module IRB
 
       @echo_on_assignment = IRB.conf[:ECHO_ON_ASSIGNMENT]
       if @echo_on_assignment.nil?
-        @echo_on_assignment = false
+        @echo_on_assignment = true
+      end
+
+      @omit_on_assignment = IRB.conf[:OMIT_ON_ASSIGNMENT]
+      if @omit_on_assignment.nil?
+        @omit_on_assignment = true
       end
 
       @newline_before_multiline_output = IRB.conf[:NEWLINE_BEFORE_MULTILINE_OUTPUT]
@@ -251,13 +256,27 @@ module IRB
     attr_accessor :echo
     # Whether to echo for assignment expressions
     #
-    # Uses <code>IRB.conf[:ECHO_ON_ASSIGNMENT]</code> if available, or defaults to +false+.
+    # Uses <code>IRB.conf[:ECHO_ON_ASSIGNMENT]</code> if available, or defaults to +true+.
     #
     #     a = "omg"
-    #     IRB.CurrentContext.echo_on_assignment = true
-    #     a = "omg"
     #     #=> omg
+    #     IRB.CurrentContext.echo_on_assignment = false
+    #     a = "omg"
     attr_accessor :echo_on_assignment
+    # Whether to omit echo for assignment expressions
+    #
+    # Uses <code>IRB.conf[:OMIT_ON_ASSIGNMENT]</code> if available, or defaults to +true+.
+    #
+    #     a = [1] * 10
+    #     #=> [1, 1, 1, 1, 1, 1, 1, 1, ...
+    #     [1] * 10
+    #     #=> [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    #     IRB.CurrentContext.omit_on_assignment = false
+    #     a = [1] * 10
+    #     #=> [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    #     [1] * 10
+    #     #=> [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    attr_accessor :omit_on_assignment
     # Whether a newline is put before multiline output.
     #
     # Uses <code>IRB.conf[:NEWLINE_BEFORE_MULTILINE_OUTPUT]</code> if available,
@@ -306,6 +325,7 @@ module IRB
     alias ignore_eof? ignore_eof
     alias echo? echo
     alias echo_on_assignment? echo_on_assignment
+    alias omit_on_assignment? omit_on_assignment
     alias newline_before_multiline_output? newline_before_multiline_output
 
     # Returns whether messages are displayed or not.

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -52,6 +52,7 @@ module IRB # :nodoc:
     @CONF[:IGNORE_EOF] = false
     @CONF[:ECHO] = nil
     @CONF[:ECHO_ON_ASSIGNMENT] = nil
+    @CONF[:OMIT_ON_ASSIGNMENT] = nil
     @CONF[:VERBOSE] = nil
 
     @CONF[:EVAL_HISTORY] = nil
@@ -177,6 +178,10 @@ module IRB # :nodoc:
         @CONF[:ECHO_ON_ASSIGNMENT] = true
       when "--noecho-on-assignment"
         @CONF[:ECHO_ON_ASSIGNMENT] = false
+      when "--omit-on-assignment"
+        @CONF[:OMIT_ON_ASSIGNMENT] = true
+      when "--noomit-on-assignment"
+        @CONF[:OMIT_ON_ASSIGNMENT] = false
       when "--verbose"
         @CONF[:VERBOSE] = true
       when "--noverbose"

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -12,6 +12,7 @@
 require_relative 'src_encoding'
 require_relative 'magic-file'
 require_relative 'completion'
+require 'io/console'
 require 'reline'
 
 module IRB
@@ -35,6 +36,14 @@ module IRB
       fail NotImplementedError, "gets"
     end
     public :gets
+
+    def winsize
+      if instance_variable_defined?(:@stdout)
+        @stdout.winsize
+      else
+        [24, 80]
+      end
+    end
 
     # Whether this input method is still readable when there is no more data to
     # read.

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -30,6 +30,10 @@ module TestIRB
       def reset
         @line_no = 0
       end
+
+      def winsize
+        [10, 20]
+      end
     end
 
     def setup
@@ -213,6 +217,75 @@ module TestIRB
       assert_equal("", out)
     end
 
+    def test_omit_on_assignment
+      input = TestInputMethod.new([
+        "a = [1] * 100\n",
+        "a\n",
+      ])
+      value = [1] * 100
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      irb.context.return_format = "=> %s\n"
+
+      irb.context.echo = true
+      irb.context.echo_on_assignment = false
+      irb.context.omit_on_assignment = true
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("=> #{value.inspect}\n", out)
+
+      input.reset
+      irb.context.echo = true
+      irb.context.echo_on_assignment = true
+      irb.context.omit_on_assignment = true
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("=> #{value.inspect[0..(input.winsize.last - 9)]}...\e[0m\n=> #{value.inspect}\n", out)
+
+      input.reset
+      irb.context.echo = true
+      irb.context.echo_on_assignment = true
+      irb.context.omit_on_assignment = false
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("=> #{value.inspect}\n=> #{value.inspect}\n", out)
+
+      input.reset
+      irb.context.echo = false
+      irb.context.echo_on_assignment = false
+      irb.context.omit_on_assignment = true
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("", out)
+
+      input.reset
+      irb.context.echo = false
+      irb.context.echo_on_assignment = true
+      irb.context.omit_on_assignment = true
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("", out)
+
+      input.reset
+      irb.context.echo = false
+      irb.context.echo_on_assignment = true
+      irb.context.omit_on_assignment = false
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("", out)
+    end
+
     def test_echo_on_assignment_conf
       # Default
       IRB.conf[:ECHO] = nil
@@ -221,22 +294,26 @@ module TestIRB
       irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
 
       assert(irb.context.echo?, "echo? should be true by default")
-      refute(irb.context.echo_on_assignment?, "echo_on_assignment? should be false by default")
+      assert(irb.context.echo_on_assignment?, "echo_on_assignment? should be true by default")
+      assert(irb.context.omit_on_assignment?, "omit_on_assignment? should be true by default")
 
       # Explicitly set :ECHO to false
       IRB.conf[:ECHO] = false
       irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
 
       refute(irb.context.echo?, "echo? should be false when IRB.conf[:ECHO] is set to false")
-      refute(irb.context.echo_on_assignment?, "echo_on_assignment? should be false by default")
+      assert(irb.context.echo_on_assignment?, "echo_on_assignment? should be true by default")
+      assert(irb.context.omit_on_assignment?, "omit_on_assignment? should be true by default")
 
       # Explicitly set :ECHO_ON_ASSIGNMENT to true
       IRB.conf[:ECHO] = nil
-      IRB.conf[:ECHO_ON_ASSIGNMENT] = true
+      IRB.conf[:ECHO_ON_ASSIGNMENT] = false
+      IRB.conf[:OMIT_ON_ASSIGNMENT] = false
       irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
 
       assert(irb.context.echo?, "echo? should be true by default")
-      assert(irb.context.echo_on_assignment?, "echo_on_assignment? should be true when IRB.conf[:ECHO_ON_ASSIGNMENT] is set to true")
+      refute(irb.context.echo_on_assignment?, "echo_on_assignment? should be false when IRB.conf[:ECHO_ON_ASSIGNMENT] is set to false")
+      refute(irb.context.omit_on_assignment?, "omit_on_assignment? should be false when IRB.conf[:OMIT_ON_ASSIGNMENT] is set to false")
     end
 
     def test_multiline_output_on_default_inspector

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -286,6 +286,82 @@ module TestIRB
       assert_equal("", out)
     end
 
+    def test_omit_multiline_on_assignment
+      input = TestInputMethod.new([
+        "class A; def inspect; ([?* * 1000] * 3).join(%{\\n}); end; end; a = A.new\n",
+        "a\n"
+      ])
+      value = ([?* * 1000] * 3).join(%{\n})
+      value_first_line = (?* * 1000).to_s
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      irb.context.return_format = "=> %s\n"
+
+      irb.context.echo = true
+      irb.context.echo_on_assignment = false
+      irb.context.omit_on_assignment = true
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("=> \n#{value}\n", out)
+      irb.context.evaluate('A.remove_method(:inspect)', 0)
+
+      input.reset
+      irb.context.echo = true
+      irb.context.echo_on_assignment = true
+      irb.context.omit_on_assignment = true
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("=> #{value_first_line[0..(input.winsize.last - 9)]}...\e[0m\n=> \n#{value}\n", out)
+      irb.context.evaluate('A.remove_method(:inspect)', 0)
+
+      input.reset
+      irb.context.echo = true
+      irb.context.echo_on_assignment = true
+      irb.context.omit_on_assignment = false
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("=> \n#{value}\n=> \n#{value}\n", out)
+      irb.context.evaluate('A.remove_method(:inspect)', 0)
+
+      input.reset
+      irb.context.echo = false
+      irb.context.echo_on_assignment = false
+      irb.context.omit_on_assignment = true
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("", out)
+      irb.context.evaluate('A.remove_method(:inspect)', 0)
+
+      input.reset
+      irb.context.echo = false
+      irb.context.echo_on_assignment = true
+      irb.context.omit_on_assignment = true
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("", out)
+      irb.context.evaluate('A.remove_method(:inspect)', 0)
+
+      input.reset
+      irb.context.echo = false
+      irb.context.echo_on_assignment = true
+      irb.context.omit_on_assignment = false
+      out, err = capture_io do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal("", out)
+      irb.context.evaluate('A.remove_method(:inspect)', 0)
+    end
+
     def test_echo_on_assignment_conf
       # Default
       IRB.conf[:ECHO] = nil


### PR DESCRIPTION
Omit the results evaluated at assignment if they are too long.

The behavior of `ECHO_ON_ASSIGNMENT` being on by default is hard to understand, so I change it to off by default. Instead, we turn `OMIT_ON_ASSIGNMENT` on by default. The result is displayed on assignment, but it will always be short and within one line of the screen.

ref. https://github.com/ruby/irb/pull/12