### PR TITLE
Use `require_relative` to require lib files

### DIFF
--- a/exe/irb
+++ b/exe/irb
@@ -6,6 +6,6 @@
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 
-require "irb"
+require_relative '../lib/irb'
 
 IRB.start(__FILE__)

--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'reline'
 require 'ripper'
-require 'irb/ruby-lex'
+require_relative 'ruby-lex'
 
 module IRB # :nodoc:
   module Color

--- a/lib/irb/color_printer.rb
+++ b/lib/irb/color_printer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'pp'
-require 'irb/color'
+require_relative 'color'
 
 module IRB
   class ColorPrinter < ::PP

--- a/lib/irb/inspector.rb
+++ b/lib/irb/inspector.rb
@@ -114,7 +114,7 @@ module IRB # :nodoc:
     end
     result
   }
-  Inspector.def_inspector([true, :pp, :pretty_inspect], proc{require "irb/color_printer"}){|v|
+  Inspector.def_inspector([true, :pp, :pretty_inspect], proc{require_relative "color_printer"}){|v|
     if IRB.conf[:MAIN_CONTEXT]&.use_colorize?
       IRB::ColorPrinter.pp(v, '').chomp
     else


### PR DESCRIPTION
1. `require` can mislead Ruby to load system irb's files and cause constant redefined warnings as other code loads the same module/class from lib folder. Like:

```
exe/irb:11:in `<main>'
/Users/st0012/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/irb-1.3.7/lib/irb/ruby-lex.rb:129: warning: already initialized constant RubyLex::ERROR_TOKENS
/Users/st0012/projects/irb/lib/irb/ruby-lex.rb:130: warning: previous definition of ERROR_TOKENS was here
```

2. Most files already use `require_relative`.
3. I believe `exe/irb` should load the irb from `lib` folder instead of the system irb?