### PR TITLE
Prevent the completion from crashing if rdoc is missing

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -7,8 +7,6 @@
 #       From Original Idea of shugo@ruby-lang.org
 #
 
-autoload :RDoc, "rdoc"
-
 require_relative 'ruby-lex'
 
 module IRB
@@ -329,13 +327,22 @@ module IRB
     end
 
     PerfectMatchedProc = ->(matched, bind: IRB.conf[:MAIN_CONTEXT].workspace.binding) {
+      begin
+        require 'rdoc'
+      rescue LoadError
+        return
+      end
+
       RDocRIDriver ||= RDoc::RI::Driver.new
+
       if matched =~ /\A(?:::)?RubyVM/ and not ENV['RUBY_YES_I_AM_NOT_A_NORMAL_USER']
         IRB.__send__(:easter_egg)
         return
       end
+
       namespace = retrieve_completion_data(matched, bind: bind, doc_namespace: true)
       return unless namespace
+
       if namespace.is_a?(Array)
         out = RDoc::Markup::Document.new
         namespace.each do |m|


### PR DESCRIPTION
There are cases where ruby is installed without rdoc and e.g.
lib/irb/cmd/help.rb also handles the LoadError

Here is how to replicate the issue:

```
$ docker run -it alpine:3.13.3 sh

/ # apk add ruby ruby-irb ruby-io-console

/ # irb

irb(main):001:0> Class[TAB][TAB]
```

And you end up with something like:

```
irb(main):001:0> ClassTraceback (most recent call last):
        34: from /usr/bin/irb:23:in `<main>'
        33: from /usr/bin/irb:23:in `load'
        32: from /usr/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
        31: from /usr/lib/ruby/2.7.0/irb.rb:400:in `start'
        30: from /usr/lib/ruby/2.7.0/irb.rb:471:in `run'
        29: from /usr/lib/ruby/2.7.0/irb.rb:471:in `catch'
        28: from /usr/lib/ruby/2.7.0/irb.rb:472:in `block in run'
        27: from /usr/lib/ruby/2.7.0/irb.rb:537:in `eval_input'
        26: from /usr/lib/ruby/2.7.0/irb/ruby-lex.rb:150:in `each_top_level_statement'
        25: from /usr/lib/ruby/2.7.0/irb/ruby-lex.rb:150:in `catch'
        24: from /usr/lib/ruby/2.7.0/irb/ruby-lex.rb:151:in `block in each_top_level_statement'
        23: from /usr/lib/ruby/2.7.0/irb/ruby-lex.rb:151:in `loop'
        22: from /usr/lib/ruby/2.7.0/irb/ruby-lex.rb:154:in `block (2 levels) in each_top_level_statement'
        21: from /usr/lib/ruby/2.7.0/irb/ruby-lex.rb:182:in `lex'
        20: from /usr/lib/ruby/2.7.0/irb.rb:518:in `block in eval_input'
        19: from /usr/lib/ruby/2.7.0/irb.rb:704:in `signal_status'
        18: from /usr/lib/ruby/2.7.0/irb.rb:519:in `block (2 levels) in eval_input'
        17: from /usr/lib/ruby/2.7.0/irb/input-method.rb:294:in `gets'
        16: from /usr/lib/ruby/2.7.0/forwardable.rb:235:in `readmultiline'
        15: from /usr/lib/ruby/2.7.0/forwardable.rb:235:in `readmultiline'
        14: from /usr/lib/ruby/2.7.0/reline.rb:175:in `readmultiline'
        13: from /usr/lib/ruby/2.7.0/reline.rb:238:in `inner_readline'
        12: from /usr/lib/ruby/2.7.0/reline.rb:238:in `loop'
        11: from /usr/lib/ruby/2.7.0/reline.rb:239:in `block in inner_readline'
        10: from /usr/lib/ruby/2.7.0/reline.rb:270:in `read_io'
         9: from /usr/lib/ruby/2.7.0/reline.rb:270:in `loop'
         8: from /usr/lib/ruby/2.7.0/reline.rb:311:in `block in read_io'
         7: from /usr/lib/ruby/2.7.0/reline.rb:240:in `block (2 levels) in inner_readline'
         6: from /usr/lib/ruby/2.7.0/reline.rb:240:in `each'
         5: from /usr/lib/ruby/2.7.0/reline.rb:241:in `block (3 levels) in inner_readline'
         4: from /usr/lib/ruby/2.7.0/reline/line_editor.rb:820:in `input_key'
         3: from /usr/lib/ruby/2.7.0/reline/line_editor.rb:608:in `complete'
         2: from /usr/lib/ruby/2.7.0/irb/completion.rb:269:in `block in <module:InputCompletor>'
         1: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
/usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': cannot load such file -- rdoc (LoadError)
```