### PR TITLE
Fix history file saving with concurrent irb sessions when history file doesn't exist

### DIFF
--- a/lib/irb/ext/save-history.rb
+++ b/lib/irb/ext/save-history.rb
@@ -107,7 +107,7 @@ module IRB
           raise
         end
 
-        if File.exist?(history_file) && @loaded_history_mtime &&
+        if File.exist?(history_file) &&
            File.mtime(history_file) != @loaded_history_mtime
           history = history[@loaded_history_lines..-1]
           append_history = true

--- a/lib/irb/ext/save-history.rb
+++ b/lib/irb/ext/save-history.rb
@@ -109,7 +109,7 @@ module IRB
 
         if File.exist?(history_file) &&
            File.mtime(history_file) != @loaded_history_mtime
-          history = history[(@loaded_history_lines||0)..-1]
+          history = history[@loaded_history_lines..-1] if @loaded_history_lines
           append_history = true
         end
 

--- a/lib/irb/ext/save-history.rb
+++ b/lib/irb/ext/save-history.rb
@@ -109,7 +109,7 @@ module IRB
 
         if File.exist?(history_file) &&
            File.mtime(history_file) != @loaded_history_mtime
-          history = history[@loaded_history_lines..-1]
+          history = history[(@loaded_history_lines||0)..-1]
           append_history = true
         end
 


### PR DESCRIPTION
If history file didn't exist when irb was started, @loaded_history_mtime
would be nil.  However, if the history file didn't exist before, but it
exists when saving history, that means the history file was modified,
and we should handle it the same way as we handle the other case where
the history file was modified.

Fixes #388