### PR TITLE
Move `:stopdoc:` directive

### DIFF
--- a/lib/irb/cmd/chws.rb
+++ b/lib/irb/cmd/chws.rb
@@ -13,8 +13,9 @@
 require_relative "nop"
 require_relative "../ext/change-ws"
 
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   module ExtendCommand
 
     class CurrentWorkingWorkspace < Nop
@@ -30,5 +31,6 @@ module IRB
       end
     end
   end
+
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/cmd/fork.rb
+++ b/lib/irb/cmd/fork.rb
@@ -10,9 +10,11 @@
 #
 #
 
+require_relative "nop"
 
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   module ExtendCommand
     class Fork < Nop
       def execute
@@ -33,5 +35,6 @@ module IRB
       end
     end
   end
+
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/cmd/help.rb
+++ b/lib/irb/cmd/help.rb
@@ -11,8 +11,9 @@
 
 require_relative "nop"
 
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   module ExtendCommand
     class Help < Nop
       def execute(*names)
@@ -43,5 +44,6 @@ module IRB
       end
     end
   end
+
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/cmd/info.rb
+++ b/lib/irb/cmd/info.rb
@@ -2,8 +2,9 @@
 
 require_relative "nop"
 
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   module ExtendCommand
     class Info < Nop
       def execute
@@ -28,5 +29,6 @@ module IRB
       end
     end
   end
+
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/cmd/load.rb
+++ b/lib/irb/cmd/load.rb
@@ -13,8 +13,9 @@
 require_relative "nop"
 require_relative "../ext/loader"
 
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   module ExtendCommand
     class Load < Nop
       include IrbLoader
@@ -63,5 +64,5 @@ module IRB
     end
   end
 
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/cmd/ls.rb
+++ b/lib/irb/cmd/ls.rb
@@ -4,8 +4,9 @@ require "reline"
 require_relative "nop"
 require_relative "../color"
 
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   module ExtendCommand
     class Ls < Nop
       def execute(*arg, grep: nil)
@@ -97,5 +98,6 @@ module IRB
       private_constant :Output
     end
   end
+
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/cmd/measure.rb
+++ b/lib/irb/cmd/measure.rb
@@ -1,7 +1,8 @@
 require_relative "nop"
 
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   module ExtendCommand
     class Measure < Nop
       def initialize(*args)
@@ -39,5 +40,6 @@ module IRB
       end
     end
   end
+
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -9,8 +9,9 @@
 #
 #
 #
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   module ExtendCommand
     class Nop
 
@@ -41,5 +42,6 @@ module IRB
       end
     end
   end
+
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/cmd/pushws.rb
+++ b/lib/irb/cmd/pushws.rb
@@ -13,8 +13,9 @@
 require_relative "nop"
 require_relative "../ext/workspaces"
 
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   module ExtendCommand
     class Workspaces < Nop
       def execute(*obj)
@@ -36,5 +37,6 @@ module IRB
       end
     end
   end
+
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -4,8 +4,9 @@ require_relative "nop"
 require_relative "../color"
 require_relative "../ruby-lex"
 
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   module ExtendCommand
     class ShowSource < Nop
       def execute(str = nil)
@@ -89,5 +90,6 @@ module IRB
       private_constant :Source
     end
   end
+
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/cmd/subirb.rb
+++ b/lib/irb/cmd/subirb.rb
@@ -12,8 +12,9 @@
 require_relative "nop"
 require_relative "../ext/multi-irb"
 
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   module ExtendCommand
     class IrbCommand < Nop
       def execute(*obj)
@@ -39,5 +40,6 @@ module IRB
       end
     end
   end
+
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/cmd/whereami.rb
+++ b/lib/irb/cmd/whereami.rb
@@ -2,8 +2,9 @@
 
 require_relative "nop"
 
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   module ExtendCommand
     class Whereami < Nop
       def execute(*)
@@ -16,5 +17,6 @@ module IRB
       end
     end
   end
+
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/lc/error.rb
+++ b/lib/irb/lc/error.rb
@@ -10,8 +10,9 @@
 #
 #
 
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   class UnrecognizedSwitch < StandardError
     def initialize(val)
       super("Unrecognized switch: #{val}")
@@ -67,5 +68,6 @@ module IRB
       super("Define illegal RC_NAME_GENERATOR.")
     end
   end
+
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/lc/ja/encoding_aliases.rb
+++ b/lib/irb/lc/ja/encoding_aliases.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: false
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   class Locale
     @@legacy_encoding_alias_map = {
       'ujis' => Encoding::EUC_JP,
       'euc' => Encoding::EUC_JP
     }.freeze
   end
+
+  # :startdoc:
 end
-# :startdoc:

--- a/lib/irb/lc/ja/error.rb
+++ b/lib/irb/lc/ja/error.rb
@@ -10,8 +10,9 @@
 #
 #
 
-# :stopdoc:
 module IRB
+  # :stopdoc:
+
   class UnrecognizedSwitch < StandardError
     def initialize(val)
       super("スイッチ(#{val})が分りません")
@@ -67,6 +68,7 @@ module IRB
       super("RC_NAME_GENERATORが正しく定義されていません.")
     end
   end
+
+  # :startdoc:
 end
-# :startdoc:
 # vim:fileencoding=utf-8


### PR DESCRIPTION
If this is at the top level, it stops the documentation of the entire module, but not only the part in this file.