### PR TITLE
Examine if in keyword is used inside case keyword

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -689,8 +689,12 @@ class RubyLex
           unless t[3].allbits?(Ripper::EXPR_LABEL)
             spaces_of_nest.push(spaces_at_line_head)
           end
-        when 'else', 'elsif', 'ensure', 'when', 'in'
+        when 'else', 'elsif', 'ensure', 'when'
           corresponding_token_depth = spaces_of_nest.last
+        when 'in'
+          if in_keyword_case_scope?
+            corresponding_token_depth = spaces_of_nest.last
+          end
         when 'end'
           if is_first_printable_of_line
             corresponding_token_depth = spaces_of_nest.pop
@@ -828,6 +832,22 @@ class RubyLex
   def heredoc_scope?
     heredoc_tokens = @tokens.select { |t| [:on_heredoc_beg, :on_heredoc_end].include?(t.event) }
     heredoc_tokens[-1]&.event == :on_heredoc_beg
+  end
+
+  def in_keyword_case_scope?
+    kw_tokens = @tokens.select { |t| t.event == :on_kw && ['case', 'for', 'end'].include?(t.tok) }
+    counter = 0
+    kw_tokens.reverse.each do |t|
+      if t.tok == 'case'
+        return true if counter.zero?
+        counter += 1
+      elsif t.tok == 'for'
+        counter += 1
+      elsif t.tok == 'end'
+        counter -= 1
+      end
+    end
+    false
   end
 end
 # :startdoc:

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -399,6 +399,23 @@ module TestIRB
       end
     end
 
+    def test_corresponding_syntax_to_keyword_in
+      input_with_correct_indents = [
+        Row.new(%q(module E), nil, 2, 1),
+        Row.new(%q(end), 0, 0, 0),
+        Row.new(%q(class A), nil, 2, 1),
+        Row.new(%q(  in), nil, 4, 1)
+      ]
+
+      lines = []
+      input_with_correct_indents.each do |row|
+        lines << row.content
+        assert_indenting(lines, row.current_line_spaces, false)
+        assert_indenting(lines, row.new_line_spaces, true)
+        assert_nesting_level(lines, row.nesting_level)
+      end
+    end
+
     def test_bracket_corresponding_to_times
       input_with_correct_indents = [
         Row.new(%q(3.times { |i|), nil, 2, 1),


### PR DESCRIPTION
Hello guys,

When the in keyword is typed the indentation breaks.

It needs to keep in the same position because the include keyword is trying to be typed.

After.

```
3.0.2 :001 > class A
3.0.2 :002 >   include
```

Before.

```
3.0.2 :001 > class A
3.0.2 :002 > include
```

Thank you very much.