### PR TITLE
Add documentation link and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Please follow the ["Making Changes To Standard Libraries"](https://docs.ruby-lan
 
 ## Test manually
 
-Make sure the `exe/irb` executable uses the `/lib` directory as source with `bundle exec`:
+Use the following command to run irb using the source files in the `/lib` directory (rather than the irb that came with Ruby):
 
 ```
 bundle exec exe/irb

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+## Build and test
+
+Please follow the ["Making Changes To Standard Libraries"](https://docs.ruby-lang.org/en/master/contributing/making_changes_to_stdlibs_md.html) guideline.
+
+## Test manually
+
+Make sure the `exe/irb` executable uses the `/lib` directory as source with `bundle exec`:
+
+```
+bundle exec exe/irb
+```
+

--- a/README.md
+++ b/README.md
@@ -40,18 +40,9 @@ irb(main):006:1> end
 
 The Readline extension module can be used with irb. Use of Readline is default if it's installed.
 
-### Configuration
+## Documentation
 
-You can customize `irb` using the global configuration file in `~/.irbrc` or using a file in your project called `.irbrc`.
-
-**Example**:
-
-```rb
-IRB.conf[:USE_AUTOCOMPLETE] = false # disable autocompletion
-IRB.conf[:USE_COLORIZE] = false # disable colorizing
-```
-
-To see all avaiable configure options, type `IRB.conf` inside an `irb` session.
+https://docs.ruby-lang.org/en/master/IRB.html
 
 ## Development
 


### PR DESCRIPTION
1. `irb`'s official document has a more detailed intro on configuration, so I replaced the configuration section with a link to it.
2. Add `CONTRIBUTING.md`.