### PR TITLE
Refactor RubyLex#process_literal_type

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -782,13 +782,8 @@ class RubyLex
     when :on_qsymbols_beg then ?]
     when :on_symbols_beg  then ?]
     when :on_heredoc_beg
-      start_token&.tok =~ /<<[-~]?(['"`])[_a-zA-Z0-9]+\1/
-      case $1
-      when ?" then ?"
-      when ?' then ?'
-      when ?` then ?`
-      else         ?"
-      end
+      start_token&.tok =~ /<<[-~]?(['"`])\w+\1/
+      $1 || ?"
     else
       nil
     end


### PR DESCRIPTION
Simplify part of regex ``[_a-zA-Z0-9]`` with equivalent shorthand ``\w``.
Replace case-when with match ``$1`` or default value ``?"``, making intention more clear.