### PR TITLE
Use require_relative to load extensions/commands

### DIFF
--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -47,7 +47,7 @@ module IRB # :nodoc:
 
     @EXTEND_COMMANDS = [
       [
-        :irb_current_working_workspace, :CurrentWorkingWorkspace, "irb/cmd/chws",
+        :irb_current_working_workspace, :CurrentWorkingWorkspace, "cmd/chws",
         [:irb_print_working_workspace, OVERRIDE_ALL],
         [:irb_cwws, OVERRIDE_ALL],
         [:irb_pwws, OVERRIDE_ALL],
@@ -59,7 +59,7 @@ module IRB # :nodoc:
         [:irb_pwb, OVERRIDE_ALL],
       ],
       [
-        :irb_change_workspace, :ChangeWorkspace, "irb/cmd/chws",
+        :irb_change_workspace, :ChangeWorkspace, "cmd/chws",
         [:irb_chws, OVERRIDE_ALL],
         [:irb_cws, OVERRIDE_ALL],
         [:chws, NO_OVERRIDE],
@@ -70,13 +70,13 @@ module IRB # :nodoc:
       ],
 
       [
-        :irb_workspaces, :Workspaces, "irb/cmd/pushws",
+        :irb_workspaces, :Workspaces, "cmd/pushws",
         [:workspaces, NO_OVERRIDE],
         [:irb_bindings, OVERRIDE_ALL],
         [:bindings, NO_OVERRIDE],
       ],
       [
-        :irb_push_workspace, :PushWorkspace, "irb/cmd/pushws",
+        :irb_push_workspace, :PushWorkspace, "cmd/pushws",
         [:irb_pushws, OVERRIDE_ALL],
         [:pushws, NO_OVERRIDE],
         [:irb_push_binding, OVERRIDE_ALL],
@@ -84,7 +84,7 @@ module IRB # :nodoc:
         [:pushb, NO_OVERRIDE],
       ],
       [
-        :irb_pop_workspace, :PopWorkspace, "irb/cmd/pushws",
+        :irb_pop_workspace, :PopWorkspace, "cmd/pushws",
         [:irb_popws, OVERRIDE_ALL],
         [:popws, NO_OVERRIDE],
         [:irb_pop_binding, OVERRIDE_ALL],
@@ -93,55 +93,55 @@ module IRB # :nodoc:
       ],
 
       [
-        :irb_load, :Load, "irb/cmd/load"],
+        :irb_load, :Load, "cmd/load"],
       [
-        :irb_require, :Require, "irb/cmd/load"],
+        :irb_require, :Require, "cmd/load"],
       [
-        :irb_source, :Source, "irb/cmd/load",
+        :irb_source, :Source, "cmd/load",
         [:source, NO_OVERRIDE],
       ],
 
       [
-        :irb, :IrbCommand, "irb/cmd/subirb"],
+        :irb, :IrbCommand, "cmd/subirb"],
       [
-        :irb_jobs, :Jobs, "irb/cmd/subirb",
+        :irb_jobs, :Jobs, "cmd/subirb",
         [:jobs, NO_OVERRIDE],
       ],
       [
-        :irb_fg, :Foreground, "irb/cmd/subirb",
+        :irb_fg, :Foreground, "cmd/subirb",
         [:fg, NO_OVERRIDE],
       ],
       [
-        :irb_kill, :Kill, "irb/cmd/subirb",
+        :irb_kill, :Kill, "cmd/subirb",
         [:kill, OVERRIDE_PRIVATE_ONLY],
       ],
 
       [
-        :irb_help, :Help, "irb/cmd/help",
+        :irb_help, :Help, "cmd/help",
         [:help, NO_OVERRIDE],
       ],
 
       [
-        :irb_info, :Info, "irb/cmd/info"
+        :irb_info, :Info, "cmd/info"
       ],
 
       [
-        :irb_ls, :Ls, "irb/cmd/ls",
+        :irb_ls, :Ls, "cmd/ls",
         [:ls, NO_OVERRIDE],
       ],
 
       [
-        :irb_measure, :Measure, "irb/cmd/measure",
+        :irb_measure, :Measure, "cmd/measure",
         [:measure, NO_OVERRIDE],
       ],
 
       [
-        :irb_show_source, :ShowSource, "irb/cmd/show_source",
+        :irb_show_source, :ShowSource, "cmd/show_source",
         [:show_source, NO_OVERRIDE],
       ],
 
       [
-        :irb_whereami, :Whereami, "irb/cmd/whereami",
+        :irb_whereami, :Whereami, "cmd/whereami",
         [:whereami, NO_OVERRIDE],
       ],
 
@@ -187,7 +187,7 @@ module IRB # :nodoc:
         kwargs = ", **kwargs" if RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.7.0"
         line = __LINE__; eval %[
           def #{cmd_name}(*opts#{kwargs}, &b)
-            require "#{load_file}"
+            require_relative "#{load_file}"
             arity = ExtendCommand::#{cmd_class}.instance_method(:execute).arity
             args = (1..(arity < 0 ? ~arity : arity)).map {|i| "arg" + i.to_s }
             args << "*opts#{kwargs}" if arity < 0
@@ -262,10 +262,10 @@ module IRB # :nodoc:
     CE = ContextExtender # :nodoc:
 
     @EXTEND_COMMANDS = [
-      [:eval_history=, "irb/ext/history.rb"],
-      [:use_tracer=, "irb/ext/tracer.rb"],
-      [:use_loader=, "irb/ext/use-loader.rb"],
-      [:save_history=, "irb/ext/save-history.rb"],
+      [:eval_history=, "ext/history.rb"],
+      [:use_tracer=, "ext/tracer.rb"],
+      [:use_loader=, "ext/use-loader.rb"],
+      [:save_history=, "ext/save-history.rb"],
     ]
 
     # Installs the default context extensions as irb commands:
@@ -288,7 +288,7 @@ module IRB # :nodoc:
       line = __LINE__; Context.module_eval %[
         def #{cmd_name}(*opts, &b)
           Context.module_eval {remove_method(:#{cmd_name})}
-          require "#{load_file}"
+          require_relative "#{load_file}"
           __send__ :#{cmd_name}, *opts, &b
         end
         for ali in aliases


### PR DESCRIPTION
Sorry that didn't notice these when doing https://github.com/ruby/irb/pull/335.