### PR TITLE
Add latest version of reline into test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   irb:
-    name: irb (${{ matrix.ruby }} / ${{ matrix.os }})
+    name: rake test ${{ matrix.ruby }} ${{ matrix.with_latest_reline && '(latest reline)' || '' }}
     strategy:
       matrix:
         ruby:
@@ -20,8 +20,11 @@ jobs:
           - head
           - truffleruby-head
         os: [ubuntu-latest]
+        with_latest_reline: [true, false]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    env:
+      WITH_LATEST_RELINE: ${{matrix.with_latest_reline}}
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby
@@ -37,7 +40,7 @@ jobs:
       run: bundle exec rake test
   vterm-yamatanooroti:
     name: >-
-      vterm-yamatanooroti ${{ matrix.os }} ${{ matrix.ruby }}
+      vterm-yamatanooroti ${{ matrix.ruby }} ${{ matrix.with_latest_reline && '(latest reline)' || '' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -46,8 +49,11 @@ jobs:
           - '3.0'
           - '2.7'
           - head
-        os: [ ubuntu-latest ]
+        os: [ubuntu-latest]
+        with_latest_reline: [true, false]
       fail-fast: false
+    env:
+      WITH_LATEST_RELINE: ${{matrix.with_latest_reline}}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby
@@ -68,4 +74,4 @@ jobs:
           gem install bundler --no-document
           WITH_VTERM=1 bundle install
       - name: rake test_yamatanooroti
-        run:  rake test_yamatanooroti
+        run:  bundle exec rake test_yamatanooroti

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,10 @@ jobs:
           - truffleruby-head
         os: [ubuntu-latest]
         with_latest_reline: [true, false]
+        exclude:
+          - ruby: '2.5'
+            os: ubuntu-latest
+            with_latest_reline: true
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development do
   gem "rake"
   gem "stackprof" if is_unix && !is_truffleruby
   gem "test-unit"
+  gem "reline", github: "ruby/reline" if ENV["WITH_LATEST_RELINE"] == "true"
 end


### PR DESCRIPTION
When adopting newest reline features (e.g. https://github.com/ruby/irb/pull/380), I find it hard to know what failures are caused by the `reline` upgrade and what's caused by the code change. [Example build](https://github.com/ruby/irb/actions/runs/2723567680).

And if we make the CI to run against the latest `reline`, we will lose the coverage on currently released `reline` version.

So I think we can make the CI run with both "latest release" and "master" to make such changes easier and safer.