### PR TITLE
Fix warning in `Lexer::Elem#[]`

### DIFF
--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -64,7 +64,7 @@ module IRB
         prev_tokens = []
 
         # chunk with line number
-        tokens.chunk { |tok| tok[0][0] }.each do |lnum, chunk|
+        tokens.chunk { |tok| tok.pos[0] }.each do |lnum, chunk|
           code = lines[0..lnum].join
           prev_tokens.concat chunk
           continue = lex.process_continue(prev_tokens)

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -598,8 +598,8 @@ module TestIRB
       tokens = RubyLex.ripper_lex_without_warning('%wwww')
       pos_to_index = {}
       tokens.each_with_index { |t, i|
-        assert_nil(pos_to_index[t[0]], "There is already another token in the position of #{t.inspect}.")
-        pos_to_index[t[0]] = i
+        assert_nil(pos_to_index[t.pos], "There is already another token in the position of #{t.inspect}.")
+        pos_to_index[t.pos] = i
       }
     end
 
@@ -615,8 +615,8 @@ module TestIRB
       EOC
       pos_to_index = {}
       tokens.each_with_index { |t, i|
-        assert_nil(pos_to_index[t[0]], "There is already another token in the position of #{t.inspect}.")
-        pos_to_index[t[0]] = i
+        assert_nil(pos_to_index[t.pos], "There is already another token in the position of #{t.inspect}.")
+        pos_to_index[t.pos] = i
       }
     end
   end


### PR DESCRIPTION
Changed to use `#pos` `#event` `#tok` `#state` since using Lexer::Elem#[0~4] now gives a warning.
see: https://github.com/ruby/ruby/commit/8944009be7418614ce7d4077807ac2b60d4d5d85