### PR TITLE
require_relative can't be used for default gems' exe files

### DIFF
--- a/exe/irb
+++ b/exe/irb
@@ -6,6 +6,6 @@
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 
-require_relative '../lib/irb'
+require "irb"
 
 IRB.start(__FILE__)


### PR DESCRIPTION
The `exe` folder and `lib` folder of default gems don't locate under the same place. While `exe/irb` will be under the gem folder, `irb.rb` will be under `lib/ruby/VERSION/`.

So `require_relative` will make `irb` unuseable when shipped with Ruby.

Related discussion in the comments: https://github.com/ruby/irb/pull/335