### PR TITLE
Update regarding NO_COLOR value

### DIFF
--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -44,7 +44,7 @@ module IRB # :nodoc:
     @CONF[:IRB_RC] = nil
 
     @CONF[:USE_SINGLELINE] = false unless defined?(ReadlineInputMethod)
-    @CONF[:USE_COLORIZE] = !ENV['NO_COLOR']&.slice(0)
+    @CONF[:USE_COLORIZE] = (nc = ENV['NO_COLOR']).nil? || nc.empty?
     @CONF[:USE_AUTOCOMPLETE] = true
     @CONF[:INSPECT_MODE] = true
     @CONF[:USE_TRACER] = false

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -44,7 +44,7 @@ module IRB # :nodoc:
     @CONF[:IRB_RC] = nil
 
     @CONF[:USE_SINGLELINE] = false unless defined?(ReadlineInputMethod)
-    @CONF[:USE_COLORIZE] = !ENV['NO_COLOR']
+    @CONF[:USE_COLORIZE] = !ENV['NO_COLOR']&.slice(0)
     @CONF[:USE_AUTOCOMPLETE] = true
     @CONF[:INSPECT_MODE] = true
     @CONF[:USE_TRACER] = false

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -79,6 +79,10 @@ module TestIRB
       IRB.setup(__FILE__)
       refute IRB.conf[:USE_COLORIZE]
 
+      ENV['NO_COLOR'] = ''
+      IRB.setup(__FILE__)
+      assert IRB.conf[:USE_COLORIZE]
+
       ENV['NO_COLOR'] = nil
       IRB.setup(__FILE__)
       assert IRB.conf[:USE_COLORIZE]


### PR DESCRIPTION
https://no-color.org has been updated (jcs/no_color#83):

> Command-line software which adds ANSI color to its output by default
should check for a `NO_COLOR` environment variable that, when present
and **not an empty string** (regardless of its value), prevents the
addition of ANSI color.