### PR TITLE
refactoring an error handling in `IRB::Inspector`

### DIFF
--- a/lib/irb/inspector.rb
+++ b/lib/irb/inspector.rb
@@ -100,21 +100,19 @@ module IRB # :nodoc:
     # Proc to call when the input is evaluated and output in irb.
     def inspect_value(v)
       @inspect.call(v)
+    rescue
+      puts "(Object doesn't support #inspect)"
+      ''
     end
   end
 
   Inspector.def_inspector([false, :to_s, :raw]){|v| v.to_s}
   Inspector.def_inspector([:p, :inspect]){|v|
-    begin
-      result = v.inspect
-      if IRB.conf[:MAIN_CONTEXT]&.use_colorize? && Color.inspect_colorable?(v)
-        result = Color.colorize_code(result)
-      end
-      result
-    rescue NoMethodError
-      puts "(Object doesn't support #inspect)"
-      ''
+    result = v.inspect
+    if IRB.conf[:MAIN_CONTEXT]&.use_colorize? && Color.inspect_colorable?(v)
+      result = Color.colorize_code(result)
     end
+    result
   }
   Inspector.def_inspector([true, :pp, :pretty_inspect], proc{require "irb/color_printer"}){|v|
     if IRB.conf[:MAIN_CONTEXT]&.use_colorize?


### PR DESCRIPTION
* moved rescue clause to `#inspect_value` to catch all failures in inspectors
* test with all (currently five kind of) inspect modes
  - tweaked the input due to only `Marshal` can inspect(dump) a `BasicObject`
