### PR TITLE
Changed to add parameters in irbrc to pass to Reline.

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -299,11 +299,18 @@ module IRB
       if IRB.conf[:USE_AUTOCOMPLETE]
         Reline.add_dialog_proc(:show_doc, SHOW_DOC_DIALOG, Reline::DEFAULT_DIALOG_CONTEXT)
       end
-      Reline.dialog_default_bg_color = IRB.conf[:DIALOG_DEFAULT_BG_COLOR]
-      Reline.dialog_pointer_bg_color = IRB.conf[:DIALOG_POINTER_BG_COLOR]
-
-      Reline.dialog_default_fg_color = IRB.conf[:DIALOG_DEFAULT_FG_COLOR]
-      Reline.dialog_pointer_fg_color = IRB.conf[:DIALOG_POINTER_FG_COLOR]
+      if IRB.conf[:DIALOG_DEFAULT_BG_COLOR] && Reline.respond_to?('dialog_default_bg_color=')
+        Reline.dialog_default_bg_color = IRB.conf[:DIALOG_DEFAULT_BG_COLOR]
+      end
+      if IRB.conf[:DIALOG_POINTER_BG_COLOR] && Reline.respond_to?('dialog_pointer_bg_color=')
+        Reline.dialog_pointer_bg_color = IRB.conf[:DIALOG_POINTER_BG_COLOR]
+      end
+      if IRB.conf[:DIALOG_DEFAULT_FG_COLOR] && Reline.respond_to?('dialog_default_fg_color=')
+        Reline.dialog_default_fg_color = IRB.conf[:DIALOG_DEFAULT_FG_COLOR]
+      end
+      if IRB.conf[:DIALOG_POINTER_FG_COLOR] && Reline.respond_to?('dialog_pointer_fg_color=')
+        Reline.dialog_pointer_fg_color = IRB.conf[:DIALOG_POINTER_FG_COLOR]
+      end
     end
 
     def check_termination(&block)

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -301,6 +301,9 @@ module IRB
       end
       Reline.dialog_default_bg_color = IRB.conf[:DIALOG_DEFAULT_BG_COLOR]
       Reline.dialog_pointer_bg_color = IRB.conf[:DIALOG_POINTER_BG_COLOR]
+
+      Reline.dialog_default_fg_color = IRB.conf[:DIALOG_DEFAULT_FG_COLOR]
+      Reline.dialog_pointer_fg_color = IRB.conf[:DIALOG_POINTER_FG_COLOR]
     end
 
     def check_termination(&block)

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -299,6 +299,8 @@ module IRB
       if IRB.conf[:USE_AUTOCOMPLETE]
         Reline.add_dialog_proc(:show_doc, SHOW_DOC_DIALOG, Reline::DEFAULT_DIALOG_CONTEXT)
       end
+      Reline.dialog_default_bg_color = IRB.conf[:DIALOG_DEFAULT_BG_COLOR]
+      Reline.dialog_pointer_bg_color = IRB.conf[:DIALOG_POINTER_BG_COLOR]
     end
 
     def check_termination(&block)


### PR DESCRIPTION
I wanted to change the color of the completion dialog in Reline, so I made the following modifications to Reline
https://github.com/ruby/reline/pull/413

Initially, I was thinking of setting the color in inputrc.

However, after receiving a [report](https://github.com/ruby/reline/pull/413#issuecomment-1008236990) from Readline that warned that it was an unknown setting, I received a suggestion to set it in irbrc.

So, I made a modification to pass the configuration items to Reline using irbrc.

This is an example of using irbrc.
<img width="758" alt="スクリーンショット 2022-01-17 23 00 08" src="https://user-images.githubusercontent.com/1496543/149782665-eaebb05b-d099-4e09-9d8c-e53fb768d9f9.png">

This is an example without irbrc settings.
<img width="428" alt="スクリーンショット 2022-01-17 23 00 41" src="https://user-images.githubusercontent.com/1496543/149782886-43d58adf-4d46-4413-8732-ee88c991ddb0.png">


You can try with the following settings
```
% cat Gemfile
# frozen_string_literal: true

source "https://rubygems.org"

gem 'reline',  github: 'pocari/reline', branch: 'support-for-changing-the-background-color-of-dialogs'
gem 'irb',  github: 'pocari/irb', branch: 'feature/add-config-params-for-reline'

% bundle install
% cat ~/.irbrc

IRB.conf[:DIALOG_DEFAULT_BG_COLOR] = 40
IRB.conf[:DIALOG_POINTER_BG_COLOR] = 47

% bundle exec irb
```
