### PR TITLE
Improve performance of `show_source` for large class

### DIFF
--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -59,11 +59,18 @@ module IRB
       def find_end(file, first_line)
         return first_line unless File.exist?(file)
         lex = RubyLex.new
-        code = +""
-        File.read(file).lines[(first_line - 1)..-1].each_with_index do |line, i|
-          _ltype, _indent, continue, code_block_open = lex.check_state(code << line)
+        lines = File.read(file).lines[(first_line - 1)..-1]
+        tokens = RubyLex.ripper_lex_without_warning(lines.join)
+        prev_tokens = []
+
+        # chunk with line number
+        tokens.chunk { |tok| tok[0][0] }.each do |lnum, chunk|
+          code = lines[0..lnum].join
+          prev_tokens.concat chunk
+          continue = lex.process_continue(prev_tokens)
+          code_block_open = lex.check_code_block(code, prev_tokens)
           if !continue && !code_block_open
-            return first_line + i
+            return first_line + lnum
           end
         end
         first_line


### PR DESCRIPTION
This patch improves performance of `show_source` command for large class.


# Problem


`show_source` is slow for large class.
For example, `show_source 'IRB::Irb'` is slow. It takes 3.6s in my environment.


Because `RubyLex.ripper_lex_without_warning` is heavy but it is called on each line.

# Profiling

```ruby
$LOAD_PATH.unshift './lib/'
require 'irb'
require 'irb/cmd/show_source'

require 'stackprof'

IRB.setup('')
w = IRB::WorkSpace.new(binding)
irb = IRB::Irb.new(w)
ctx = IRB::Context.new(irb, w)


StackProf.run(mode: :wall, out: 'stackprof-out', raw: true) do
  IRB::ExtendCommand::ShowSource.new(ctx).execute('IRB::Irb')
end
```

![210625154610](https://user-images.githubusercontent.com/4361134/123382092-80730b80-d5cc-11eb-8a36-4606a6211776.png)



# Solution


Call `RubyLex.ripper_lex_without_warning` just once, instead of calling it on each line.

This change also stops calling `RubyLex#check-state`, but it uses `RubyLex#process_continue` and `check_code_block` directly. Because the other checks in `check_state` methods, such as `process_literal_type`, are slow. This change makes 5x difference the speed.


# Benchmark

code

```ruby
$LOAD_PATH.unshift './lib/'
require 'irb'
require 'irb/cmd/show_source'

IRB.setup('')
w = IRB::WorkSpace.new(binding)
irb = IRB::Irb.new(w)
ctx = IRB::Context.new(irb, w)


module IRB
  module ExtendCommand
    class ShowSource < Nop
      def puts(*)
        # to suppress printing code
      end
    end
  end
end

require 'benchmark'
Benchmark.bmbm(20) do |x|
  x.report{10.times{
    IRB::ExtendCommand::ShowSource.new(ctx).execute('IRB::Irb')
  }}
end
```

result (before)

```
Rehearsal --------------------------------------------------------
                      36.009193   0.002964  36.012157 ( 36.056616)
---------------------------------------------- total: 36.012157sec

                           user     system      total        real
                      36.069129   0.000000  36.069129 ( 36.113850)
```

result (after)


```
Switch to inspect mode.
Switch to inspect mode.
Rehearsal --------------------------------------------------------
                       1.342156   0.000415   1.342571 (  1.344645)
----------------------------------------------- total: 1.342571sec

                           user     system      total        real
                       1.366725   0.003345   1.370070 (  1.372135)
```

In this case, it will be 26.3x faster :rocket: 