### PR TITLE
Use a real screen size for pp by default

### DIFF
--- a/lib/irb/color_printer.rb
+++ b/lib/irb/color_printer.rb
@@ -4,7 +4,7 @@ require 'irb/color'
 
 module IRB
   class ColorPrinter < ::PP
-    def self.pp(obj, out = $>, width = 79)
+    def self.pp(obj, out = $>, width = Reline.get_screen_size.last)
       q = ColorPrinter.new(out, width)
       q.guard_inspect_key {q.pp obj}
       q.flush


### PR DESCRIPTION
This tries to mitigate the situation around https://bugs.ruby-lang.org/issues/17557 a little bit.

It seems this API is fast enough, but is that always true?

```rb
irb(main)[02:0]> measure 'Reline.get_screen_size.last'
processing time: 0.000165s
=> nil
```