### PR TITLE
Add info.rb to gemspec

### DIFF
--- a/irb.gemspec
+++ b/irb.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
     "lib/irb/cmd/chws.rb",
     "lib/irb/cmd/fork.rb",
     "lib/irb/cmd/help.rb",
+    "lib/irb/cmd/info.rb",
     "lib/irb/cmd/load.rb",
     "lib/irb/cmd/measure.rb",
     "lib/irb/cmd/nop.rb",


### PR DESCRIPTION
Fixed a problem with `irb_info` in Ruby 2.6.6.

Thanks @osyo-manga 😊 

Before:
```
irb(main):001:0> RUBY_VERSION
=> "2.6.6"
irb(main):003:0> IRB::VERSION
=> "1.3.2"
irb(main):004:0> Reline::VERSION
=> "0.2.2"
irb(main):005:0> irb_info
Traceback (most recent call last):
	22: from /Users/mi/.rbenv/versions/2.6.6/bin/irb:23:in `<main>'
	21: from /Users/mi/.rbenv/versions/2.6.6/bin/irb:23:in `load'
	20: from /Users/mi/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.3.2/exe/irb:11:in `<top (required)>'
	 3: from (irb):5:in `<main>'
	 1: from /Users/mi/.rbenv/versions/2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/Users/mi/.rbenv/versions/2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- irb/cmd/info (LoadError)
```

After:
```
❯ RBENV_VERSION=2.6.6 irb         
irb(main):001:0> RUBY_VERSION
=> "2.6.6"
irb(main):002:0> IRB::VERSION
=> "1.3.2"
irb(main):003:0> Reline::VERSION
=> "0.2.2"
irb(main):004:0> irb_info
=> 
Ruby version: 2.6.6
IRB version: irb 1.3.2 (2021-01-18)
InputMethod: ReidlineInputMethod with Reline 0.2.2
.irbrc path: /Users/mi/.irbrc
```