### PR TITLE
Sort ls result ordered by anscestry

### DIFF
--- a/lib/irb/cmd/ls.rb
+++ b/lib/irb/cmd/ls.rb
@@ -17,25 +17,17 @@ module IRB
         klass  = (obj.class == Class || obj.class == Module ? obj : obj.class)
 
         o.dump("constants", obj.constants) if obj.respond_to?(:constants)
-        dump_singleton_methods(o, klass, obj)
-        dump_instance_methods(o, klass)
+        dump_methods(o, klass, obj)
         o.dump("instance variables", obj.instance_variables)
         o.dump("class variables", klass.class_variables)
         o.dump("locals", locals)
       end
 
-      def dump_singleton_methods(o, klass, obj)
-        maps = class_method_map(obj.singleton_class.ancestors.take_while { |c| c != klass })
+      def dump_methods(o, klass, obj)
+        maps = class_method_map(obj.singleton_class.ancestors)
         maps.each do |mod, methods|
           name = mod == obj.singleton_class ? "#{klass}.methods" : "#{mod}#methods"
           o.dump(name, methods)
-        end
-      end
-
-      def dump_instance_methods(o, klass)
-        maps = class_method_map(klass.ancestors)
-        maps.each do |mod, methods|
-          o.dump("#{mod}#methods", methods)
         end
       end
 

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -377,23 +377,30 @@ module TestIRB
 
     def test_ls
       input = TestInputMethod.new([
-        "class C\n",
-        "  def m1() end\n",
-        "end\n",
-
-        "module M\n",
+        "class P\n",
+        "  def m() end\n",
         "  def m2() end\n",
         "end\n",
 
+        "class C < P\n",
+        "  def m1() end\n",
+        "  def m2() end\n",
+        "end\n",
+
+        "module M\n",
+        "  def m1() end\n",
+        "  def m3() end\n",
+        "end\n",
+        
         "module M2\n",
         "  include M\n",
-        "  def m3() end\n",
+        "  def m4() end\n",
         "end\n",
 
         "obj = C.new\n",
         "obj.instance_variable_set(:@a, 1)\n",
         "obj.extend M2\n",
-        "def obj.m4() end\n",
+        "def obj.m5() end\n",
         "ls obj\n",
       ])
       IRB.init_config(nil)
@@ -407,10 +414,11 @@ module TestIRB
       end
       assert_empty err
       assert_match(/^instance variables:\s+@a\n/m, out)
-      assert_match(/C#methods:\s+m1\n/m, out)
-      assert_match(/M#methods:\s+m2\n/m, out)
-      assert_match(/M2#methods:\s+m3\n/m, out)
-      assert_match(/C.methods:\s+m4\n/m, out)
+      assert_match(/P#methods:\s+m\n/m, out)
+      assert_match(/C#methods:\s+m2\n/m, out)
+      assert_match(/M#methods:\s+m1\s+m3\n/m, out)
+      assert_match(/M2#methods:\s+m4\n/m, out)
+      assert_match(/C.methods:\s+m5\n/m, out)
     end
 
     def test_show_source


### PR DESCRIPTION
This PR suggests to improve `ls` command.  

I changed these two points.
* I expect it to be the same as the result of the method search, but it is not.
* I want the output to be in the same order as the results of `ancestors`, but but in fact it is displayed in the order of modules->classes.


## Example 
Definitions are below; a little bit different from sample codes in #234, I added some modules and classes have the same methods.

```ruby
class P
  def m() end
  def m2() end
end

class C < P
  def m1() end
  def m2() end
end

module M
  def m1() end
  def m3() end
end

module M2
  include M
  def m4() end
end

obj = C.new; obj.extend M2; def obj.m5() end;
```

## Before

```
> ls obj
M#methods: m1  m3
M2#methods: m4
C.methods: m5
P#methods: m
C#methods: m1  m2
```
* `m1` appears twice.
* `obj.singleton_class.ancestors` is `[M2, M, C, P, Object, PP::ObjectMixin, Kernel, BasicObject]`. I was a little confused the difference between my expectation and actual.


## After

```
> ls obj
P#methods: m
C#methods: m2
M#methods: m1  m3
M2#methods: m4
C.methods: m5
```