### PR TITLE
Improve HEREDOCS

### DIFF
--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -109,8 +109,8 @@ module TestIRB
         Row.new(%q(    ]), 4, 4),
         Row.new(%q(  ]), 2, 2),
         Row.new(%q(]), 0, 0),
-        Row.new(%q([<<FOO]), nil, 0),
-        Row.new(%q(hello), nil, 0),
+        Row.new(%q([<<FOO]), 0, 0),
+        Row.new(%q(hello), 0, 0),
         Row.new(%q(FOO), nil, 0),
       ]
 
@@ -465,10 +465,10 @@ module TestIRB
 
     def test_heredoc_with_indent
       input_with_correct_indents = [
-        Row.new(%q(<<~Q), nil, 0, 0),
-        Row.new(%q({), nil, 0, 0),
-        Row.new(%q(  #), nil, 0, 0),
-        Row.new(%q(}), nil, 0, 0),
+        Row.new(%q(<<~Q), 0, 0, 0),
+        Row.new(%q({), 0, 0, 0),
+        Row.new(%q(  #), 2, 0, 0),
+        Row.new(%q(}), 0, 0, 0)
       ]
 
       lines = []
@@ -503,8 +503,8 @@ module TestIRB
       end
       input_with_correct_indents = [
         Row.new(%q(def foo), nil, 2, 1),
-        Row.new(%q(  <<~Q), nil, 2, 1),
-        Row.new(%q(  Qend), nil, 2, 1),
+        Row.new(%q(  <<~Q), 2, 2, 1),
+        Row.new(%q(  Qend), 2, 2, 1),
       ]
 
       lines = []


### PR DESCRIPTION
Hi guys,

This is an attempt to fix the issue https://github.com/ruby/irb/issues/265.

During auto indentation the methods `check_newline_depth_difference` and `check_corresponding_token_depth` are not considering on_heredoc_beg and on_heredoc_end.

The solution is checking if the line is inside heredocs, if so the extra spaces in the beginning of the line is returned.

#### Without brackets

After

```
3.0.2 :001"> <<a
3.0.2 :002">   0
3.0.2 :003 > a
 => "  0\n"
3.0.2 :004"> <<-a
3.0.2 :005">   0
3.0.2 :006 > a
 => "  0\n"
3.0.2 :007"> <<~a
3.0.2 :008">   0
3.0.2 :009 > a
 => "0\n"
```

Before

```
3.0.2 :001"> <<a
3.0.2 :002"> 0
3.0.2 :003 > a
 => "0\n"
3.0.2 :004"> <<-a
3.0.2 :005"> 0
3.0.2 :006 > a
 => "0\n"
3.0.2 :007"> <<~a
3.0.2 :008"> 0
3.0.2 :009 > a
 => "0\n"
```

#### Using brackets

After

```
3.0.2 :001"> [<<a]
3.0.2 :002">   0
3.0.2 :003 > a
 => ["  0\n"]
3.0.2 :004"> [<<-a]
3.0.2 :005">   0
3.0.2 :006 > a
 => ["  0\n"]
3.0.2 :007"> [<<~a]
3.0.2 :008">   0
3.0.2 :009 > a
 => ["0\n"]
```

Before

```
3.0.2 :001"> [<<a]
3.0.2 :002"> 0
3.0.2 :003 > a
 => ["0\n"]
3.0.2 :004"> [<<-a]
3.0.2 :005"> 0
3.0.2 :006 > a
 => ["0\n"]
3.0.2 :007"> [<<~a]
3.0.2 :008"> 0
3.0.2 :009 > a
 => ["0\n"]
```


Thank you very much.