### PR TITLE
Remove `require` in signal handler to avoid ThreadError

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -319,11 +319,6 @@ module IRB
         [Reline::Key.new(nil, 0xE4, true)], # Normal Alt+d.
         [195, 164] # The "ä" that appears when Alt+d is pressed on xterm.
       ]
-      begin
-        require 'rdoc'
-      rescue LoadError
-        return nil
-      end
 
       if just_cursor_moving and completion_journey_data.nil?
         return nil


### PR DESCRIPTION
This PR fixes a ThreadError, which is https://github.com/ruby/irb/issues/282.

Fix #282 

# Problem

IRB does `require 'rdoc'` in `SHOW_DOC_DIALOG` and it is called from a trap context. Then it causes the ThreadError.


# Solution

Remove the `require` from the proc. It looks unnecessary because `rdoc` is required from the top-level of the same file.
https://github.com/ruby/irb/blob/5f749c613c895cf1b11b5e4cbd1205363bc58028/lib/irb/input-method.rb#L17