### PR TITLE
Stringify when a non-object is passed to PP#text

### DIFF
--- a/lib/irb/color_printer.rb
+++ b/lib/irb/color_printer.rb
@@ -10,7 +10,12 @@ module IRB
       out
     end
 
-    def text(str, width = str.length)
+    def text(str, width = nil)
+      unless str.is_a?(String)
+        str = str.inspect
+      end
+      width ||= str.length
+
       case str
       when /\A#</, '=', '>'
         super(Color.colorize(str, [:GREEN]), width)

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: false
 require 'test/unit'
 require 'irb/color'
+require 'irb/color_printer'
 require 'rubygems'
 require 'stringio'
 
@@ -152,6 +153,20 @@ module TestIRB
       end
     end
 
+    def test_color_printer
+      unless ripper_lexer_scan_supported?
+        skip 'Ripper::Lexer#scan is supported in Ruby 2.7+'
+      end
+      {
+        1 => "#{BLUE}#{BOLD}1#{CLEAR}",
+        Struct.new('IRBTestColorPrinter', :a).new('test') => "#{GREEN}#<struct Struct::IRBTestColorPrinter#{CLEAR} a#{GREEN}=#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{RED}test#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{GREEN}>#{CLEAR}",
+        Ripper::Lexer.new('1').scan => "[#{GREEN}#<Ripper::Lexer::Elem:#{CLEAR} on_int@1:0 END token: #{RED}#{BOLD}\"#{CLEAR}#{RED}1#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{GREEN}>#{CLEAR}]",
+      }.each do |object, result|
+        actual = with_term { IRB::ColorPrinter.pp(object, '') }
+        assert_equal(result, actual, "Case: IRB::ColorPrinter.pp(#{object.inspect}, '')")
+      end
+    end
+
     def test_inspect_colorable
       {
         1 => true,
@@ -181,6 +196,10 @@ module TestIRB
 
     # `complete: true` is the same as `complete: false` in Ruby 2.6-
     def complete_option_supported?
+      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+    end
+
+    def ripper_lexer_scan_supported?
       Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
     end
 


### PR DESCRIPTION
If a nested object is passed to `#pp`, it may be sometimes passed to the `#text` method as an object without being stringified.

This is [fixed on the Ruby main repository](https://github.com/ruby/ruby/commit/433a3be86a811de0b4adbb92e054ee3a6fc6b4d8), but it was a bug of Ripper so still needs this workaround for using irb as a gem on Ruby 3.0.0 or earlier.