### PR TITLE
Fix code terminated check with heredoc and backtick

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -729,8 +729,10 @@ class RubyLex
           end
         end
       when :on_backtick
-        start_token << t
-        end_type << :on_tstring_end
+        if t.state.allbits?(Ripper::EXPR_BEG)
+          start_token << t
+          end_type << :on_tstring_end
+        end
       when :on_qwords_beg, :on_words_beg, :on_qsymbols_beg, :on_symbols_beg
         start_token << t
         end_type << :on_tstring_end

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -162,7 +162,7 @@ class RubyLex
           end
         end
       else
-        lexer.parse.reject { |it| it.pos.first == 0 }
+        lexer.parse.sort_by(&:pos).reject { |it| it.pos.first == 0 }
       end
     end
   ensure

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -741,7 +741,7 @@ class RubyLex
         pending_heredocs << t
       end
 
-      if !pending_heredocs.empty? && t.tok.include?("\n")
+      if pending_heredocs.any? && t.tok.include?("\n")
         pending_heredocs.reverse_each do |t|
           start_token << t
           end_type << :on_heredoc_end

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -162,7 +162,7 @@ class RubyLex
           end
         end
       else
-        lexer.parse.sort_by(&:pos).reject { |it| it.pos.first == 0 }
+        lexer.parse.reject { |it| it.pos.first == 0 }.sort_by(&:pos)
       end
     end
   ensure

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -170,6 +170,19 @@ module TestIRB
       assert_dynamic_prompt(lines, expected_prompt_list)
     end
 
+    def test_backtick_method
+      input_with_prompt = [
+        PromptRow.new('001:0: :> ', %q(self.`(arg))),
+        PromptRow.new('002:0: :* ', %q()),
+        PromptRow.new('003:0: :> ', %q(def `(); end)),
+        PromptRow.new('004:0: :* ', %q()),
+      ]
+
+      lines = input_with_prompt.map(&:content)
+      expected_prompt_list = input_with_prompt.map(&:prompt)
+      assert_dynamic_prompt(lines, expected_prompt_list)
+    end
+
     def test_incomplete_coding_magic_comment
       input_with_correct_indents = [
         Row.new(%q(#coding:u), nil, 0),

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -666,5 +666,13 @@ module TestIRB
         assert_empty(error_tokens, 'Error tokens must be ignored if there is corresponding non-error token')
       end
     end
+
+    def test_unterminated_heredoc_string_literal
+      ['<<A;<<B', "<<A;<<B\n", "%W[\#{<<A;<<B", "%W[\#{<<A;<<B\n"].each do |code|
+        tokens = RubyLex.ripper_lex_without_warning(code)
+        string_literal = RubyLex.new.check_string_literal(tokens)
+        assert_equal('<<A', string_literal&.tok)
+      end
+    end
   end
 end

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -170,6 +170,27 @@ module TestIRB
       assert_dynamic_prompt(lines, expected_prompt_list)
     end
 
+    def test_heredoc_with_embexpr
+      input_with_prompt = [
+        PromptRow.new('001:0:":* ', %q(<<A+%W[#{<<B)),
+        PromptRow.new('002:0:":* ', %q(#{<<C+%W[)),
+        PromptRow.new('003:0:":* ', %q()),
+        PromptRow.new('004:0:":* ', %q(C)),
+        PromptRow.new('005:0:]:* ', %q()),
+        PromptRow.new('006:0:":* ', %q(]})),
+        PromptRow.new('007:0:":* ', %q(})),
+        PromptRow.new('008:0:":* ', %q(A)),
+        PromptRow.new('009:0:]:* ', %q(B)),
+        PromptRow.new('010:0:]:* ', %q(})),
+        PromptRow.new('011:0: :> ', %q(])),
+        PromptRow.new('012:0: :* ', %q()),
+      ]
+
+      lines = input_with_prompt.map(&:content)
+      expected_prompt_list = input_with_prompt.map(&:prompt)
+      assert_dynamic_prompt(lines, expected_prompt_list)
+    end
+
     def test_backtick_method
       input_with_prompt = [
         PromptRow.new('001:0: :> ', %q(self.`(arg))),


### PR DESCRIPTION
Fixes #361 and also fixes similar problem with ``def `();end`` ``self.`('sleep 1')`` (#334)

### Heredoc
This code shows a sample of finding heredoc_beg corresponding to heredoc_end.
```ruby
<<A+<<B+%[#{<<C+<<D
#{<<E+<<F
#{<<G+<<H
G
H
}
E
F
}
A
B
C
D
}]
```
In line 1, there are heredocs(A,B,C,D). These heredocs will start from the next line. (pushed into `pending_heredoc`)
Heredoc will be closed in an order `A → B → C → D`, so it should be reversed and pushed to start_token when reached a new line.

### Backtick
```
irb(main):001:0` def `();end
irb(main):002:0` 
irb(main):003:0` self.`('sleep 1')
irb(main):004:0` 
# expect
irb(main):001:0> def `(); end
=> :`
irb(main):002:0> self.`('sleep 1')
=> ""
```

Checks if backtick is `` `command` `` or not.
```ruby
`sleep 1`         #<Ripper::Lexer::Elem: on_backtick@1:0 BEG token: "`">
self.`('sleep 1') #<Ripper::Lexer::Elem: on_backtick@1:5 ARG token: "`">
def `(arg); end   #<Ripper::Lexer::Elem: on_backtick@1:4 ENDFN token: "`">
```

### lexer.parse.sort_by(&:pos)
Test that I added failed in ruby 2.5.0 and 2.6.0 without the third commit.
Result of `Ripper::Lexer.new("<<A\nA\n").parse` (used in < 2.7.0) is not ordered by position.
```
[#<struct Ripper::Lexer::Elem pos=[1, 0], event=:on_heredoc_beg, tok="<<A", state=EXPR_BEG>,
 #<struct Ripper::Lexer::Elem pos=[2, 0], event=:on_heredoc_end, tok="A\n", state=EXPR_BEG>,
 #<struct Ripper::Lexer::Elem pos=[1, 3], event=:on_nl, tok="\n", state=EXPR_BEG>]
```


