### PR TITLE
Ignore parenthesis during completion

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -197,7 +197,7 @@ module IRB
         end
         candidates.grep(/^#{Regexp.quote(sym)}/)
 
-      when /^::([A-Z][^:\.\(]*)$/
+      when /^::([A-Z][^:\.\(\)]*)$/
         # Absolute Constant or class methods
         receiver = $1
         candidates = Object.constants.collect{|m| m.to_s}

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -41,6 +41,13 @@ module TestIRB
       assert_empty(IRB::InputCompletor.retrieve_completion_data(":::", bind: binding))
     end
 
+    def test_complete_absolute_constants_with_special_characters
+      assert_empty(IRB::InputCompletor.retrieve_completion_data("::A:", bind: binding))
+      assert_empty(IRB::InputCompletor.retrieve_completion_data("::A.", bind: binding))
+      assert_empty(IRB::InputCompletor.retrieve_completion_data("::A(", bind: binding))
+      assert_empty(IRB::InputCompletor.retrieve_completion_data("::A)", bind: binding))
+    end
+
     def test_complete_symbol_failure
       assert_nil(IRB::InputCompletor::PerfectMatchedProc.(":aiueo", bind: binding))
     end


### PR DESCRIPTION
Hello guys,

This is an attempt to fix the issue https://github.com/ruby/irb/issues/299.

When absolute constant is used with ) an exception is raised with regex during completion.

It includes ) character verification to prevent raising an exception.

After

```
3.0.2 :001 > defined?(::A)
 => nil
```

Before

```
3.0.2 :001 > defined?(::A)
/irb/lib/irb/completion.rb:207:in `retrieve_completion_data': unmatched close parenthesis: /^A)/ (RegexpError)
```

Thank you very much.