### PR TITLE
Pass RI options to help

### DIFF
--- a/lib/irb/cmd/help.rb
+++ b/lib/irb/cmd/help.rb
@@ -17,7 +17,8 @@ module IRB
     class Help < Nop
       def execute(*names)
         require 'rdoc/ri/driver'
-        IRB::ExtendCommand::Help.const_set(:Ri, RDoc::RI::Driver.new)
+        opts = RDoc::RI::Driver.process_args([])
+        IRB::ExtendCommand::Help.const_set(:Ri, RDoc::RI::Driver.new(opts))
       rescue LoadError, SystemExit
         IRB::ExtendCommand::Help.remove_method(:execute)
         # raise NoMethodError in ensure


### PR DESCRIPTION
Hello,

I noticed `help` command ignores `RI` env variable. Sometimes it has little significance but sometimes not - especially if `RI` env includes list of directories to search. This happens because calling `RDoc::RI::Driver.new` won't (contrary to what source comments say) parse `RI` env variable. To parse `RI` env var `process_args` has to be called (it returns options that could later be passed to driver).

Cheers
🍷