### PR TITLE
follow up the actual line number

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -223,7 +223,10 @@ class RubyLex
             throw :TERM_INPUT if @line == ''
           else
             @line_no += l.count("\n")
-            next if l == "\n"
+            if l == "\n"
+              @exp_line_no += 1
+              next
+            end
             @line.concat l
             if @code_block_open or @ltype or @continue or @indent > 0
               next

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -572,5 +572,26 @@ module TestIRB
     ensure
       $VERBOSE = verbose
     end
+
+    def test_lineno
+      input = TestInputMethod.new([
+        "\n",
+        "__LINE__\n",
+        "__LINE__\n",
+        "\n",
+        "\n",
+        "__LINE__\n",
+      ])
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_pattern_list([
+          :*, /\b2\n/,
+          :*, /\b3\n/,
+          :*, /\b6\n/,
+        ], out)
+    end
   end
 end


### PR DESCRIPTION
Empty lines do not increment `__LINE__`  as follow:

```ruby
$ bundle exec bin/console -f
irb(main):001:0> 
irb(main):002:0> __LINE__
=> 1
irb(main):003:0> __LINE__
=> 3
irb(main):004:0> 
irb(main):005:0> 
irb(main):006:0> __LINE__
=> 4
irb(main):007:0> 
```

This PR fixes this behavior to follow up the actual line number.

```ruby
$ bundle exec bin/console -f
irb(main):001:0> 
irb(main):002:0> __LINE__
=> 2
irb(main):003:0> __LINE__
=> 3
irb(main):004:0> 
irb(main):005:0> 
irb(main):006:0> __LINE__
=> 6
irb(main):007:0> 
```
