### PR TITLE
Stop using bang version for #inspect of result

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -761,7 +761,7 @@ module IRB
             str = "%s...\e[0m" % lines.first
             multiline_p = false
           else
-            str.gsub!(/(\A.*?\n).*/m, "\\1...")
+            str = str.gsub(/(\A.*?\n).*/m, "\\1...")
           end
         else
           output_width = Reline::Unicode.calculate_width(@context.return_format % str, true)


### PR DESCRIPTION
This fixes https://github.com/ruby/irb/issues/136.