### PR TITLE
No need to manually disable locale warning on TruffleRuby anymore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: build
 
 on: [push, pull_request]
 
-env:
-  TRUFFLERUBYOPT: --experimental-options --warn-locale=false
-
 jobs:
   irb:
     name: irb (${{ matrix.ruby }} / ${{ matrix.os }})


### PR DESCRIPTION
https://github.com/ruby/irb/pull/247 is no longer needed, because I found that it's too annoying to disable this for all the CIs using `assert_in_out_err`/`assert_separately`.
So now the warning is not emitted if `LANG=C LC_ALL=C`: https://github.com/oracle/truffleruby/commit/c22c3d4865a33e7e41f506487ed94b7bdf8bca7d