### PR TITLE
Drop hard dependency on RDoc.

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -14,7 +14,6 @@ require_relative 'magic-file'
 require_relative 'completion'
 require 'io/console'
 require 'reline'
-require 'rdoc'
 
 module IRB
   STDIN_FILE_NAME = "(line)" # :nodoc:


### PR DESCRIPTION
This has been introduced in 026700499dfd640b2072d7bf0370247a98d5ac40, but it seems that this is just be mistake, otherwise the later handling of `LoadError` would not be needed.

Of course I might misunderstand the code. But if that is the case, I still think that RDoc should not be loaded by default during startup, but later when really needed.