### PR TITLE
Heredoc may contain multiple newlines in a single token

### DIFF
--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -333,6 +333,23 @@ module TestIRB
       end
     end
 
+    def test_heredoc_with_indent
+      input_with_correct_indents = [
+        Row.new(%q(<<~Q), nil, 0, 0),
+        Row.new(%q({), nil, 0, 0),
+        Row.new(%q(  #), nil, 0, 0),
+        Row.new(%q(}), nil, 0, 0),
+      ]
+
+      lines = []
+      input_with_correct_indents.each do |row|
+        lines << row.content
+        assert_indenting(lines, row.current_line_spaces, false)
+        assert_indenting(lines, row.new_line_spaces, true)
+        assert_nesting_level(lines, row.nesting_level)
+      end
+    end
+
     def test_oneliner_def_in_multiple_lines
       input_with_correct_indents = [
         Row.new(%q(def a()=[), nil, 4, 2),


### PR DESCRIPTION
Use the start token as the indentation criteria so that it works properly in heredoc.

ref. https://github.com/ruby/reline/pull/242