### PR TITLE
Fix colorize_code, fix irb crash.

### DIFF
--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -128,10 +128,14 @@ module IRB # :nodoc:
 
         symbol_state = SymbolState.new
         colored = +''
-        length = 0
-        end_seen = false
 
         scan(code, allow_last_error: !complete) do |token, str, expr|
+          # handle uncolorable code
+          if token.nil?
+            colored << Reline::Unicode.escape_for_print(str)
+            next
+          end
+
           # IRB::ColorPrinter skips colorizing fragments with any invalid token
           if ignore_error && ERROR_TOKENS.include?(token)
             return Reline::Unicode.escape_for_print(code)
@@ -147,15 +151,7 @@ module IRB # :nodoc:
               colored << line
             end
           end
-          length += str.bytesize
-          end_seen = true if token == :on___end__
         end
-
-        # give up colorizing incomplete Ripper tokens
-        unless end_seen or length == code.bytesize
-          return Reline::Unicode.escape_for_print(code)
-        end
-
         colored
       end
 
@@ -170,33 +166,38 @@ module IRB # :nodoc:
       end
 
       def scan(code, allow_last_error:)
-        pos = [1, 0]
-
         verbose, $VERBOSE = $VERBOSE, nil
         RubyLex.compile_with_errors_suppressed(code) do |inner_code, line_no|
           lexer = Ripper::Lexer.new(inner_code, '(ripper)', line_no)
+          byte_pos = 0
+          line_positions = [0]
+          inner_code.lines.each do |line|
+            line_positions << line_positions.last + line.bytesize
+          end
+
+          on_scan = proc do |elem|
+            str = elem.tok
+            start_pos = line_positions[elem.pos[0] - 1] + elem.pos[1]
+            end_pos = start_pos + str.bytesize
+            next if start_pos < byte_pos
+
+            yield(nil, inner_code.byteslice(byte_pos...start_pos), nil) if byte_pos < start_pos
+            yield(elem.event, str, elem.state)
+            byte_pos = end_pos
+          end
+
           if lexer.respond_to?(:scan) # Ruby 2.7+
             lexer.scan.each do |elem|
-              str = elem.tok
               next if allow_last_error and /meets end of file|unexpected end-of-input/ =~ elem.message
-              next if ([elem.pos[0], elem.pos[1] + str.bytesize] <=> pos) <= 0
-
-              str.each_line do |line|
-                if line.end_with?("\n")
-                  pos[0] += 1
-                  pos[1] = 0
-                else
-                  pos[1] += line.bytesize
-                end
-              end
-
-              yield(elem.event, str, elem.state)
+              on_scan.call(elem)
             end
           else
-            lexer.parse.each do |elem|
-              yield(elem.event, elem.tok, elem.state)
+            lexer.parse.sort_by(&:pos).each do |elem|
+              on_scan.call(elem)
             end
           end
+          # yield uncolorable DATA section
+          yield(nil, inner_code.byteslice(byte_pos...inner_code.bytesize), nil) if byte_pos < inner_code.bytesize
         end
       ensure
         $VERBOSE = verbose

--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -176,14 +176,18 @@ module IRB # :nodoc:
           end
 
           on_scan = proc do |elem|
-            str = elem.tok
             start_pos = line_positions[elem.pos[0] - 1] + elem.pos[1]
-            end_pos = start_pos + str.bytesize
-            next if start_pos < byte_pos
 
-            yield(nil, inner_code.byteslice(byte_pos...start_pos), nil) if byte_pos < start_pos
-            yield(elem.event, str, elem.state)
-            byte_pos = end_pos
+            # yield uncolorable code
+            if byte_pos < start_pos
+              yield(nil, inner_code.byteslice(byte_pos...start_pos), nil)
+            end
+
+            if byte_pos <= start_pos
+              str = elem.tok
+              yield(elem.event, str, elem.state)
+              byte_pos = start_pos + str.bytesize
+            end
           end
 
           if lexer.respond_to?(:scan) # Ruby 2.7+

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -90,6 +90,7 @@ module TestIRB
         "__END__" => "#{GREEN}__END__#{CLEAR}",
         "foo\n__END__\nbar" => "foo\n#{GREEN}__END__#{CLEAR}\nbar",
         "foo\n<<A\0\0bar\nA\nbaz" => "foo\n#{RED}<<A#{CLEAR}^@^@bar\n#{RED}A#{CLEAR}\nbaz",
+        "<<A+1\nA" => "#{RED}<<A#{CLEAR}+#{BLUE}#{BOLD}1#{CLEAR}\n#{RED}A#{CLEAR}",
       }
 
       # specific to Ruby 2.7+
@@ -114,11 +115,18 @@ module TestIRB
           "def req(@a) end" => "#{GREEN}def#{CLEAR} #{BLUE}#{BOLD}req#{CLEAR}(#{RED}#{REVERSE}@a#{CLEAR}) #{GREEN}end#{CLEAR}",
         })
       else
-        tests.merge!({
-          "[1]]]\u0013" => "[1]]]^S",
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+          tests.merge!({
+            "[1]]]\u0013" => "[#{BLUE}#{BOLD}1#{CLEAR}]#{RED}#{REVERSE}]#{CLEAR}]^S",
+            "def req(true) end" => "#{GREEN}def#{CLEAR} #{BLUE}#{BOLD}req#{CLEAR}(#{RED}#{REVERSE}true#{CLEAR}) end",
           })
+        else
+          tests.merge!({
+            "[1]]]\u0013" => "[#{BLUE}#{BOLD}1#{CLEAR}]]]^S",
+            "def req(true) end" => "#{GREEN}def#{CLEAR} #{BLUE}#{BOLD}req#{CLEAR}(#{CYAN}#{BOLD}true#{CLEAR}) end",
+          })
+        end
         tests.merge!({
-          "def req(true) end" => "def req(true) end",
           "nil = 1" => "#{CYAN}#{BOLD}nil#{CLEAR} = #{BLUE}#{BOLD}1#{CLEAR}",
           "alias $x $1" => "#{GREEN}alias#{CLEAR} #{GREEN}#{BOLD}$x#{CLEAR} $1",
           "class bad; end" => "#{GREEN}class#{CLEAR} bad; #{GREEN}end#{CLEAR}",

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -88,6 +88,8 @@ module TestIRB
         "foo(*%W(bar))" => "foo(*#{RED}#{BOLD}%W(#{CLEAR}#{RED}bar#{CLEAR}#{RED}#{BOLD})#{CLEAR})",
         "$stdout" => "#{GREEN}#{BOLD}$stdout#{CLEAR}",
         "__END__" => "#{GREEN}__END__#{CLEAR}",
+        "foo\n__END__\nbar" => "foo\n#{GREEN}__END__#{CLEAR}\nbar",
+        "foo\n<<A\0\0bar\nA\nbaz" => "foo\n#{RED}<<A#{CLEAR}^@^@bar\n#{RED}A#{CLEAR}\nbaz",
       }
 
       # specific to Ruby 2.7+


### PR DESCRIPTION
Fixed `IRB::Color.colorize_code` to fix irb crash.

irb crashes when I pasted the code below.
```ruby
__END__
foobar
```

```
/Users/tomoya/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/reline-0.3.1/lib/reline/line_editor.rb:1177:in `+': no implicit conversion of nil into String (TypeError)
	from /Users/tomoya/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/reline-0.3.1/lib/reline/line_editor.rb:1177:in `render_partial'
	from /Users/tomoya/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/reline-0.3.1/lib/reline/line_editor.rb:508:in `rerender'
```

`IRB::Color.colorize_code` did not colorized the DATA part, and `Reline.output_modifier_proc` returned too few lines, caused `string + nil` error.
IRB::Color.colorize_code must colorize all lines, and IMO, all characters.

Ripper.lex sometimes skips some characters.
```ruby
# "world" is skipped.
Ripper.lex("hello\n__END__\nworld").map{_3}.join #=> "hello\n__END__\n"
# "\0\0foo\n" and "bar" are skipped.
Ripper.lex("<<A\0\0foo\nA\nbar").map{_3}.join #=> "<<AA\n"
```
Since colorize_code is used in `ruby -run -e colorize`, ability to colorize every characters in a code that includes `"\0"` `"\4"` `"\32"` might be useful.
In this pull request, I changed `IRB::Color.scan` to also scan those skipped chars and include it in the colorized string.
