### PR TITLE
Changed to call Kernel.print

### DIFF
--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -235,7 +235,7 @@ module IRB # :nodoc:
           alias_method to, from
         }
       else
-        print "irb: warn: can't alias #{to} from #{from}.\n"
+        Kernel.print "irb: warn: can't alias #{to} from #{from}.\n"
       end
     end
 


### PR DESCRIPTION
If you call `binding.irb` on a class defined `#print`, it will crash, so call `Kernel.print`.

Fix [[Bug #18389]](https://bugs.ruby-lang.org/issues/18389) `binding.irb` can fail in some classes that implement `context` and `print` methods.