### PR TITLE
Assign values to RUBY_VERSION and ENV without raising exceptions

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -556,7 +556,7 @@ module IRB
       @scanner.each_top_level_statement do |line, line_no|
         signal_status(:IN_EVAL) do
           begin
-            line.untaint if RUBY_VERSION < '2.7'
+            line.untaint if RUBY_VERSION.instance_of?(String) && RUBY_VERSION < '2.7'
             if IRB.conf[:MEASURE] && IRB.conf[:MEASURE_CALLBACKS].empty?
               IRB.set_measure_callback
             end
@@ -643,7 +643,7 @@ module IRB
           # Exception#full_message doesn't have keyword arguments.
           message = exc.full_message # the same of (highlight: true, order: bottom)
           order = :bottom
-        elsif '2.5.1' <= RUBY_VERSION && RUBY_VERSION < '3.0.0'
+        elsif RUBY_VERSION.instance_of?(String) && '2.5.1' <= RUBY_VERSION && RUBY_VERSION < '3.0.0'
           if STDOUT.tty?
             message = exc.full_message(order: :bottom)
             order = :bottom

--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -77,7 +77,8 @@ module IRB # :nodoc:
 
     class << self
       def colorable?
-        $stdout.tty? && (/mswin|mingw/ =~ RUBY_PLATFORM || (ENV.key?('TERM') && ENV['TERM'] != 'dumb'))
+        $stdout.tty? && (/mswin|mingw/ =~ RUBY_PLATFORM ||
+          (ENV.public_methods.include?(:[]) && ENV.instance_of?(Object) && ENV.key?('TERM') && ENV['TERM'] != 'dumb'))
       end
 
       def inspect_colorable?(obj, seen: {}.compare_by_identity)

--- a/test/irb/test_constant.rb
+++ b/test/irb/test_constant.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: false
+require 'test/unit'
+
+module TestIRB
+  class TestConstant < Test::Unit::TestCase
+    def test_version
+      bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []
+      assert_in_out_err(bundle_exec + %w[-rirb -W0 -e IRB.start(__FILE__) -- -f --], <<-IRB, /true/, [])
+        RUBY_VERSION = nil
+        RUBY_VERSION.nil?
+      IRB
+    end
+  end
+end


### PR DESCRIPTION
Hello guys,

This is an attempt to fix the issue https://github.com/ruby/irb/issues/235.

In order to fix the issue IRB and Reline https://github.com/ruby/reline/pull/373 projects need to be updated.

When RUBY_VERSION change its value to a type different than String an exception will be raised in the next command.

```
3.0.2 :001 > RUBY_VERSION=nil
(irb):1: warning: already initialized constant RUBY_VERSION
 => nil
3.0.2 :002 > 0
/.rvm/gems/ruby-3.0.2/gems/reline-0.2.8.pre.10/lib/reline.rb:252:in `readmultiline': undefined method `<' for nil:NilClass (NoMethodError)
```

A similar situation happens with ENV when a value is assigned to it.

```
3.0.2 :001 > ENV=0
(irb):1: warning: already initialized constant ENV
(Object doesn't support #inspect)
 =>
/.rvm/gems/ruby-3.0.2/gems/reline-0.2.8.pre.10/lib/reline.rb:275:in `[]': no implicit conversion of String into Integer (TypeError)
```

It is possible to replicate the scenarios above using the master branch.

The reason for that is the invalid comparisons <= and < when RUBY_VERSION is not a String, and when ENV is trying to invoke [] without having this method or when ENV is whatever object with [] method different than the correct Object's ENV class.

Fixing only Reline is not enough because IRB also tries to do the similar operations.

The following replications assume that Reline is fixed not raising Reline anymore, but it starts raising IRB.

RUBY_VERSION test to raise.

```
3.0.2 :001 > RUBY_VERSION=nil
(irb):1: warning: already initialized constant RUBY_VERSION
 => nil
3.0.2 :002 > RUBY_VERSION
/irb/lib/irb.rb:646:in `<=': comparison of String with nil failed (ArgumentError)
```

ENV test to raise.

```
3.0.2 :001 > ENV=0
(irb):1: warning: already initialized constant ENV
(Object doesn't support #inspect)
 =>
/irb/lib/irb/color.rb:80:in `colorable?': undefined method `key?' for 0:Integer (NoMethodError)
```

I only added tests for the RUBY_VERSION.

I tried to test a scenario using ENV, however I do not know why it also works with the master branch.

```
def test_env
  bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []
  assert_in_out_err(bundle_exec + %w[-rirb -W0 -e IRB.start(__FILE__) -- -f --], <<-IRB, /4/, [])
    ENV = 2
    puts 2 + ENV
  IRB
end
```

After changes.

Assign nil to RUBY_VERSION.

```
3.0.2 :001 > RUBY_VERSION=nil
(irb):1: warning: already initialized constant RUBY_VERSION
 => nil
3.0.2 :002 > RUBY_VERSION
 => nil
```

Assign 0 to ENV.

```
3.0.2 :001 > ENV=0
(irb):1: warning: already initialized constant ENV
 => 0
```

Thank you very much.