### PR TITLE
Suppress verbose messages in the parallel test

### DIFF
--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -381,8 +381,8 @@ module TestIRB
       ])
       IRB.init_config(nil)
       workspace = IRB::WorkSpace.new(self)
-      irb = IRB::Irb.new(workspace, input)
       IRB.conf[:VERBOSE] = false
+      irb = IRB::Irb.new(workspace, input)
       IRB.conf[:MAIN_CONTEXT] = irb.context
       irb.context.return_format = "=> %s\n"
       out, err = capture_output do
@@ -398,8 +398,8 @@ module TestIRB
       ])
       IRB.init_config(nil)
       workspace = IRB::WorkSpace.new(self)
-      irb = IRB::Irb.new(workspace, input)
       IRB.conf[:VERBOSE] = false
+      irb = IRB::Irb.new(workspace, input)
       IRB.conf[:MAIN_CONTEXT] = irb.context
       irb.context.return_format = "=> %s\n"
       out, err = capture_output do


### PR DESCRIPTION
`:VERBOSE` flag needs to be set prior to `IRB::Irb.new`.