### PR TITLE
Additions/revisions to help-message

### DIFF
--- a/lib/irb/lc/help-message
+++ b/lib/irb/lc/help-message
@@ -10,52 +10,53 @@
 #
 #
 Usage:  irb.rb [options] [programfile] [arguments]
-  -f                Suppress read of ~/.irbrc
-  -d                Set $DEBUG to true (same as `ruby -d')
-  -r load-module    Same as `ruby -r'
-  -I path           Specify $LOAD_PATH directory
-  -U                Same as `ruby -U`
-  -E enc            Same as `ruby -E`
-  -w                Same as `ruby -w`
-  -W[level=2]       Same as `ruby -W`
+  -f                Don't initialize from configuration file.
+  -d                Set $DEBUG and $VERBOSE to true (same as 'ruby -d').
+  -r load-module    Require load-module (same as 'ruby -r').
+  -I path           Specify $LOAD_PATH directory (same as 'ruby -I').
+  -U                Set external and internal encodings to UTF-8.
+  -E ex[:in]        Set default external and internal encodings
+                    (same as 'ruby -E').
+  -w                Suppress warnings (same as 'ruby -w').
+  -W[level=2]       Set warning level: 0=silence, 1=medium, 2=verbose
+                    (same as 'ruby -W').
   --context-mode n  Set n[0-4] to method to create Binding Object,
-                    when new workspace was created
-  --extra-doc-dir   Add an extra doc dir for the doc dialog
-  --echo            Show result (default)
-  --noecho          Don't show result
+                    when new workspace was created.
+  --extra-doc-dir   Add an extra doc dir for the doc dialog.
+  --echo            Show result (default).
+  --noecho          Don't show result.
   --echo-on-assignment
-                    Show result on assignment
+                    Show result on assignment.
   --noecho-on-assignment
-                    Don't show result on assignment
+                    Don't show result on assignment.
   --truncate-echo-on-assignment
-                    Show truncated result on assignment (default)
-  --inspect         Use `inspect' for output
-  --noinspect       Don't use inspect for output
-  --multiline       Use multiline editor module
-  --nomultiline     Don't use multiline editor module
-  --singleline      Use singleline editor module
-  --nosingleline    Don't use singleline editor module
-  --colorize        Use colorization
-  --nocolorize      Don't use colorization
-  --autocomplete    Use autocompletion
-  --noautocomplete  Don't use autocompletion
-  --prompt prompt-mode/--prompt-mode prompt-mode
-                    Switch prompt mode. Pre-defined prompt modes are
-                    `default', `simple', `xmp' and `inf-ruby'
+                    Show truncated result on assignment (default).
+  --inspect         Use 'inspect' for output.
+  --noinspect       Don't use 'inspect' for output.
+  --multiline       Use multiline editor module.
+  --nomultiline     Don't use multiline editor module (default).
+  --singleline      Use single line editor module.
+  --nosingleline    Don't use single line editor module (default).
+  --colorize        Use color-highlighting (default).
+  --nocolorize      Don't use color-highlighting.
+  --autocomplete    Use auto-completion (default).
+  --noautocomplete  Don't use auto-completion.
+  --prompt prompt-mode, --prompt-mode prompt-mode
+                    Set prompt mode. Pre-defined prompt modes are:
+                    'default', 'classic', 'simple', 'inf-ruby', 'xmp', 'null'.
   --inf-ruby-mode   Use prompt appropriate for inf-ruby-mode on emacs.
                     Suppresses --multiline and --singleline.
-  --sample-book-mode/--simple-prompt
-                    Simple prompt mode
-  --noprompt        No prompt mode
+  --sample-book-mode, --simple-prompt
+                    Set prompt mode to 'simple'.
+  --noprompt        Don't output prompt.
   --single-irb      Share self with sub-irb.
-  --tracer          Display trace for each execution of commands.
-  --back-trace-limit n
-                    Display backtrace top n and tail n. The default
-                    value is 16.
-  --verbose         Show details
-  --noverbose       Don't show details
-  -v, --version	    Print the version of irb
-  -h, --help        Print help
-  --                Separate options of irb from the list of command-line args
+  --tracer          Show stack trace for each command.
+  --back-trace-limit n[=16]
+                    Display backtrace top n and bottom n.
+  --verbose         Show details.
+  --noverbose       Don't show details.
+  -v, --version     Print the version of irb.
+  -h, --help        Print help.
+  --                Separate options of irb from the list of command-line args.
 
 # vim:fileencoding=utf-8

--- a/lib/irb/lc/help-message
+++ b/lib/irb/lc/help-message
@@ -15,7 +15,7 @@ Usage:  irb.rb [options] [programfile] [arguments]
   -r load-module    Require load-module (same as 'ruby -r').
   -I path           Specify $LOAD_PATH directory (same as 'ruby -I').
   -U                Set external and internal encodings to UTF-8.
-  -E ex[:in]        Set default external and internal encodings
+  -E ex[:in]        Set default external (ex) and internal (in) encodings
                     (same as 'ruby -E').
   -w                Suppress warnings (same as 'ruby -w').
   -W[level=2]       Set warning level: 0=silence, 1=medium, 2=verbose


### PR DESCRIPTION
Changed:
- Added text to options that said just 'same as ruby -whatever'.
- Added defaults.
- Removed an errant tab.

I'm not adding the documentation label, because I'm not sure about how else this might be used.

If/when approved, section "Command line options" in irb.rb will need to be updated.
