### PR TITLE
Make IRB::Context#exit call super if UncaughtThrowError

### DIFF
--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -478,6 +478,8 @@ module IRB
     # Exits the current session, see IRB.irb_exit
     def exit(ret = 0)
       IRB.irb_exit(@irb, ret)
+    rescue UncaughtThrowError
+      super
     end
 
     NOPRINTING_IVARS = ["@last_value"] # :nodoc:


### PR DESCRIPTION
Fixes calling exit after binding.irb.

Fixes [Bug #18234]