### PR TITLE
handle repeated exception separately

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -574,6 +574,8 @@ module IRB
             next
           end
           handle_exception(exc)
+          @context.workspace.local_variable_set(:_, exc)
+          exc = nil
         end
       end
     end

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -105,6 +105,24 @@ module TestIRB
       $VERBOSE = verbose
     end
 
+    def test_eval_input_raise2x
+      input = TestInputMethod.new([
+        "raise 'Foo'\n",
+        "raise 'Bar'\n",
+        "_\n",
+      ])
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_pattern_list([
+          :*, /\(irb\):1:in `<main>': Foo \(RuntimeError\)\n/,
+          :*, /\(irb\):2:in `<main>': Bar \(RuntimeError\)\n/,
+          :*, /#<RuntimeError: Bar>\n/,
+        ], out)
+    end
+
     def test_eval_object_without_inspect_method
       verbose, $VERBOSE = $VERBOSE, nil
       all_assertions do |all|

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -106,6 +106,7 @@ module TestIRB
     end
 
     def test_eval_input_raise2x
+      skip if RUBY_ENGINE == 'truffleruby'
       input = TestInputMethod.new([
         "raise 'Foo'\n",
         "raise 'Bar'\n",


### PR DESCRIPTION
In the following situation, the second excption should not contain the first exception.

```ruby
$ bundle exec bin/console -f
irb(main):001:0> context.back_trace_limit = 1
=> 1
irb(main):002:0> raise "Foo"
(irb):2:in `<main>': Foo (RuntimeError)
	from bin/console:6:in `<top (required)>'
	... 15 levels...
irb(main):003:0> raise "Bar"
(irb):3:in `rescue in <main>': Bar (RuntimeError)
	from (irb):2:in `<main>'
	... 16 levels...
(irb):2:in `<main>': Foo (RuntimeError)
	from bin/console:6:in `<top (required)>'
	... 15 levels...
irb(main):004:0> _
=> #<RuntimeError: Bar>
```

This PR fixes this as following:

```ruby
$ bundle exec bin/console -f
irb(main):001:0> context.back_trace_limit = 1
=> 1
irb(main):002:0> raise "Foo"
(irb):2:in `<main>': Foo (RuntimeError)
	from bin/console:6:in `<top (required)>'
	... 15 levels...
irb(main):003:0> raise "Bar"
(irb):3:in `<main>': Bar (RuntimeError)
	from bin/console:6:in `<top (required)>'
	... 15 levels...
irb(main):004:0> _
=> #<RuntimeError: Bar>
```
