### PR TITLE
Fix `Encoding::ConverterNotFoundError`

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -647,7 +647,7 @@ module IRB
           order = :top
         end
         message = convert_invalid_byte_sequence(message, exc.message.encoding)
-        message = encode_with_invalid_byte_sequence(message, IRB.conf[:LC_MESSAGES].encoding) if message.encoding != IRB.conf[:LC_MESSAGES].encoding
+        message = encode_with_invalid_byte_sequence(message, IRB.conf[:LC_MESSAGES].encoding) unless message.encoding.to_s.casecmp?(IRB.conf[:LC_MESSAGES].encoding.to_s)
         message = message.gsub(/((?:^\t.+$\n)+)/)  { |m|
           case order
           when :top


### PR DESCRIPTION
Follow https://github.com/ruby/irb/pull/237.

This PR fixes the following `Encoding::ConverterNotFoundError`.

```console
% bin/spring stop && bin/rails c
Spring stopped.
Running via Spring preloader in process 58395
Loading development environment (Rails 6.0.3.7)
irb(main):001:0> "こんにちは".do_something
Traceback (most recent call last):
(snip)

    12: from /Users/koic/src/github.com/ruby/irb/lib/irb.rb:547:in `eval_input'
    11: from /Users/koic/src/github.com/ruby/irb/lib/irb/ruby-lex.rb:232:in `each_top_level_statement'
    10: from /Users/koic/src/github.com/ruby/irb/lib/irb/ruby-lex.rb:232:in `catch'
     9: from /Users/koic/src/github.com/ruby/irb/lib/irb/ruby-lex.rb:233:in  `block in each_top_level_statement'
     8: from /Users/koic/src/github.com/ruby/irb/lib/irb/ruby-lex.rb:233:in `loop'
     7: from /Users/koic/src/github.com/ruby/irb/lib/irb/ruby-lex.rb:251:in `block (2 levels) in each_top_level_statement'
     6: from /Users/koic/src/github.com/ruby/irb/lib/irb.rb:548:in `block in eval_input'
     5: from /Users/koic/src/github.com/ruby/irb/lib/irb.rb:758:in `signal_status'
     4: from /Users/koic/src/github.com/ruby/irb/lib/irb.rb:586:in `block (2 levels) in eval_input'
     3: from /Users/koic/src/github.com/ruby/irb/lib/irb.rb:650:in `handle_exception'
     2: from /Users/koic/src/github.com/ruby/irb/lib/irb.rb:601:in `encode_with_invalid_byte_sequence'
     1: from /Users/koic/src/github.com/ruby/irb/lib/irb.rb:601:in `new'
/Users/koic/src/github.com/ruby/irb/lib/irb.rb:601:in `initialize': code
converter not found (UTF-8 to UTF-8) (Encoding::ConverterNotFoundError)
```

First, this patch skips `Encoding::Converter.new` for the same encoding.
https://github.com/ruby/irb/blob/170531df19bce289444afe97360480efed5f27f0/lib/irb.rb#L601

Next, this is a talk about the condition for skipping. `IRB.conf[:LC_MESSAGES].encoding` becomes `"UTF-8"` string when `Reline.encoding_system_needs.name` is set in the below.
https://github.com/ruby/irb/blob/170531df19bce289444afe97360480efed5f27f0/lib/irb/input-method.rb#L269

OTOH, `message.encoding` is `Encoding::UTF_8`, so these are compared as a string by this patch.