### PR TITLE
Add `colorable` keyword option

### DIFF
--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -101,22 +101,22 @@ module IRB # :nodoc:
         end
       end
 
-      def clear
-        return '' unless colorable?
+      def clear(colorable: colorable?)
+        return '' unless colorable
         "\e[#{CLEAR}m"
       end
 
-      def colorize(text, seq)
-        return text unless colorable?
+      def colorize(text, seq, colorable: colorable?)
+        return text unless colorable
         seq = seq.map { |s| "\e[#{const_get(s)}m" }.join('')
-        "#{seq}#{text}#{clear}"
+        "#{seq}#{text}#{clear(colorable: colorable)}"
       end
 
       # If `complete` is false (code is incomplete), this does not warn compile_error.
       # This option is needed to avoid warning a user when the compile_error is happening
       # because the input is not wrong but just incomplete.
-      def colorize_code(code, complete: true, ignore_error: false)
-        return code unless colorable?
+      def colorize_code(code, complete: true, ignore_error: false, colorable: colorable?)
+        return code unless colorable
 
         symbol_state = SymbolState.new
         colored = +''
@@ -134,7 +134,7 @@ module IRB # :nodoc:
             line = Reline::Unicode.escape_for_print(line)
             if seq = dispatch_seq(token, expr, line, in_symbol: in_symbol)
               colored << seq.map { |s| "\e[#{s}m" }.join('')
-              colored << line.sub(/\Z/, clear)
+              colored << line.sub(/\Z/, clear(colorable: colorable))
             else
               colored << line
             end

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -33,6 +33,8 @@ module TestIRB
         assert_equal_with_term(result, text, seq: seq)
 
         assert_equal_with_term(text, text, seq: seq, tty: false)
+        assert_equal_with_term(text, text, seq: seq, colorable: false)
+        assert_equal_with_term(result, text, seq: seq, tty: false, colorable: true)
       end
     end
 
@@ -129,6 +131,14 @@ module TestIRB
 
           assert_equal_with_term(code, code, complete: true, tty: false)
           assert_equal_with_term(code, code, complete: false, tty: false)
+
+          assert_equal_with_term(code, code, complete: true, colorable: false)
+
+          assert_equal_with_term(code, code, complete: false, colorable: false)
+
+          assert_equal_with_term(result, code, complete: true, tty: false, colorable: true)
+
+          assert_equal_with_term(result, code, complete: false, tty: false, colorable: true)
         else
           assert_equal_with_term(code, code)
         end
@@ -148,6 +158,10 @@ module TestIRB
         assert_equal_with_term(result, code, complete: true)
 
         assert_equal_with_term(code, code, complete: true, tty: false)
+
+        assert_equal_with_term(code, code, complete: true, colorable: false)
+
+        assert_equal_with_term(result, code, complete: true, tty: false, colorable: true)
       end
     end
 
@@ -162,10 +176,18 @@ module TestIRB
 
           assert_equal_with_term(code, code, complete: false, tty: false)
 
+          assert_equal_with_term(code, code, complete: false, colorable: false)
+
+          assert_equal_with_term(result, code, complete: false, tty: false, colorable: true)
+
           unless complete_option_supported?
             assert_equal_with_term(result, code, complete: true)
 
             assert_equal_with_term(code, code, complete: true, tty: false)
+
+            assert_equal_with_term(code, code, complete: true, colorable: false)
+
+            assert_equal_with_term(result, code, complete: true, tty: false, colorable: true)
           end
         else
           assert_equal_with_term(code, code)

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -105,14 +105,10 @@ module TestIRB
 
       tests.each do |code, result|
         if colorize_code_supported?
-          actual = with_term { IRB::Color.colorize_code(code, complete: true) }
-          assert_equal(result, actual, "Case: IRB::Color.colorize_code(#{code.dump}, complete: true)\nResult: #{humanized_literal(actual)}")
-
-          actual = with_term { IRB::Color.colorize_code(code, complete: false) }
-          assert_equal(result, actual, "Case: IRB::Color.colorize_code(#{code.dump}, complete: false)\nResult: #{humanized_literal(actual)}")
+          assert_equal_with_term(result, code, complete: true)
+          assert_equal_with_term(result, code, complete: false)
         else
-          actual = with_term { IRB::Color.colorize_code(code) }
-          assert_equal(code, actual)
+          assert_equal_with_term(code, code)
         end
       end
     end
@@ -127,8 +123,7 @@ module TestIRB
         "'foo' + 'bar" => "#{RED}#{BOLD}'#{CLEAR}#{RED}foo#{CLEAR}#{RED}#{BOLD}'#{CLEAR} + #{RED}#{BOLD}'#{CLEAR}#{RED}#{REVERSE}bar#{CLEAR}",
         "('foo" => "(#{RED}#{BOLD}'#{CLEAR}#{RED}#{REVERSE}foo#{CLEAR}",
       }.each do |code, result|
-        actual = with_term { IRB::Color.colorize_code(code, complete: true) }
-        assert_equal(result, actual, "Case: colorize_code(#{code.dump}, complete: true)\nResult: #{humanized_literal(actual)}")
+        assert_equal_with_term(result, code, complete: true)
       end
     end
 
@@ -139,16 +134,13 @@ module TestIRB
         "('foo" => "(#{RED}#{BOLD}'#{CLEAR}#{RED}foo#{CLEAR}",
       }.each do |code, result|
         if colorize_code_supported?
-          actual = with_term { IRB::Color.colorize_code(code, complete: false) }
-          assert_equal(result, actual, "Case: colorize_code(#{code.dump}, complete: false)\nResult: #{humanized_literal(actual)}")
+          assert_equal_with_term(result, code, complete: false)
 
           unless complete_option_supported?
-            actual = with_term { IRB::Color.colorize_code(code, complete: true) }
-            assert_equal(result, actual, "Case: colorize_code(#{code.dump}, complete: false)\nResult: #{humanized_literal(actual)}")
+            assert_equal_with_term(result, code, complete: true)
           end
         else
-          actual = with_term { IRB::Color.colorize_code(code) }
-          assert_equal(code, actual)
+          assert_equal_with_term(code, code)
         end
       end
     end
@@ -198,6 +190,16 @@ module TestIRB
     ensure
       $stdout = stdout
       ENV.replace(env) if env
+    end
+
+    def assert_equal_with_term(result, code, **opts)
+      actual = with_term { IRB::Color.colorize_code(code, **opts) }
+      message = -> {
+        args = [code.dump]
+        opts.each {|kwd, val| args << "#{kwd}: #{val}"}
+        "Case: colorize_code(#{args.join(', ')})\nResult: #{humanized_literal(actual)}"
+      }
+      assert_equal(result, actual, message)
     end
 
     def humanized_literal(str)

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -17,6 +17,23 @@ module TestIRB
     MAGENTA   = "\e[35m"
     CYAN      = "\e[36m"
 
+    def test_colorize
+      text = "text"
+      {
+        [:BOLD]      => "#{BOLD}#{text}#{CLEAR}",
+        [:UNDERLINE] => "#{UNDERLINE}#{text}#{CLEAR}",
+        [:REVERSE]   => "#{REVERSE}#{text}#{CLEAR}",
+        [:RED]       => "#{RED}#{text}#{CLEAR}",
+        [:GREEN]     => "#{GREEN}#{text}#{CLEAR}",
+        [:YELLOW]    => "#{YELLOW}#{text}#{CLEAR}",
+        [:BLUE]      => "#{BLUE}#{text}#{CLEAR}",
+        [:MAGENTA]   => "#{MAGENTA}#{text}#{CLEAR}",
+        [:CYAN]      => "#{CYAN}#{text}#{CLEAR}",
+      }.each do |seq, result|
+        assert_equal_with_term(result, text, seq: seq)
+      end
+    end
+
     def test_colorize_code
       # Common behaviors. Warn parser error, but do not warn compile error.
       tests = {
@@ -192,12 +209,19 @@ module TestIRB
       ENV.replace(env) if env
     end
 
-    def assert_equal_with_term(result, code, **opts)
-      actual = with_term { IRB::Color.colorize_code(code, **opts) }
+    def assert_equal_with_term(result, code, seq: nil, **opts)
+      actual = with_term do
+        if seq
+          IRB::Color.colorize(code, seq, **opts)
+        else
+          IRB::Color.colorize_code(code, **opts)
+        end
+      end
       message = -> {
         args = [code.dump]
+        args << seq.inspect if seq
         opts.each {|kwd, val| args << "#{kwd}: #{val}"}
-        "Case: colorize_code(#{args.join(', ')})\nResult: #{humanized_literal(actual)}"
+        "Case: colorize#{seq ? "" : "_code"}(#{args.join(', ')})\nResult: #{humanized_literal(actual)}"
       }
       assert_equal(result, actual, message)
     end


### PR DESCRIPTION
Currently `IRB::Color.colorize` and `IRB::Color.colorize_code` refer `$stdin.tty?` internally.

This patch adds `colorable` keyword option which overrides it.
