### PR TITLE
Fix indent after multiline string

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -637,7 +637,7 @@ class RubyLex
       end
 
       case t.event
-      when :on_ignored_nl, :on_nl, :on_comment
+      when :on_ignored_nl, :on_nl, :on_comment, :on_heredoc_end, :on_embdoc_end
         if in_oneliner_def != :BODY
           corresponding_token_depth = nil
           spaces_at_line_head = 0

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -182,6 +182,7 @@ class RubyLex
         if line_count >= line_index
           return prev_spaces
         end
+        next if t.event == :on_tstring_content || t.event == :on_words_sep
         if (@tokens.size - 1) > i
           md = @tokens[i + 1].tok.match(/(\A +)/)
           prev_spaces = md.nil? ? 0 : md[1].count(' ')

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -697,5 +697,68 @@ module TestIRB
         assert_equal('<<A', string_literal&.tok)
       end
     end
+
+    def test_corresponding_token_depth_with_heredoc_and_embdoc
+      reference_code = <<~EOC.chomp
+        if true
+          hello
+          p(
+          )
+      EOC
+      code_with_heredoc = <<~EOC.chomp
+        if true
+          <<~A
+          A
+          p(
+          )
+      EOC
+      code_with_embdoc = <<~EOC.chomp
+        if true
+        =begin
+        =end
+          p(
+          )
+      EOC
+      [reference_code, code_with_heredoc, code_with_embdoc].each do |code|
+        lex = RubyLex.new
+        lines = code.lines
+        lex.instance_variable_set('@tokens', RubyLex.ripper_lex_without_warning(code))
+        assert_equal 2, lex.check_corresponding_token_depth(lines, lines.size)
+      end
+    end
+
+    def test_find_prev_spaces_with_multiline_literal
+      lex = RubyLex.new
+      reference_code = <<~EOC.chomp
+        if true
+          1
+          hello
+          1
+          world
+        end
+      EOC
+      code_with_percent_string = <<~EOC.chomp
+        if true
+          %w[
+            hello
+          ]
+          world
+        end
+      EOC
+      code_with_quoted_string = <<~EOC.chomp
+        if true
+          '
+            hello
+          '
+          world
+        end
+      EOC
+      [reference_code, code_with_percent_string, code_with_quoted_string].each do |code|
+        lex = RubyLex.new
+        lex.instance_variable_set('@tokens', RubyLex.ripper_lex_without_warning(code))
+        prev_spaces = (1..code.lines.size).map { |index| lex.find_prev_spaces index }
+        assert_equal [0, 2, 2, 2, 2, 0], prev_spaces
+      end
+    end
   end
 end


### PR DESCRIPTION
This pullreq fixes two indent problem with multiline string.

### Fixed indent after `"stri\ng"`, `%[stri\ng]` `%w[string\nstring]`
```
# Case1
irb(main):001:0> if 0
irb(main):002:1"   "1
irb(main):003:1"   2"
irb(main):004:1* 3
expected:          3

# Case2
irb(main):001:1* if 0
irb(main):002:2"   p("1
irb(main):003:2"     2",
irb(main):004:2*   3,
expected:            3,
```

Multiline string can contain `"\n"`, but the next token does not matches `/(\A +)/`.
Skipped updating prev_spaces if token is :on_tstring_content or :on_words_sep


###  Fixed calculation of corresponding_token_depth after heredoc
```
irb(main):001:0> if 1
irb(main):002:1"   <<~A
irb(main):003:1"   A
irb(main):004:1*   p(
irb(main):005:3*     p(
irb(main):006:4*     )
irb(main):007:1* )
expected:          )
```
and after embdoc
```
irb(main):001:1* if 1
irb(main):002:1* =begin
irb(main):003:1* =end
irb(main):004:2*   p(
irb(main):005:3*     p(
irb(main):006:2*     )
irb(main):007:1* )
expected:          )
```

Added `:on_heredoc_end` and `:on_embdoc_end`. It also ends with `"\n"`.
```ruby
# all tokens that include "\n" in ruby/ruby source code
Dir.glob('**/*.rb').flat_map do |file|
  RubyLex.ripper_lex_without_warning(File.read(file), context: context).select { _1.tok.include? $/ }
end.map(&:event).uniq
# => [:on_comment, :on_nl, :on_ignored_nl, :on_tstring_content, :on_heredoc_end, :on_words_sep, :on_embdoc_beg, :on_embdoc, :on_embdoc_end, :on_sp, :on___end__]
```
