### PR TITLE
Dump ancestors' methods by ls command

### DIFF
--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -377,7 +377,24 @@ module TestIRB
 
     def test_ls
       input = TestInputMethod.new([
-        "ls Object.new.tap { |o| o.instance_variable_set(:@a, 1) }\n",
+        "class C\n",
+        "  def m1() end\n",
+        "end\n",
+
+        "module M\n",
+        "  def m2() end\n",
+        "end\n",
+
+        "module M2\n",
+        "  include M\n",
+        "  def m3() end\n",
+        "end\n",
+
+        "obj = C.new\n",
+        "obj.instance_variable_set(:@a, 1)\n",
+        "obj.extend M2\n",
+        "def obj.m4() end\n",
+        "ls obj\n",
       ])
       IRB.init_config(nil)
       workspace = IRB::WorkSpace.new(self)
@@ -390,6 +407,10 @@ module TestIRB
       end
       assert_empty err
       assert_match(/^instance variables:\s+@a\n/m, out)
+      assert_match(/C#methods: m1\n/m, out)
+      assert_match(/M#methods: m2\n/m, out)
+      assert_match(/M2#methods: m3\n/m, out)
+      assert_match(/C.methods: m4\n/m, out)
     end
 
     def test_show_source


### PR DESCRIPTION
`ls` command has been implemented by #203.
Pry's `ls` displays ancestors' methods, but IRB doesn't.


This pull request makes `ls` command display ancestors' methods.


# Example

With the following definition:

```ruby
class P
  def p() end
end

class C < P
  def m1() end
end

module M
  def m2() end
end

module M2
  include M
  def m3() end
end

obj = C.new
obj.extend M2
def obj.m4() end
```


before

```
irb(main):043:0> ls obj
C.methods: m4
C#methods: m1
```

after

```
irb(main):026:0> ls obj
M#methods: m2
M2#methods: m3
C.methods: m4
P#methods: p
C#methods: m1
```


---


Note that it omits `Object` and Object's ancestors because we can assure the argument inherits `Object` class easily. Pry has the same behavior.