### PR TITLE
Disable locale warning from TruffleRuby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: build
 
 on: [push, pull_request]
 
+env:
+  TRUFFLERUBYOPT: --experimental-options --warn-locale=false
+
 jobs:
   irb:
     name: irb (${{ matrix.ruby }} / ${{ matrix.os }})


### PR DESCRIPTION
`assert_in_out_err` fails due to the warnings since oracle/truffleruby@6b03a11d685c4ce58855628ebfef5bafbfa211af.