### PR TITLE
Fix bug infinite loop when pasting multilines fo code in Ruby 2.6

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -165,7 +165,7 @@ class RubyLex
           end
         end
       else
-        tokens = lexer.parse
+        tokens = lexer.parse.reject { |it| it.pos.first == 0 }
       end
     end
     tokens


### PR DESCRIPTION

## Description

Fix bug infinite loop when pasting multilines fo code in Ruby 2.6.
This is not reproduced in Ruby 2.7.
Changes added in https://github.com/ruby/irb/pull/242/files#diff-612b926e42ed78aed1a889ac1944f7d22229b3a489cc08f837a7f75eca3d3399R155 are also reflected in Ruby 2.6.

This bug was found by @ima1zumi, Thanks!! :)


## Steps to reproduce

1. Run `irb`
2. Pasting multilines of code

```ruby
def hoge
end
```

3. Infinite loop

![simplescreenrecorder-2021-11-23_22 56 41](https://user-images.githubusercontent.com/214488/143039219-40a91917-db7a-4210-86b8-12247e5a2b13.gif)


## Result of irb_info

```shell
$ RBENV_VERSION=2.6.8 bundle exec irb
irb(main):001:0> irb_info
=>
Ruby version: 2.6.8
IRB version: irb 1.3.8.pre.11 (2021-10-09)
InputMethod: ReidlineInputMethod with Reline 0.2.8.pre.11
RUBY_PLATFORM: x86_64-linux
LANG env: ja_JP.UTF-8

irb(main):002:0>
```


## Terminal Emulator

* `GNOME Terminal 3.36.2`

## Setting Files

None setting files.