### PR TITLE
Add 3.1 to CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.1'
           - '3.0'
           - '2.7'
           - '2.6'
@@ -41,6 +42,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.1'
           - '3.0'
           - '2.7'
           - head


### PR DESCRIPTION
Since 3.1 has been released, it probably needs to be added to the matrix as well?