### PR TITLE
Add a fallback for check_code_block that does not depend on implementation-private APIs

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -222,11 +222,16 @@ class RubyLex
     begin # check if parser error are available
       verbose, $VERBOSE = $VERBOSE, nil
       case RUBY_ENGINE
+      when 'ruby'
+        self.class.compile_with_errors_suppressed(code) do |inner_code, line_no|
+          RubyVM::InstructionSequence.compile(inner_code, nil, nil, line_no)
+        end
       when 'jruby'
         JRuby.compile_ir(code)
       else
-        self.class.compile_with_errors_suppressed(code) do |inner_code, line_no|
-          RubyVM::InstructionSequence.compile(inner_code, nil, nil, line_no)
+        catch(:valid) do
+          eval("BEGIN { throw :valid, true }\n#{code}")
+          false
         end
       end
     rescue EncodingError


### PR DESCRIPTION
* Fixes https://github.com/ruby/irb/issues/133

I also suggest to add TruffleRuby in CI to notice this earlier: https://github.com/ruby/irb/pull/135