### PR TITLE
Improve stackprof measure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development do
   gem 'vterm', '>= 0.0.5' if is_unix && ENV['WITH_VTERM']
   gem 'yamatanooroti', '>= 0.0.6'
   gem "rake"
+  gem "stackprof" if is_unix
 end

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -120,7 +120,11 @@ module IRB # :nodoc:
       puts 'processing time: %fs' % (now - time) if IRB.conf[:MEASURE]
       result
     }
+    # arg can be either a symbol for the mode (:cpu, :wall, ..) or a hash for
+    # a more complete configuration.
+    # See https://github.com/tmm1/stackprof#all-options.
     @CONF[:MEASURE_PROC][:STACKPROF] = proc { |context, code, line_no, arg, &block|
+      return block.() unless IRB.conf[:MEASURE]
       success = false
       begin
         require 'stackprof'
@@ -130,10 +134,18 @@ module IRB # :nodoc:
       end
       if success
         result = nil
-        stackprof_result = StackProf.run(mode: arg ? arg : :cpu) do
+        arg = { mode: arg || :cpu } unless arg.is_a?(Hash)
+        stackprof_result = StackProf.run(**arg) do
           result = block.()
         end
-        StackProf::Report.new(stackprof_result).print_text if IRB.conf[:MEASURE]
+        case stackprof_result
+        when File
+          puts "StackProf report saved to #{stackprof_result.path}"
+        when Hash
+          StackProf::Report.new(stackprof_result).print_text
+        else
+          puts "Stackprof ran with #{arg.inspect}"
+        end
         result
       else
         block.()


### PR DESCRIPTION
Allow usage of more detailed args when setting stackprof callback.

---

Hi,

Since this is my first contrib here please tell me if there is anything I could improve.

On tests, looking at what is written already it seems that they are designed only for critical processes. If it is not the case, I can add some.

On my addition to the `Gemfile`, it felt important to me that when developing, one should be able to try all features without needing to pollute its global gems.

Cheers,
Ulysse