### PR TITLE
Capitalize IRBRC environment variable name in docs

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -100,7 +100,7 @@ require_relative "irb/easter-egg"
 # * +.irbrc+
 # * +irb.rc+
 # * +_irbrc+
-# * <code>$irbrc</code>
+# * <code>$IRBRC</code>
 #
 # The following are alternatives to the command line options. To use them type
 # as follows in an +irb+ session:


### PR DESCRIPTION
The docs currently say that setting `$irbrc` to a file will cause it to be loaded. This is not true; [line 360 of `lib/irb/init.rb`](https://github.com/ruby/irb/blob/master/lib/irb/init.rb#L360) checks for `ENV["IRBRC"]`. Changed to match the code.