### PR TITLE
Don't call Ruby 2.4+'s String#pretty_print

### DIFF
--- a/lib/irb/color_printer.rb
+++ b/lib/irb/color_printer.rb
@@ -21,6 +21,15 @@ module IRB
       end
     end
 
+    def pp(obj)
+      if obj.is_a?(String)
+        # Avoid calling Ruby 2.4+ String#pretty_print that splits a string by "\n"
+        text(obj.inspect)
+      else
+        super
+      end
+    end
+
     def text(str, width = nil)
       unless str.is_a?(String)
         str = str.inspect

--- a/test/irb/test_color_printer.rb
+++ b/test/irb/test_color_printer.rb
@@ -34,6 +34,7 @@ module TestIRB
       end
       {
         1 => "#{BLUE}#{BOLD}1#{CLEAR}\n",
+        "a\nb" => %[#{RED}#{BOLD}"#{CLEAR}#{RED}a\\nb#{CLEAR}#{RED}#{BOLD}"#{CLEAR}\n],
         IRBTestColorPrinter.new('test') => "#{GREEN}#<struct TestIRB::TestColorPrinter::IRBTestColorPrinter#{CLEAR} a#{GREEN}=#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{RED}test#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{GREEN}>#{CLEAR}\n",
         Ripper::Lexer.new('1').scan => "[#{GREEN}#<Ripper::Lexer::Elem:#{CLEAR} on_int@1:0 END token: #{RED}#{BOLD}\"#{CLEAR}#{RED}1#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{GREEN}>#{CLEAR}]\n",
         Class.new{define_method(:pretty_print){|q| q.text("[__FILE__, __LINE__, __ENCODING__]")}}.new => "[#{CYAN}#{BOLD}__FILE__#{CLEAR}, #{CYAN}#{BOLD}__LINE__#{CLEAR}, #{CYAN}#{BOLD}__ENCODING__#{CLEAR}]\n",


### PR DESCRIPTION
Just like what pry does.

## Before
```rb
$ irb
irb(main)[01:0]> "a\nb"
=> "a\n" + "b"
```

## After
```rb
$ irb
irb(main)[01:0]> "a\nb"
=> "a\nb"
```