### PR TITLE
IRB raises exception when stdout is a pipe

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -39,7 +39,7 @@ module IRB
     public :gets
 
     def winsize
-      if instance_variable_defined?(:@stdout)
+      if instance_variable_defined?(:@stdout) && @stdout.tty?
         @stdout.winsize
       else
         [24, 80]

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -30,10 +30,6 @@ module TestIRB
       def reset
         @line_no = 0
       end
-
-      def winsize
-        [10, 20]
-      end
     end
 
     def setup
@@ -133,6 +129,18 @@ module TestIRB
           :*, /\(irb\):2:in `<main>': Bar \(RuntimeError\)\n/,
           :*, /#<RuntimeError: Bar>\n/,
         ], out)
+    end
+
+    def test_output_to_pipe
+      input = TestInputMethod.new(["n=1"])
+      input.instance_variable_set(:@stdout, StringIO.new)
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      irb.context.echo_on_assignment = :truncate
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_equal "=> 1\n", out
     end
 
     def test_eval_object_without_inspect_method


### PR DESCRIPTION
When piping stdout to another process IRB fails:

```
lib/ruby/3.0.0/irb/input-method.rb:42:in `winsize': Inappropriate ioctl for device (Errno::ENOTTY)
```

For example:

```
echo n=1 | irb | cat
```

This bug was introduced in Ruby commits: e468d9f49ca34f713c030c623f655a40370e186d and triggered by 8f9b1902f48b413bd161666630c878ad58418c04 and 555ea8334451c5ccd881e68b8b7ddc15745e66e3.

See also: https://bugs.ruby-lang.org/issues/18657