### PR TITLE
Drop Ruby 2.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,10 @@ jobs:
           - '3.0'
           - '2.7'
           - '2.6'
-          - '2.5'
           - head
           - truffleruby-head
         os: [ubuntu-latest]
         with_latest_reline: [true, false]
-        exclude:
-          - ruby: '2.5'
-            os: ubuntu-latest
-            with_latest_reline: true
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/irb.gemspec
+++ b/irb.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.5")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6")
 
   spec.add_dependency "reline", ">= 0.3.0"
 end

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -596,11 +596,7 @@ module IRB
 
       if exc.backtrace
         order = nil
-        if '2.5.0' == RUBY_VERSION
-          # Exception#full_message doesn't have keyword arguments.
-          message = exc.full_message # the same of (highlight: true, order: bottom)
-          order = :bottom
-        elsif '2.5.1' <= RUBY_VERSION && RUBY_VERSION < '3.0.0'
+        if RUBY_VERSION < '3.0.0'
           if STDOUT.tty?
             message = exc.full_message(order: :bottom)
             order = :bottom

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -125,23 +125,19 @@ module TestIRB
       end
 
       tests.each do |code, result|
-        if colorize_code_supported?
-          assert_equal_with_term(result, code, complete: true)
-          assert_equal_with_term(result, code, complete: false)
+        assert_equal_with_term(result, code, complete: true)
+        assert_equal_with_term(result, code, complete: false)
 
-          assert_equal_with_term(code, code, complete: true, tty: false)
-          assert_equal_with_term(code, code, complete: false, tty: false)
+        assert_equal_with_term(code, code, complete: true, tty: false)
+        assert_equal_with_term(code, code, complete: false, tty: false)
 
-          assert_equal_with_term(code, code, complete: true, colorable: false)
+        assert_equal_with_term(code, code, complete: true, colorable: false)
 
-          assert_equal_with_term(code, code, complete: false, colorable: false)
+        assert_equal_with_term(code, code, complete: false, colorable: false)
 
-          assert_equal_with_term(result, code, complete: true, tty: false, colorable: true)
+        assert_equal_with_term(result, code, complete: true, tty: false, colorable: true)
 
-          assert_equal_with_term(result, code, complete: false, tty: false, colorable: true)
-        else
-          assert_equal_with_term(code, code)
-        end
+        assert_equal_with_term(result, code, complete: false, tty: false, colorable: true)
       end
     end
 
@@ -171,26 +167,22 @@ module TestIRB
         "'foo' + 'bar" => "#{RED}#{BOLD}'#{CLEAR}#{RED}foo#{CLEAR}#{RED}#{BOLD}'#{CLEAR} + #{RED}#{BOLD}'#{CLEAR}#{RED}bar#{CLEAR}",
         "('foo" => "(#{RED}#{BOLD}'#{CLEAR}#{RED}foo#{CLEAR}",
       }.each do |code, result|
-        if colorize_code_supported?
-          assert_equal_with_term(result, code, complete: false)
+        assert_equal_with_term(result, code, complete: false)
 
-          assert_equal_with_term(code, code, complete: false, tty: false)
+        assert_equal_with_term(code, code, complete: false, tty: false)
 
-          assert_equal_with_term(code, code, complete: false, colorable: false)
+        assert_equal_with_term(code, code, complete: false, colorable: false)
 
-          assert_equal_with_term(result, code, complete: false, tty: false, colorable: true)
+        assert_equal_with_term(result, code, complete: false, tty: false, colorable: true)
 
-          unless complete_option_supported?
-            assert_equal_with_term(result, code, complete: true)
+        unless complete_option_supported?
+          assert_equal_with_term(result, code, complete: true)
 
-            assert_equal_with_term(code, code, complete: true, tty: false)
+          assert_equal_with_term(code, code, complete: true, tty: false)
 
-            assert_equal_with_term(code, code, complete: true, colorable: false)
+          assert_equal_with_term(code, code, complete: true, colorable: false)
 
-            assert_equal_with_term(result, code, complete: true, tty: false, colorable: true)
-          end
-        else
-          assert_equal_with_term(code, code)
+          assert_equal_with_term(result, code, complete: true, tty: false, colorable: true)
         end
       end
     end
@@ -216,11 +208,6 @@ module TestIRB
     end
 
     private
-
-    # `#colorize_code` is supported only for Ruby 2.5+. It just returns the original code in 2.4-.
-    def colorize_code_supported?
-      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
-    end
 
     # `complete: true` is the same as `complete: false` in Ruby 2.6-
     def complete_option_supported?

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -507,7 +507,7 @@ module TestIRB
         irb.eval_input
       end
       assert_empty err
-      if '2.5.0' <= RUBY_VERSION && RUBY_VERSION < '3.0.0' && STDOUT.tty?
+      if RUBY_VERSION < '3.0.0' && STDOUT.tty?
         expected = [
           :*, /Traceback \(most recent call last\):\n/,
           :*, /\t 2: from \(irb\):1:in `<main>'\n/,
@@ -538,7 +538,7 @@ module TestIRB
         irb.eval_input
       end
       assert_empty err
-      if '2.5.0' <= RUBY_VERSION && RUBY_VERSION < '3.0.0' && STDOUT.tty?
+      if RUBY_VERSION < '3.0.0' && STDOUT.tty?
         expected = [
           :*, /Traceback \(most recent call last\):\n/,
           :*, /\t 2: from \(irb\):1:in `<main>'\n/,
@@ -575,7 +575,7 @@ module TestIRB
         irb.eval_input
       end
       assert_empty err
-      if '2.5.0' <= RUBY_VERSION && RUBY_VERSION < '3.0.0' && STDOUT.tty?
+      if RUBY_VERSION < '3.0.0' && STDOUT.tty?
         expected = [
           :*, /Traceback \(most recent call last\):\n/,
           :*, /\t... \d+ levels...\n/,

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -157,9 +157,6 @@ module TestIRB
     end
 
     def test_endless_range_at_end_of_line
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.6.0')
-        pend 'Endless range is available in 2.6.0 or later'
-      end
       input_with_prompt = [
         PromptRow.new('001:0: :> ', %q(a = 3..)),
         PromptRow.new('002:0: :* ', %q()),

--- a/test/lib/core_assertions.rb
+++ b/test/lib/core_assertions.rb
@@ -694,8 +694,7 @@ eom
         if !errs.empty?
           msg = "exceptions on #{errs.length} threads:\n" +
             errs.map {|t, err|
-            "#{t.inspect}:\n" +
-              RUBY_VERSION >= "2.5.0" ? err.full_message(highlight: false, order: :top) : err.message
+            "#{t.inspect}:\n" + err.full_message(highlight: false, order: :top)
           }.join("\n---\n")
           if message
             msg = "#{message}\n#{msg}"


### PR DESCRIPTION
Because Ruby 2.5 has reached EOL for more than 1.5 years and it won't be supported by the next `reline` version either.