### PR TITLE
Allow chained methods show up during autocompletion

### DIFF
--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -26,6 +26,13 @@ module TestIRB
       assert_empty(IRB::InputCompletor.retrieve_completion_data("1i.positi", bind: binding))
     end
 
+    def test_complete_chained_methods
+      assert_include(IRB::InputCompletor.retrieve_completion_data("Array.new.", bind: binding), "Array.new.to_h")
+      assert_not_include(IRB::InputCompletor.retrieve_completion_data("Array.new.", bind: binding), "Array.new.Array")
+      assert_include(IRB::InputCompletor.retrieve_completion_data("0.to_s.", bind: binding), "0.to_s.unicode_normalized?")
+      assert_not_include(IRB::InputCompletor.retrieve_completion_data("0.to_s.", bind: binding), "0.to_s.Array")
+    end
+
     def test_complete_symbol
       %w"UTF-16LE UTF-7".each do |enc|
         "K".force_encoding(enc).to_sym


### PR DESCRIPTION
It is allowing chained methods show up during autocompletion correctly.

Evaluates the input and then uses the result to get public methods for suggestions.

After.

```
3.1.0 :001 > 0.to_s.
# 0.to_s.unicode_normalized?
# 0.to_s.encode!
# 0.to_s.unicode_normalize
# 0.to_s.ascii_only?

3.1.0 :001 > Array.new.to_h.
# Array.new.to_h.compare_by_identity
# Array.new.to_h.value?
# Array.new.to_h.deconstruct_keys
# Array.new.to_h.compare_by_identity?
```

Before.

```
3.1.0 :001 > 0.to_s.
# 0.to_s.Array
# 0.to_s.Complex
# 0.to_s.CurrentContext
# 0.to_s.Float

3.1.0 :001 > Array.new.to_h.
# Array.new.to_h.Array
# Array.new.to_h.Complex
# Array.new.to_h.CurrentContext
# Array.new.to_h.Float
```