### PR TITLE
Fix error on `ls object_cant_define_singleton`

### DIFF
--- a/lib/irb/cmd/ls.rb
+++ b/lib/irb/cmd/ls.rb
@@ -24,9 +24,10 @@ module IRB
       end
 
       def dump_methods(o, klass, obj)
-        maps = class_method_map(obj.singleton_class.ancestors)
+        singleton_class = obj.singleton_class rescue nil
+        maps = class_method_map((singleton_class || klass).ancestors)
         maps.each do |mod, methods|
-          name = mod == obj.singleton_class ? "#{klass}.methods" : "#{mod}#methods"
+          name = mod == singleton_class ? "#{klass}.methods" : "#{mod}#methods"
           o.dump(name, methods)
         end
       end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -421,6 +421,25 @@ module TestIRB
       assert_match(/C.methods:\s+m5\n/m, out)
     end
 
+    def test_ls_with_no_singleton_class
+      input = TestInputMethod.new([
+        "ls 42",
+      ])
+      IRB.init_config(nil)
+      workspace = IRB::WorkSpace.new(self)
+      IRB.conf[:VERBOSE] = false
+      irb = IRB::Irb.new(workspace, input)
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+      irb.context.return_format = "=> %s\n"
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(/Comparable#methods:\s+/, out)
+      assert_match(/Numeric#methods:\s+/, out)
+      assert_match(/Integer#methods:\s+/, out)
+    end
+
     def test_show_source
       input = TestInputMethod.new([
         "show_source 'IRB.conf'\n",


### PR DESCRIPTION
Fix #251

An error occurred on `ls obj_cant_define_singleton`, such as `ls 42`, `ls :sym` and so on.
This patch fixes the problem.