### PR TITLE
Need reline >= 0.1.6

### DIFF
--- a/irb.gemspec
+++ b/irb.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5")
 
-  spec.add_dependency "reline", ">= 0.1.5"
+  spec.add_dependency "reline", ">= 0.1.6"
 end


### PR DESCRIPTION
irb 1.3.5 need reline >= 0.1.6 because irb use `Reline::IOGate.in_pasting?`.


This method defined from reline 0.1.6.
https://github.com/ruby/reline/commit/a6a54b1f4b47cc45ed1713160f63b78b916868e5

fix #228.