### PR TITLE
Commands should respect `USE_COLORIZE` config

### DIFF
--- a/lib/irb/cmd/ls.rb
+++ b/lib/irb/cmd/ls.rb
@@ -10,7 +10,7 @@ module IRB
   module ExtendCommand
     class Ls < Nop
       def execute(*arg, grep: nil)
-        o = Output.new(grep: grep)
+        o = Output.new(grep: grep, use_colorize: irb_context.use_colorize)
 
         obj    = arg.empty? ? irb_context.workspace.main : arg.first
         locals = arg.empty? ? irb_context.workspace.binding.local_variables : []
@@ -45,7 +45,8 @@ module IRB
       class Output
         MARGIN = "  "
 
-        def initialize(grep: nil)
+        def initialize(grep: nil, use_colorize: true)
+          @use_colorize = use_colorize
           @grep = grep
           @line_width = screen_width - MARGIN.length # right padding
         end
@@ -56,7 +57,7 @@ module IRB
           return if strs.empty?
 
           # Attempt a single line
-          print "#{Color.colorize(name, [:BOLD, :BLUE])}: "
+          print "#{Color.colorize(name, [:BOLD, :BLUE], colorable: Color.colorable? && @use_colorize)}: "
           if fits_on_line?(strs, cols: strs.size, offset: "#{name}: ".length)
             puts strs.join(MARGIN)
             return

--- a/lib/irb/cmd/ls.rb
+++ b/lib/irb/cmd/ls.rb
@@ -10,7 +10,7 @@ module IRB
   module ExtendCommand
     class Ls < Nop
       def execute(*arg, grep: nil)
-        o = Output.new(grep: grep, use_colorize: irb_context.use_colorize)
+        o = Output.new(grep: grep, colorable: colorable)
 
         obj    = arg.empty? ? irb_context.workspace.main : arg.first
         locals = arg.empty? ? irb_context.workspace.binding.local_variables : []
@@ -45,8 +45,8 @@ module IRB
       class Output
         MARGIN = "  "
 
-        def initialize(grep: nil, use_colorize: true)
-          @use_colorize = use_colorize
+        def initialize(grep: nil, colorable: true)
+          @colorable = colorable
           @grep = grep
           @line_width = screen_width - MARGIN.length # right padding
         end
@@ -57,7 +57,7 @@ module IRB
           return if strs.empty?
 
           # Attempt a single line
-          print "#{Color.colorize(name, [:BOLD, :BLUE], colorable: Color.colorable? && @use_colorize)}: "
+          print "#{Color.colorize(name, [:BOLD, :BLUE], colorable: @colorable)}: "
           if fits_on_line?(strs, cols: strs.size, offset: "#{name}: ".length)
             puts strs.join(MARGIN)
             return

--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -29,9 +29,10 @@ module IRB
 
       def initialize(conf)
         @irb_context = conf
+        @colorable = Color.colorable? && conf.use_colorize
       end
 
-      attr_reader :irb_context
+      attr_reader :irb_context, :colorable
 
       def irb
         @irb_context.irb

--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -30,7 +30,7 @@ module IRB
         puts
         puts "#{bold("From")}: #{source.file}:#{source.first_line}"
         puts
-        code = IRB::Color.colorize_code(File.read(source.file))
+        code = IRB::Color.colorize_code(File.read(source.file), colorable: Color.colorable? && irb_context.use_colorize)
         puts code.lines[(source.first_line - 1)...source.last_line].join
         puts
       end
@@ -78,7 +78,7 @@ module IRB
       end
 
       def bold(str)
-        Color.colorize(str, [:BOLD])
+        Color.colorize(str, [:BOLD], colorable: Color.colorable? && irb_context.use_colorize)
       end
 
       Source = Struct.new(

--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -30,7 +30,7 @@ module IRB
         puts
         puts "#{bold("From")}: #{source.file}:#{source.first_line}"
         puts
-        code = IRB::Color.colorize_code(File.read(source.file), colorable: Color.colorable? && irb_context.use_colorize)
+        code = IRB::Color.colorize_code(File.read(source.file), colorable: colorable)
         puts code.lines[(source.first_line - 1)...source.last_line].join
         puts
       end
@@ -78,7 +78,7 @@ module IRB
       end
 
       def bold(str)
-        Color.colorize(str, [:BOLD], colorable: Color.colorable? && irb_context.use_colorize)
+        Color.colorize(str, [:BOLD], colorable: colorable)
       end
 
       Source = Struct.new(


### PR DESCRIPTION
Currently, colored commands `ls` and `show_source` doesn't respect the `USE_COLORIZE` config:

<img width="80%" alt="截圖 2022-05-09 12 04 28" src="https://user-images.githubusercontent.com/5079556/167398018-5e22a8ef-38ac-41f5-a712-ce0cc31d5763.png">

This PR addresses the issue and here's the result:

<img width="80%" alt="截圖 2022-05-09 12 07 48" src="https://user-images.githubusercontent.com/5079556/167398213-dc5e62ed-308b-48e6-a5d3-2f3f83a090d8.png">

<img width="80%" alt="截圖 2022-05-09 12 11 44" src="https://user-images.githubusercontent.com/5079556/167398387-40734393-e8ea-42fe-9b9f-f97b34cec814.png">

BTW as suggested in https://github.com/ruby/irb/issues/351#issuecomment-1058205478, I think `irb` should adopt the `NO_COLOR` env var for easier no-color config.