### PR TITLE
Use a patched version of reline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development do
   gem "rake"
   gem "stackprof" if is_unix && !is_truffleruby
   gem "test-unit"
+  # gem "fiddle", github: "ruby/fiddle"
 end


### PR DESCRIPTION
This is to prove that https://github.com/ruby/reline/pull/451 fixes the hanging CI.