### PR TITLE
Speedup Pretty Print

### DIFF
--- a/lib/irb/color_printer.rb
+++ b/lib/irb/color_printer.rb
@@ -37,6 +37,9 @@ module IRB
       width ||= str.length
 
       case str
+      when ''
+      when ',', '=>', '[', ']', '{', '}', '..', '...', /\A@\w+\z/
+        super(str, width)
       when /\A#</, '=', '>'
         super(Color.colorize(str, [:GREEN]), width)
       else


### PR DESCRIPTION
Many `""`, `","`, `"="`, `"=>"` are passed to Color.colorize_code
```ruby
test_obj = [IRB::ColorPrinter.new]*100;
test_arr = 1000.times.to_a
test_hash = 1000.times.to_h{[_1, _1]}
$counts=Hash.new(0)
IRB::ColorPrinter.prepend Module.new{ def text(t,w=nil) = ($counts[t]+=1; super(t,w)) }
IRB::ColorPrinter.pp([test_obj, test_arr, test_hash], [])
pp $counts.values.sum #=> 31115
pp $counts.sort_by{-_2}.take(10)
# =>
[["", 17208], # 55%
 [",", 3399], # 11%
 ["=", 1700], # 5%
 ["=>", 1000],# 3%
 ["]", 603],
 ["[", 603],
 ["0", 503],
 [">", 400],
 ["#<PrettyPrint::Group:0x000000010fab4ae0", 200],
 ["false", 200]]
```

Added a shortcut path to skip colorizing these tokens
`',', '=>', '[', ']', '{', '}', '..', '...'`, empty string, and instance_variable(`/\A@\w+\z/`)


Benchmark (using irb measure command)
```ruby
test_obj = [IRB::ColorPrinter.new]*100;
test_arr = 1000.times.to_a
test_hash = 1000.times.to_h{[_1, _1]}

IRB::ColorPrinter.pp(test_obj, [])
# processing time: 0.457954s → 0.190865s (240% faster)

IRB::ColorPrinter.pp(test_arr, [])
# processing time: 0.136560s → 0.099233s (137% faster)

IRB::ColorPrinter.pp(test_hash, [])
# processing time: 0.318571s → 0.121728s (262% faster)
```
