### PR TITLE
Implement pry-like ls command

### DIFF
--- a/lib/irb/cmd/ls.rb
+++ b/lib/irb/cmd/ls.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative "nop"
+require_relative "../color"
+
+# :stopdoc:
+module IRB
+  module ExtendCommand
+    class Ls < Nop
+      def execute(*arg, grep: nil)
+        o = Output.new(grep: grep)
+
+        obj    = arg.empty? ? irb_context.workspace.main : arg.first
+        locals = arg.empty? ? irb_context.workspace.binding.local_variables : []
+        klass  = (obj.class == Class || obj.class == Module ? obj : obj.class)
+
+        o.dump("constants", obj.constants) if obj.respond_to?(:constants)
+        o.dump("#{klass}.methods", obj.singleton_methods(false))
+        o.dump("#{klass}#methods", klass.public_instance_methods(false))
+        o.dump("instance variables", obj.instance_variables)
+        o.dump("class variables", klass.class_variables)
+        o.dump("locals", locals)
+      end
+
+      class Output
+        def initialize(grep: nil)
+          @grep = grep
+        end
+
+        def dump(name, strs)
+          strs = strs.grep(@grep) if @grep
+          strs = strs.sort
+          return if strs.empty?
+
+          print "#{Color.colorize(name, [:BOLD, :BLUE])}: "
+          if strs.size > 7
+            len = [strs.map(&:length).max, 16].min
+            puts; strs.each_slice(7) { |ss| puts "  #{ss.map { |s| "%-#{len}s" % s }.join("  ")}" }
+          else
+            puts strs.join("  ")
+          end
+        end
+      end
+      private_constant :Output
+    end
+  end
+end
+# :startdoc:

--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -14,10 +14,16 @@ module IRB
   module ExtendCommand
     class Nop
 
-
-      def self.execute(conf, *opts, &block)
-        command = new(conf)
-        command.execute(*opts, &block)
+      if RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.7.0"
+        def self.execute(conf, *opts, **kwargs, &block)
+          command = new(conf)
+          command.execute(*opts, **kwargs, &block)
+        end
+      else
+        def self.execute(conf, *opts, &block)
+          command = new(conf)
+          command.execute(*opts, &block)
+        end
       end
 
       def initialize(conf)

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -126,6 +126,11 @@ module IRB # :nodoc:
       ],
 
       [
+        :irb_ls, :Ls, "irb/cmd/ls",
+        [:ls, NO_OVERRIDE],
+      ],
+
+      [
         :irb_measure, :Measure, "irb/cmd/measure",
         [:measure, NO_OVERRIDE],
       ],
@@ -169,12 +174,13 @@ module IRB # :nodoc:
       end
 
       if load_file
+        kwargs = ", **kwargs" if RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.7.0"
         line = __LINE__; eval %[
-          def #{cmd_name}(*opts, &b)
+          def #{cmd_name}(*opts#{kwargs}, &b)
             require "#{load_file}"
             arity = ExtendCommand::#{cmd_class}.instance_method(:execute).arity
             args = (1..(arity < 0 ? ~arity : arity)).map {|i| "arg" + i.to_s }
-            args << "*opts" if arity < 0
+            args << "*opts#{kwargs}" if arity < 0
             args << "&block"
             args = args.join(", ")
             line = __LINE__; eval %[
@@ -185,7 +191,7 @@ module IRB # :nodoc:
                 end
               end
             ], nil, __FILE__, line
-            __send__ :#{cmd_name}_, *opts, &b
+            __send__ :#{cmd_name}_, *opts#{kwargs}, &b
           end
         ], nil, __FILE__, line
       else

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -372,5 +372,22 @@ module TestIRB
           /=> "bug17564"\n/,
         ], out)
     end
+
+    def test_ls
+      IRB.init_config(nil)
+      workspace = IRB::WorkSpace.new(self)
+      irb = IRB::Irb.new(workspace)
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+      input = TestInputMethod.new([
+        "ls Object.new.tap { |o| o.instance_variable_set(:@a, 1) }\n",
+      ])
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      irb.context.return_format = "=> %s\n"
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(/^instance variables: @a\n/, out)
+    end
   end
 end


### PR DESCRIPTION
I implemented pry's `ls` command for irb. This is useful when you want to inspect constants, methods, and variables of self or an object without typing a lot.

```rb
$ irb
irb(main)[01:0]> ls ERB.new('test')
ERB#methods:
  def_class         def_method        def_module        encoding          filename          filename=         lineno
  lineno=           location=         make_compiler     result            result_with_hash  run               set_eoutvar
  src
instance variables: @_init  @encoding  @filename  @frozen_string  @lineno  @src
```