### PR TITLE
Do not continue line if last expression is an endless range

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -277,8 +277,9 @@ class RubyLex
       return true
     elsif tokens.size >= 1 and tokens[-1][1] == :on_heredoc_end # "EOH\n"
       return false
-    elsif tokens.size >= 2 and defined?(Ripper::EXPR_BEG) and tokens[-2][3].anybits?(Ripper::EXPR_BEG | Ripper::EXPR_FNAME)
+    elsif tokens.size >= 2 and defined?(Ripper::EXPR_BEG) and tokens[-2][3].anybits?(Ripper::EXPR_BEG | Ripper::EXPR_FNAME) and tokens[-2][2] !~ /\A\.\.\.?\z/
       # end of literal except for regexp
+      # endless range at end of line is not a continue
       return true
     end
     false

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -136,6 +136,20 @@ module TestIRB
       end
     end
 
+    def test_endless_range_at_end_of_line
+      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.6.0')
+        skip 'Endless range is available in 2.6.0 or later'
+      end
+      input_with_prompt = [
+        PromptRow.new('001:0: :> ', %q(a = 3..)),
+        PromptRow.new('002:0: :* ', %q()),
+      ]
+
+      lines = input_with_prompt.map(&:content)
+      expected_prompt_list = input_with_prompt.map(&:prompt)
+      assert_dynamic_prompt(lines, expected_prompt_list)
+    end
+
     def test_incomplete_coding_magic_comment
       input_with_correct_indents = [
         Row.new(%q(#coding:u), nil, 0),


### PR DESCRIPTION
I couldn't figure out how to add an automated test for this.

Fixes [Bug #14824]