### PR TITLE
Newline in oneliner def doesn't reset indent

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -410,7 +410,7 @@ class RubyLex
 
       case t[1]
       when :on_ignored_nl, :on_nl, :on_comment
-        if index != (@tokens.size - 1)
+        if index != (@tokens.size - 1) and in_oneliner_def != :BODY
           depth_difference = 0
           open_brace_on_line = 0
         end
@@ -488,11 +488,13 @@ class RubyLex
 
       case t[1]
       when :on_ignored_nl, :on_nl, :on_comment
-        corresponding_token_depth = nil
-        spaces_at_line_head = 0
-        is_first_spaces_of_line = true
-        is_first_printable_of_line = true
-        open_brace_on_line = 0
+        if in_oneliner_def != :BODY
+          corresponding_token_depth = nil
+          spaces_at_line_head = 0
+          is_first_spaces_of_line = true
+          is_first_printable_of_line = true
+          open_brace_on_line = 0
+        end
         next
       when :on_sp
         spaces_at_line_head = t[2].count(' ') if is_first_spaces_of_line

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -263,6 +263,23 @@ module TestIRB
       end
     end
 
+    def test_oneliner_def_in_multiple_lines
+      input_with_correct_indents = [
+        Row.new(%q(def a()=[), nil, 4, 2),
+        Row.new(%q(  1,), nil, 4, 1),
+        Row.new(%q(].), 0, 0, 0),
+        Row.new(%q(to_s), nil, 0, 0),
+      ]
+
+      lines = []
+      input_with_correct_indents.each do |row|
+        lines << row.content
+        assert_indenting(lines, row.current_line_spaces, false)
+        assert_indenting(lines, row.new_line_spaces, true)
+        assert_nesting_level(lines, row.nesting_level)
+      end
+    end
+
     PromptRow = Struct.new(:prompt, :content)
 
     class MockIO_DynamicPrompt


### PR DESCRIPTION
This closes ruby/irb#132.