### PR TITLE
Add whereami command

### DIFF
--- a/lib/irb/cmd/whereami.rb
+++ b/lib/irb/cmd/whereami.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "nop"
+
+# :stopdoc:
+module IRB
+  module ExtendCommand
+    class Whereami < Nop
+      def execute(*)
+        code = irb_context.workspace.code_around_binding
+        if code
+          puts code
+        else
+          puts "The current context doesn't have code."
+        end
+      end
+    end
+  end
+end
+# :startdoc:

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -135,6 +135,11 @@ module IRB # :nodoc:
         [:measure, NO_OVERRIDE],
       ],
 
+      [
+        :irb_whereami, :Whereami, "irb/cmd/whereami",
+        [:whereami, NO_OVERRIDE],
+      ],
+
     ]
 
     # Installs the default irb commands:

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -389,5 +389,22 @@ module TestIRB
       assert_empty err
       assert_match(/^instance variables: @a\n/, out)
     end
+
+    def test_whereami
+      IRB.init_config(nil)
+      workspace = IRB::WorkSpace.new(self)
+      irb = IRB::Irb.new(workspace)
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+      input = TestInputMethod.new([
+        "whereami\n",
+      ])
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      irb.context.return_format = "=> %s\n"
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(/^From: .+ @ line \d+ :\n/, out)
+    end
   end
 end


### PR DESCRIPTION
This is another command in pry. When you execute a lot of expressions after your `binding.irb` invocation, sometimes the source code of your context may go out of your screen. If you use this `whereami` like gdb's `list`, you can show the code again.

```rb
$ ruby /tmp/a.rb

From: /tmp/a.rb @ line 3 :

    1: a = 1
    2: @b = 2
 => 3: binding.irb

irb(main)[01:0]> a
=> 1
irb(main)[02:0]> @b
=> 2
irb(main)[03:0]> whereami

From: /tmp/a.rb @ line 3 :

    1: a = 1
    2: @b = 2
 => 3: binding.irb

=> nil
```