### PR TITLE
Add Alt+d keycode when convert-meta isn't used

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -318,6 +318,7 @@ module IRB
       dialog.trap_key = nil
       alt_d = [
         [Reline::Key.new(nil, 0xE4, true)], # Normal Alt+d.
+        [27, 100], # Normal Alt+d when convert-meta isn't used.
         [195, 164] # The "ä" that appears when Alt+d is pressed on xterm.
       ]
 


### PR DESCRIPTION
fix https://github.com/ruby/reline/issues/357

I pushed [reline#389](https://github.com/ruby/reline/pull/389) for when convert-meta is not turned on in .inputrc.
Alt+D in irb also needs to be set to the keycode for not using convert-meta.