### PR TITLE
Call Kernel.print to print warning for alias

### DIFF
--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -235,7 +235,7 @@ module IRB # :nodoc:
           alias_method to, from
         }
       else
-        print "irb: warn: can't alias #{to} from #{from}.\n"
+        Kernel.print "irb: warn: can't alias #{to} from #{from}.\n"
       end
     end
 


### PR DESCRIPTION
Fixing binding.irb use in class that overrides #print.

Fixes [Bug #18389]