### PR TITLE
Fix prompt and code mismatch

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -90,7 +90,8 @@ class RubyLex
           if t.tok.include?("\n")
             t_str = t.tok
             t_str.each_line("\n") do |s|
-              code << s << "\n"
+              code << s
+              next unless s.include?("\n")
               ltype, indent, continue, code_block_open = check_state(code, partial_tokens, context: context)
               result << @prompt.call(ltype, indent, continue || code_block_open, @line_no + line_num_offset)
               line_num_offset += 1

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -578,6 +578,38 @@ module TestIRB
       assert_dynamic_prompt(lines, expected_prompt_list)
     end
 
+    def test_dyanmic_prompt_with_double_newline_braking_code
+      input_with_prompt = [
+        PromptRow.new('001:1: :* ', %q(if true)),
+        PromptRow.new('002:1: :* ', %q(%)),
+        PromptRow.new('003:1: :* ', %q(;end)),
+        PromptRow.new('004:1: :* ', %q(;hello)),
+        PromptRow.new('005:0: :> ', %q(end)),
+      ]
+
+      lines = input_with_prompt.map(&:content)
+      expected_prompt_list = input_with_prompt.map(&:prompt)
+      assert_dynamic_prompt(lines, expected_prompt_list)
+    end
+
+    def test_dyanmic_prompt_with_multiline_literal
+      input_with_prompt = [
+        PromptRow.new('001:1: :* ', %q(if true)),
+        PromptRow.new('002:1:]:* ', %q(  %w[)),
+        PromptRow.new('003:1:]:* ', %q(  a)),
+        PromptRow.new('004:1: :* ', %q(  ])),
+        PromptRow.new('005:1: :* ', %q(  b)),
+        PromptRow.new('006:1:]:* ', %q(  %w[)),
+        PromptRow.new('007:1:]:* ', %q(  c)),
+        PromptRow.new('008:1: :* ', %q(  ])),
+        PromptRow.new('009:0: :> ', %q(end)),
+      ]
+
+      lines = input_with_prompt.map(&:content)
+      expected_prompt_list = input_with_prompt.map(&:prompt)
+      assert_dynamic_prompt(lines, expected_prompt_list)
+    end
+
     def test_dyanmic_prompt_with_blank_line
       input_with_prompt = [
         PromptRow.new('001:0:]:* ', %q(%w[)),


### PR DESCRIPTION
Fixed: ltype of the prompt(`*` `"` `]` `>` on the right end of the prompt) sometimes does not matches the code
```
# before
irb(main):001:1* if 1
irb(main):002:1"   "
irb(main):003:1"   "
irb(main):004:1*   1
irb(main):005:1*   %(
irb(main):006:1"   )
irb(main):007:1"   1
irb(main):008:1*   %w[a
irb(main):009:1*   ]
irb(main):010:1]   1
irb(main):011:1]   "
irb(main):012:1*   "
irb(main):013:1*   1
irb(main):014:1"   1
irb(main):015:1"   1
irb(main):016:1* end

# after
irb(main):001:1* if 1
irb(main):002:1"   "
irb(main):003:1*   "
irb(main):004:1*   1
irb(main):005:1"   %(
irb(main):006:1*   )
irb(main):007:1*   1
irb(main):008:1]   %w[a
irb(main):009:1*   ]
irb(main):010:1*   1
irb(main):011:1"   "
irb(main):012:1*   "
irb(main):013:1*   1
irb(main):014:1*   1
irb(main):015:1*   1
irb(main):016:0> end
```

For tokens below, count of  `t.tok.each_line("\n") #=> ["\n", "  "]` does not match count of `"\n"` in token.
```
#<Ripper::Lexer::Elem: on_tstring_content@5:4 BEG token: "\n" + "  ">,
#<Ripper::Lexer::Elem: on_words_sep@8:6 BEG token: "\n" + "  ">
```

Changes:
Skip if line does not contain `"\n"`
Do not add `"\n"` to line. It already ends with `"\n"` and adding might change syntax. ex: `str = %\nend\n` != `str = %\n\nend\n\n`
