### PR TITLE
support more body argument for oneliner method definition

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -317,13 +317,11 @@ class RubyLex
           if t[2] == '='
             in_oneliner_def = :BODY
           end
-        elsif t[3].allbits?(Ripper::EXPR_END)
+        else
           if in_oneliner_def == :BODY
             # one-liner method definition
             indent -= 1
           end
-          in_oneliner_def = nil
-        else
           in_oneliner_def = nil
         end
       end
@@ -376,13 +374,11 @@ class RubyLex
           if t[2] == '='
             in_oneliner_def = :BODY
           end
-        elsif t[3].allbits?(Ripper::EXPR_END)
+        else
           if in_oneliner_def == :BODY
             # one[-liner method definition
             depth_difference -= 1
           end
-          in_oneliner_def = nil
-        else
           in_oneliner_def = nil
         end
       end
@@ -451,7 +447,7 @@ class RubyLex
           if t[2] == '='
             in_oneliner_def = :BODY
           end
-        elsif t[3].allbits?(Ripper::EXPR_END)
+        else
           if in_oneliner_def == :BODY
             # one-liner method definition
             if is_first_printable_of_line
@@ -461,8 +457,6 @@ class RubyLex
               corresponding_token_depth = nil
             end
           end
-          in_oneliner_def = nil
-        else
           in_oneliner_def = nil
         end
       end

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -233,6 +233,8 @@ module TestIRB
         Row.new(%q(  def bar0() = 3), nil, 2),
         Row.new(%q(  def bar1(a) = a), nil, 2),
         Row.new(%q(  def bar2(a, b) = a + b), nil, 2),
+        Row.new(%q(  def bar3() = :s), nil, 2),
+        Row.new(%q(  def bar4() = Time.now), nil, 2),
         Row.new(%q(end), 0, 0),
       ]
 


### PR DESCRIPTION
```ruby
def i() = 1
def s() = :s
def t() = Time.now
```

are all valid, but

```ruby
$ bin/console -f
irb(main):001:0> def i() = 1
=> :i
irb(main):002:1> def s() = :s
irb(main):003:1*   ^C
irb(main):002:1> def t() = Time.now
irb(main):003:1*   ^C
irb(main):002:0> 
```

It seems that a method body does not always contain `Ripper::EXPR_END`.