### PR TITLE
Add TruffleRuby in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.6.6
   - 2.7.1
   - ruby-head
+  - truffleruby-head
 before_install:
   - yes | gem update --system
 

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -68,6 +68,7 @@ module TestIRB
     end
 
     def test_evaluate_with_encoding_error_without_lineno
+      skip if RUBY_ENGINE == 'truffleruby'
       assert_raise_with_message(EncodingError, /invalid symbol/) {
         @context.evaluate(%q[{"\xAE": 1}], 1)
         # The backtrace of this invalid encoding hash doesn't contain lineno.
@@ -75,6 +76,7 @@ module TestIRB
     end
 
     def test_evaluate_with_onigmo_warning
+      skip if RUBY_ENGINE == 'truffleruby'
       assert_warning("(irb):1: warning: character class has duplicated range: /[aa]/\n") do
         @context.evaluate('/[aa]/', 1)
       end

--- a/test/irb/test_raise_no_backtrace_exception.rb
+++ b/test/irb/test_raise_no_backtrace_exception.rb
@@ -4,6 +4,7 @@ require 'test/unit'
 module TestIRB
   class TestRaiseNoBacktraceException < Test::Unit::TestCase
     def test_raise_exception
+      skip if RUBY_ENGINE == 'truffleruby'
       bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []
       assert_in_out_err(bundle_exec + %w[-rirb -W0 -e IRB.start(__FILE__) -- -f --], <<-IRB, /Exception: foo/, [])
       e = Exception.new("foo")


### PR DESCRIPTION
Current failures:
```
bundle exec rake test
Run options: 

# Running tests:

[20/51] TestIRB::TestContext#test_evaluate_with_encoding_error_without_lineno = 0.01 s
  1) Failure:
TestIRB::TestContext#test_evaluate_with_encoding_error_without_lineno [/home/eregon/code/irb/test/irb/test_context.rb:71]:
Exception(EncodingError) with message matches to /invalid symbol/.
EncodingError expected but nothing was raised.

[22/51] TestIRB::TestContext#test_evaluate_with_onigmo_warning = 0.03 s               
  2) Failure:
TestIRB::TestContext#test_evaluate_with_onigmo_warning [/home/eregon/code/irb/test/irb/test_context.rb:78]:
--- expected
+++ actual
@@ -1,2 +1 @@
-"(irb):1: warning: character class has duplicated range: /[aa]/
-"
+""
.

[36/51] TestIRB::TestRaiseNoBacktraceException#test_raise_exception = 1.95 s           
  3) Failure:
TestIRB::TestRaiseNoBacktraceException#test_raise_exception [/home/eregon/code/irb/test/irb/test_raise_no_backtrace_exception.rb:8]:

1. [2/2] Assertion for "stderr"
   | <[]> expected but was
   | <["stty: 'standard input': Inappropriate ioctl for device"]>.

[40/51] TestIRB::TestRubyLex#test_incomplete_coding_magic_comment = 0.01 s              
  4) Error:
TestIRB::TestRubyLex#test_incomplete_coding_magic_comment:
RuntimeError: External LLVMFunction rb_make_exception cannot be found. (LLVMLinkerException)
Translated to internal error
    ripper.y:6601:in `parser_set_encode'
    ripper.y:6641:in `magic_comment_encoding'
    ripper.y:6838:in `parser_magic_comment'
    ripper.y:7709:in `parser_yylex'
    ripper.y:8330:in `yylex'
    ripper.c:5263:in `ripper_yyparse'
    ripper.y:11398:in `ripper_parse0'
    /home/eregon/.rubies/truffleruby-dev/lib/truffle/truffle/cext.rb:1482:in `rb_ensure'
    exception.c:68:in `rb_ensure'
    ripper.y:11436:in `ripper_parse'
    /home/eregon/.rubies/truffleruby-dev/lib/truffle/truffle/cext_ruby.rb:39:in `parse'
    /home/eregon/.rubies/truffleruby-dev/lib/mri/ripper/lexer.rb:79:in `parse'
    /home/eregon/.rubies/truffleruby-dev/lib/mri/ripper/lexer.rb:73:in `lex'
    /home/eregon/.rubies/truffleruby-dev/lib/mri/ripper/lexer.rb:45:in `lex'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:93:in `block in ripper_lex_without_warning'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:36:in `compile_with_errors_suppressed'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:92:in `ripper_lex_without_warning'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:112:in `block in set_auto_indent'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:17:in `call'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:17:in `auto_indent'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:101:in `set_auto_indent'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:34:in `assert_indenting'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:147:in `block in test_incomplete_coding_magic_comment'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:145:in `each'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:145:in `test_incomplete_coding_magic_comment'

TestIRB::TestRubyLex#test_incomplete_coding_magic_comment: $VERBOSE == 
[41/51] TestIRB::TestRubyLex#test_incomplete_emacs_coding_magic_comment = 0.00 s
  5) Error:
TestIRB::TestRubyLex#test_incomplete_emacs_coding_magic_comment:
RuntimeError: External LLVMFunction rb_make_exception cannot be found. (LLVMLinkerException)
Translated to internal error
    ripper.y:6601:in `parser_set_encode'
    ripper.y:6890:in `set_file_encoding'
    ripper.y:7711:in `parser_yylex'
    ripper.y:8330:in `yylex'
    ripper.c:5263:in `ripper_yyparse'
    ripper.y:11398:in `ripper_parse0'
    /home/eregon/.rubies/truffleruby-dev/lib/truffle/truffle/cext.rb:1482:in `rb_ensure'
    exception.c:68:in `rb_ensure'
    ripper.y:11436:in `ripper_parse'
    /home/eregon/.rubies/truffleruby-dev/lib/truffle/truffle/cext_ruby.rb:39:in `parse'
    /home/eregon/.rubies/truffleruby-dev/lib/mri/ripper/lexer.rb:79:in `parse'
    /home/eregon/.rubies/truffleruby-dev/lib/mri/ripper/lexer.rb:73:in `lex'
    /home/eregon/.rubies/truffleruby-dev/lib/mri/ripper/lexer.rb:45:in `lex'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:93:in `block in ripper_lex_without_warning'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:36:in `compile_with_errors_suppressed'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:92:in `ripper_lex_without_warning'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:112:in `block in set_auto_indent'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:17:in `call'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:17:in `auto_indent'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:101:in `set_auto_indent'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:34:in `assert_indenting'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:173:in `block in test_incomplete_emacs_coding_magic_comment'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:171:in `each'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:171:in `test_incomplete_emacs_coding_magic_comment'

TestIRB::TestRubyLex#test_incomplete_emacs_coding_magic_comment: $VERBOSE == 
[42/51] TestIRB::TestRubyLex#test_incomplete_encoding_magic_comment = 0.00 s    
  6) Error:
TestIRB::TestRubyLex#test_incomplete_encoding_magic_comment:
RuntimeError: External LLVMFunction rb_make_exception cannot be found. (LLVMLinkerException)
Translated to internal error
    ripper.y:6601:in `parser_set_encode'
    ripper.y:6641:in `magic_comment_encoding'
    ripper.y:6838:in `parser_magic_comment'
    ripper.y:7709:in `parser_yylex'
    ripper.y:8330:in `yylex'
    ripper.c:5263:in `ripper_yyparse'
    ripper.y:11398:in `ripper_parse0'
    /home/eregon/.rubies/truffleruby-dev/lib/truffle/truffle/cext.rb:1482:in `rb_ensure'
    exception.c:68:in `rb_ensure'
    ripper.y:11436:in `ripper_parse'
    /home/eregon/.rubies/truffleruby-dev/lib/truffle/truffle/cext_ruby.rb:39:in `parse'
    /home/eregon/.rubies/truffleruby-dev/lib/mri/ripper/lexer.rb:79:in `parse'
    /home/eregon/.rubies/truffleruby-dev/lib/mri/ripper/lexer.rb:73:in `lex'
    /home/eregon/.rubies/truffleruby-dev/lib/mri/ripper/lexer.rb:45:in `lex'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:93:in `block in ripper_lex_without_warning'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:36:in `compile_with_errors_suppressed'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:92:in `ripper_lex_without_warning'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:112:in `block in set_auto_indent'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:17:in `call'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:17:in `auto_indent'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:101:in `set_auto_indent'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:34:in `assert_indenting'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:160:in `block in test_incomplete_encoding_magic_comment'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:158:in `each'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:158:in `test_incomplete_encoding_magic_comment'

TestIRB::TestRubyLex#test_incomplete_encoding_magic_comment: $VERBOSE == 
[43/51] TestIRB::TestRubyLex#test_incomplete_vim_coding_magic_comment = 0.00 s
  7) Error:
TestIRB::TestRubyLex#test_incomplete_vim_coding_magic_comment:
RuntimeError: External LLVMFunction rb_make_exception cannot be found. (LLVMLinkerException)
Translated to internal error
    ripper.y:6601:in `parser_set_encode'
    ripper.y:6890:in `set_file_encoding'
    ripper.y:7711:in `parser_yylex'
    ripper.y:8330:in `yylex'
    ripper.c:5263:in `ripper_yyparse'
    ripper.y:11398:in `ripper_parse0'
    /home/eregon/.rubies/truffleruby-dev/lib/truffle/truffle/cext.rb:1482:in `rb_ensure'
    exception.c:68:in `rb_ensure'
    ripper.y:11436:in `ripper_parse'
    /home/eregon/.rubies/truffleruby-dev/lib/truffle/truffle/cext_ruby.rb:39:in `parse'
    /home/eregon/.rubies/truffleruby-dev/lib/mri/ripper/lexer.rb:79:in `parse'
    /home/eregon/.rubies/truffleruby-dev/lib/mri/ripper/lexer.rb:73:in `lex'
    /home/eregon/.rubies/truffleruby-dev/lib/mri/ripper/lexer.rb:45:in `lex'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:93:in `block in ripper_lex_without_warning'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:36:in `compile_with_errors_suppressed'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:92:in `ripper_lex_without_warning'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:112:in `block in set_auto_indent'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:17:in `call'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:17:in `auto_indent'
    /home/eregon/code/irb/lib/irb/ruby-lex.rb:101:in `set_auto_indent'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:34:in `assert_indenting'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:186:in `block in test_incomplete_vim_coding_magic_comment'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:184:in `each'
    /home/eregon/code/irb/test/irb/test_ruby_lex.rb:184:in `test_incomplete_vim_coding_magic_comment'

TestIRB::TestRubyLex#test_incomplete_vim_coding_magic_comment: $VERBOSE == 
TestIRB::TestRubyLex#test_mixed_rescue: $VERBOSE ==                           
TestIRB::TestRubyLex#test_multiple_braces_in_a_line: $VERBOSE ==    
TestIRB::TestRubyLex#test_oneliner_method_definition: $VERBOSE ==    
TestIRB::TestRubyLex#test_tlambda: $VERBOSE ==    
Finished tests in 15.793000s, 3.2293 tests/s, 28.2404 assertions/s.                           
51 tests, 446 assertions, 3 failures, 4 errors, 1 skips

ruby -v: truffleruby 20.3.0-dev-cefb5307, like ruby 2.6.6, GraalVM CE Native [x86_64-linux]
rake aborted!
Command failed with status (7)
<internal:core> core/kernel.rb:401:in `load'
<internal:core> core/kernel.rb:401:in `load'
<internal:core> core/kernel.rb:401:in `load'
<internal:core> core/kernel.rb:401:in `load'
<internal:core> core/kernel.rb:401:in `load'
<internal:core> core/kernel.rb:401:in `load'
/home/eregon/.rubies/truffleruby-dev/bin/bundle:43:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

The last 4 I'll fix by implementing `rb_make_exception()` in TruffleRuby.
The first 3 I think it's fair to skip it on non-MRI.