### PR TITLE
Color.colorable? needs to consider the condition when irb is not loaded

### DIFF
--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -77,7 +77,15 @@ module IRB # :nodoc:
 
     class << self
       def colorable?
-        $stdout.tty? && (/mswin|mingw/ =~ RUBY_PLATFORM || (ENV.key?('TERM') && ENV['TERM'] != 'dumb')) && IRB.conf.fetch(:USE_COLORIZE, true)
+        supported = $stdout.tty? && (/mswin|mingw/ =~ RUBY_PLATFORM || (ENV.key?('TERM') && ENV['TERM'] != 'dumb'))
+
+        # because ruby/debug also uses irb's color module selectively,
+        # irb won't be activated in that case.
+        if IRB.respond_to?(:conf)
+          supported && IRB.conf.fetch(:USE_COLORIZE, true)
+        else
+          supported
+        end
       end
 
       def inspect_colorable?(obj, seen: {}.compare_by_identity)


### PR DESCRIPTION
`ruby/debug` uses `irb/color` selectively:
https://github.com/ruby/debug/blob/0ac22406bb8f65bc76f9f5576a00c729cac693af/lib/debug/color.rb#L4

And in that case, `IRB.conf` won't be defined. So Color.colorable? needs to consider that.

This also fixes the Ruby trunk CI.