### PR TITLE
Require RDoc in `input-method.rb` again in a limited scope.

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -320,6 +320,11 @@ module IRB
         [195, 164], # The "ä" that appears when Alt+d is pressed on xterm.
         [226, 136, 130] # The "∂" that appears when Alt+d in pressed on iTerm2.
       ]
+      begin
+        require 'rdoc'
+      rescue LoadError
+        return nil
+      end
 
       if just_cursor_moving and completion_journey_data.nil?
         return nil


### PR DESCRIPTION
This PR is a follow up by https://github.com/ruby/irb/pull/393#issuecomment-1227362145.

RDoc is implemented as soft dependency in IRB. See how the rdoc is required in the files. I reverted the commit below.

```
$ grep -ril rdoc lib/
lib/irb/cmd/help.rb
lib/irb/completion.rb
lib/irb/easter-egg.rb
lib/irb/input-method.rb
```

Ideally I wanted to run test the case of 'no rdoc'  with the logic in `test/lib/helper.rb` below. But I couldn't do it. Perhaps the `Kernel#require` was overridden by Rubygems or Bundler in the process of running unit-test.

```
if ENV["NO_RDOC"] == "true"
  module Kernel
    alias_method :old_require, :require
    def require(name)
      raise LoadError, "cannot load such file -- rdoc (test)" if name == "rdoc"
      old_require(name)
    end
  end
end

require 'irb'
```

---

Revert "Remove `require` in signal handler to avoid ThreadError"

This reverts commit 5f749c613c895cf1b11b5e4cbd1205363bc58028.
