### PR TITLE
Escape invalid byte sequence in Exception

### DIFF
--- a/test/irb/test_raise_no_backtrace_exception.rb
+++ b/test/irb/test_raise_no_backtrace_exception.rb
@@ -13,5 +13,13 @@ module TestIRB
       raise e
 IRB
     end
+
+    def test_raise_exception_with_invalid_byte_sequence
+      skip if RUBY_ENGINE == 'truffleruby'
+      bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []
+      assert_in_out_err(bundle_exec + %w[-rirb -W0 -e IRB.start(__FILE__) -- -f --], <<~IRB, /StandardError \(A\\xF3B\)/, [])
+        raise StandardError, "A\\xf3B"
+      IRB
+    end
   end
 end


### PR DESCRIPTION
This fixes ruby/irb#141.