### PR TITLE
Change context-mode's default to new mode 4.

### DIFF
--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -108,7 +108,7 @@ module IRB # :nodoc:
     @CONF[:PROMPT_MODE] = (STDIN.tty? ? :DEFAULT : :NULL)
     @CONF[:AUTO_INDENT] = true
 
-    @CONF[:CONTEXT_MODE] = 3 # use binding in function on TOPLEVEL_BINDING
+    @CONF[:CONTEXT_MODE] = 4 # use a copy of TOPLEVEL_BINDING
     @CONF[:SINGLE_IRB] = false
 
     @CONF[:LC_MESSAGES] = Locale.new

--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -51,11 +51,13 @@ EOF
           end
           @binding = BINDING_QUEUE.pop
 
-        when 3	# binding in function on TOPLEVEL_BINDING(default)
+        when 3	# binding in function on TOPLEVEL_BINDING
           @binding = eval("self.class.remove_method(:irb_binding) if defined?(irb_binding); private; def irb_binding; binding; end; irb_binding",
                           TOPLEVEL_BINDING,
                           __FILE__,
                           __LINE__ - 3)
+        when 4  # binding is a copy of TOPLEVEL_BINDING (default)
+          @binding = TOPLEVEL_BINDING.dup
         end
       end
 


### PR DESCRIPTION
This new mode uses a copy of the TOPLEVEL_BINDING. This is compatible with refinements (contrary to mode 3), while keeping nested IRB sessions separate.

Current default makes it impossible to call `using SomeModule` from the top level.
Other modes work:

```sh
irb --single-irb # => works (shared context for nested sessions)
irb --context 0 # => works
irb --context 1 # => works
irb --context 2 # => works
irb --context 3 # (current default) => does not work
irb --context 4 # (proposed default) => works
```

I believe the default mode can not be made to work as it is by design that one can not call `using` from inside a method.

This PR proposes a 4th mode that seems the most versatile and least error prone: `TOPLEVEL_BINDING.dup`.

I am surprised that it isn't used already, I was expecting this to be the default. Either there is some limitation that I am not aware of, or else maybe it is for historical reason that is not used?

Fixes [redmine bug #9580](https://bugs.ruby-lang.org/issues/9580)