### PR TITLE
Actions - add a few Windows jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,19 +2,21 @@ name: build
 
 on: [push, pull_request]
 
+# matrix notes
+# ruby - without quotes, 3.0 is parsed as 3 (semantic major)
+# os - see https://github.com/actions/virtual-environments#available-environments
+
 jobs:
   build:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby:
-          - '3.0'
-          - '2.7'
-          - '2.6'
-          - '2.5'
-          - head
-          - truffleruby-head
-        os: [ubuntu-latest]
+        ruby: [ '3.0', '2.7', '2.6', '2.5', head, truffleruby-head ]
+        os: [ubuntu-20.04] # macos-11.0
+        include:
+          - { os: windows-2019 , ruby: '3.0' }
+          - { os: windows-2019 , ruby: '2.5' }
+          - { os: windows-2019 , ruby: mingw }
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -24,8 +26,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies
-      run: |
-        gem install bundler --no-document
-        bundle install
+      run: bundle install
     - name: Run test
       run: bundle exec rake test


### PR DESCRIPTION
Also, add matrix notes, ruby/setup-ruby install Bundler by default

std-lib repos should test on Windows rather than break ruby/ruby...

macOS-11.0 is better, but still troublesome.