### PR TITLE
Always use local variables in current context to parse code

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -513,6 +513,7 @@ module IRB
             if IRB.conf[:MEASURE] && IRB.conf[:MEASURE_CALLBACKS].empty?
               IRB.set_measure_callback
             end
+            is_assignment = assignment_expression?(line)
             if IRB.conf[:MEASURE] && !IRB.conf[:MEASURE_CALLBACKS].empty?
               result = nil
               last_proc = proc{ result = @context.evaluate(line, line_no, exception: exc) }
@@ -529,7 +530,7 @@ module IRB
               @context.evaluate(line, line_no, exception: exc)
             end
             if @context.echo?
-              if assignment_expression?(line, context: @context)
+              if is_assignment
                 if @context.echo_on_assignment?
                   output_value(@context.echo_on_assignment? == :truncate)
                 end

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -828,7 +828,7 @@ module IRB
       # array of parsed expressions. The first element of each expression is the
       # expression's type.
       verbose, $VERBOSE = $VERBOSE, nil
-      code = "#{RubyLex.local_variables_assign_code(context: @context) || 'nil;'}\n#{line}"
+      code = "#{RubyLex.generate_local_variables_assign_code(context: @context) || 'nil;'}\n#{line}"
       node_type = Ripper.sexp(code)&.dig(1)&.drop(1)&.dig(-1, 0)
       result = ASSIGNMENT_NODE_TYPES.include?(node_type)
       $VERBOSE = verbose

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -529,7 +529,7 @@ module IRB
               @context.evaluate(line, line_no, exception: exc)
             end
             if @context.echo?
-              if assignment_expression?(line)
+              if assignment_expression?(line, context: @context)
                 if @context.echo_on_assignment?
                   output_value(@context.echo_on_assignment? == :truncate)
                 end
@@ -827,7 +827,9 @@ module IRB
       # array of parsed expressions. The first element of each expression is the
       # expression's type.
       verbose, $VERBOSE = $VERBOSE, nil
-      result = ASSIGNMENT_NODE_TYPES.include?(Ripper.sexp(line)&.dig(1,-1,0))
+      code = "#{RubyLex.local_variables_assign_code(context: @context) || 'nil;'}\n#{line}"
+      node_type = Ripper.sexp(code)&.dig(1)&.drop(1)&.dig(-1, 0)
+      result = ASSIGNMENT_NODE_TYPES.include?(node_type)
       $VERBOSE = verbose
       result
     end

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -513,6 +513,7 @@ module IRB
             if IRB.conf[:MEASURE] && IRB.conf[:MEASURE_CALLBACKS].empty?
               IRB.set_measure_callback
             end
+            # Assignment expression check should be done before @context.evaluate to handle code like `a /2#/ if false; a = 1`
             is_assignment = assignment_expression?(line)
             if IRB.conf[:MEASURE] && !IRB.conf[:MEASURE_CALLBACKS].empty?
               result = nil

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -506,7 +506,7 @@ module IRB
 
       @scanner.set_auto_indent(@context) if @context.auto_indent_mode
 
-      @scanner.each_top_level_statement do |line, line_no|
+      @scanner.each_top_level_statement(@context) do |line, line_no|
         signal_status(:IN_EVAL) do
           begin
             line.untaint if RUBY_VERSION < '2.7'

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -828,11 +828,12 @@ module IRB
       # array of parsed expressions. The first element of each expression is the
       # expression's type.
       verbose, $VERBOSE = $VERBOSE, nil
-      code = "#{RubyLex.generate_local_variables_assign_code(context: @context) || 'nil;'}\n#{line}"
+      code = "#{RubyLex.generate_local_variables_assign_code(@context.local_variables) || 'nil;'}\n#{line}"
+      # Get the last node_type of the line. drop(1) is to ignore the local_variables_assign_code part.
       node_type = Ripper.sexp(code)&.dig(1)&.drop(1)&.dig(-1, 0)
-      result = ASSIGNMENT_NODE_TYPES.include?(node_type)
+      ASSIGNMENT_NODE_TYPES.include?(node_type)
+    ensure
       $VERBOSE = verbose
-      result
     end
 
     ATTR_TTY = "\e[%sm"

--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -128,7 +128,7 @@ module IRB # :nodoc:
 
         symbol_state = SymbolState.new
         colored = +''
-        lvars_code = RubyLex.generate_local_variables_assign_code(local_variables: local_variables)
+        lvars_code = RubyLex.generate_local_variables_assign_code(local_variables)
         code_with_lvars = lvars_code ? "#{lvars_code}\n#{code}" : code
 
         scan(code_with_lvars, allow_last_error: !complete) do |token, str, expr|

--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -128,7 +128,7 @@ module IRB # :nodoc:
 
         symbol_state = SymbolState.new
         colored = +''
-        lvars_code = RubyLex.local_variables_assign_code(local_variables: local_variables)
+        lvars_code = RubyLex.generate_local_variables_assign_code(local_variables: local_variables)
         code_with_lvars = lvars_code ? "#{lvars_code}\n#{code}" : code
 
         scan(code_with_lvars, allow_last_error: !complete) do |token, str, expr|

--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -123,13 +123,15 @@ module IRB # :nodoc:
       # If `complete` is false (code is incomplete), this does not warn compile_error.
       # This option is needed to avoid warning a user when the compile_error is happening
       # because the input is not wrong but just incomplete.
-      def colorize_code(code, complete: true, ignore_error: false, colorable: colorable?)
+      def colorize_code(code, complete: true, ignore_error: false, colorable: colorable?, local_variables: [])
         return code unless colorable
 
         symbol_state = SymbolState.new
         colored = +''
+        lvars_code = RubyLex.local_variables_assign_code(local_variables: local_variables)
+        code_with_lvars = lvars_code ? "#{lvars_code}\n#{code}" : code
 
-        scan(code, allow_last_error: !complete) do |token, str, expr|
+        scan(code_with_lvars, allow_last_error: !complete) do |token, str, expr|
           # handle uncolorable code
           if token.nil?
             colored << Reline::Unicode.escape_for_print(str)
@@ -152,7 +154,12 @@ module IRB # :nodoc:
             end
           end
         end
-        colored
+
+        if lvars_code
+          colored.sub(/\A.+\n/, '')
+        else
+          colored
+        end
       end
 
       private

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -518,5 +518,9 @@ module IRB
     end
     alias __to_s__ to_s
     alias to_s inspect
+
+    def local_variables # :nodoc:
+      workspace.binding.local_variables
+    end
   end
 end

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -286,7 +286,7 @@ module IRB
         if IRB.conf[:USE_COLORIZE]
           proc do |output, complete: |
             next unless IRB::Color.colorable?
-            lvars = IRB.CurrentContext&.workspace&.binding&.local_variables || []
+            lvars = IRB.CurrentContext&.local_variables || []
             IRB::Color.colorize_code(output, complete: complete, local_variables: lvars)
           end
         else

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -286,7 +286,8 @@ module IRB
         if IRB.conf[:USE_COLORIZE]
           proc do |output, complete: |
             next unless IRB::Color.colorable?
-            IRB::Color.colorize_code(output, complete: complete)
+            lvars = IRB.CurrentContext&.workspace&.binding&.local_variables || []
+            IRB::Color.colorize_code(output, complete: complete, local_variables: lvars)
           end
         else
           proc do |output|

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -136,16 +136,20 @@ class RubyLex
     :on_param_error
   ]
 
+  def self.local_variables_assign_code(context: nil, local_variables: [])
+    context_local_variables = context&.workspace&.binding&.local_variables
+    local_variables |= context_local_variables if context_local_variables
+    "#{local_variables.join('=')}=nil;" unless local_variables.empty?
+  end
+
   def self.ripper_lex_without_warning(code, context: nil)
     verbose, $VERBOSE = $VERBOSE, nil
-    if context
-      lvars = context.workspace&.binding&.local_variables
-      if lvars && !lvars.empty?
-        code = "#{lvars.join('=')}=nil\n#{code}"
-        line_no = 0
-      else
-        line_no = 1
-      end
+    lvars_code = local_variables_assign_code(context: context)
+    if lvars_code
+      code = "#{lvars_code}\n#{code}"
+      line_no = 0
+    else
+      line_no = 1
     end
 
     compile_with_errors_suppressed(code, line_no: line_no) do |inner_code, line_no|
@@ -214,6 +218,8 @@ class RubyLex
     ltype = process_literal_type(tokens)
     indent = process_nesting_level(tokens)
     continue = process_continue(tokens)
+    lvars_code = self.class.local_variables_assign_code(context: context)
+    code = "#{lvars_code}\n#{code}" if lvars_code
     code_block_open = check_code_block(code, tokens)
     [ltype, indent, continue, code_block_open]
   end
@@ -269,18 +275,15 @@ class RubyLex
     end
   end
 
-  def lex
+  def lex(context: nil)
     line = @input.call
     if @io.respond_to?(:check_termination)
       return line # multiline
     end
     code = @line + (line.nil? ? '' : line)
     code.gsub!(/\s*\z/, '').concat("\n")
-    @tokens = self.class.ripper_lex_without_warning(code)
-    @continue = process_continue
-    @code_block_open = check_code_block(code)
-    @indent = process_nesting_level
-    @ltype = process_literal_type
+    @tokens = self.class.ripper_lex_without_warning(code, context: context)
+    @ltype, @indent, @continue, @code_block_open = check_state(code, @tokens, context: context)
     line
   end
 

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -136,15 +136,13 @@ class RubyLex
     :on_param_error
   ]
 
-  def self.generate_local_variables_assign_code(context: nil, local_variables: [])
-    context_local_variables = context&.workspace&.binding&.local_variables
-    local_variables |= context_local_variables if context_local_variables
+  def self.generate_local_variables_assign_code(local_variables)
     "#{local_variables.join('=')}=nil;" unless local_variables.empty?
   end
 
   def self.ripper_lex_without_warning(code, context: nil)
     verbose, $VERBOSE = $VERBOSE, nil
-    lvars_code = generate_local_variables_assign_code(context: context)
+    lvars_code = generate_local_variables_assign_code(context&.local_variables || [])
     if lvars_code
       code = "#{lvars_code}\n#{code}"
       line_no = 0
@@ -218,7 +216,7 @@ class RubyLex
     ltype = process_literal_type(tokens)
     indent = process_nesting_level(tokens)
     continue = process_continue(tokens)
-    lvars_code = self.class.generate_local_variables_assign_code(context: context)
+    lvars_code = self.class.generate_local_variables_assign_code(context&.local_variables || [])
     code = "#{lvars_code}\n#{code}" if lvars_code
     code_block_open = check_code_block(code, tokens)
     [ltype, indent, continue, code_block_open]

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -239,13 +239,13 @@ class RubyLex
     @code_block_open = false
   end
 
-  def each_top_level_statement
+  def each_top_level_statement(context)
     initialize_input
     catch(:TERM_INPUT) do
       loop do
         begin
           prompt
-          unless l = lex
+          unless l = lex(context)
             throw :TERM_INPUT if @line == ''
           else
             @line_no += l.count("\n")
@@ -275,7 +275,7 @@ class RubyLex
     end
   end
 
-  def lex(context: nil)
+  def lex(context)
     line = @input.call
     if @io.respond_to?(:check_termination)
       return line # multiline

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -136,7 +136,7 @@ class RubyLex
     :on_param_error
   ]
 
-  def self.local_variables_assign_code(context: nil, local_variables: [])
+  def self.generate_local_variables_assign_code(context: nil, local_variables: [])
     context_local_variables = context&.workspace&.binding&.local_variables
     local_variables |= context_local_variables if context_local_variables
     "#{local_variables.join('=')}=nil;" unless local_variables.empty?
@@ -144,7 +144,7 @@ class RubyLex
 
   def self.ripper_lex_without_warning(code, context: nil)
     verbose, $VERBOSE = $VERBOSE, nil
-    lvars_code = local_variables_assign_code(context: context)
+    lvars_code = generate_local_variables_assign_code(context: context)
     if lvars_code
       code = "#{lvars_code}\n#{code}"
       line_no = 0
@@ -218,7 +218,7 @@ class RubyLex
     ltype = process_literal_type(tokens)
     indent = process_nesting_level(tokens)
     continue = process_continue(tokens)
-    lvars_code = self.class.local_variables_assign_code(context: context)
+    lvars_code = self.class.generate_local_variables_assign_code(context: context)
     code = "#{lvars_code}\n#{code}" if lvars_code
     code_block_open = check_code_block(code, tokens)
     [ltype, indent, continue, code_block_open]

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -155,6 +155,17 @@ module TestIRB
       end
     end
 
+    def test_colorize_code_with_local_variables
+      code = "a /(b +1)/i"
+      result_without_lvars = "a #{RED}#{BOLD}/#{CLEAR}#{RED}(b +1)#{CLEAR}#{RED}#{BOLD}/i#{CLEAR}"
+      result_with_lvar = "a /(b #{BLUE}#{BOLD}+1#{CLEAR})/i"
+      result_with_lvars = "a /(b +#{BLUE}#{BOLD}1#{CLEAR})/i"
+
+      assert_equal_with_term(result_without_lvars, code)
+      assert_equal_with_term(result_with_lvar, code, local_variables: ['a'])
+      assert_equal_with_term(result_with_lvars, code, local_variables: ['a', 'b'])
+    end
+
     def test_colorize_code_complete_true
       unless complete_option_supported?
         pend '`complete: true` is the same as `complete: false` in Ruby 2.6-'

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -225,6 +225,16 @@ module TestIRB
       end
     end
 
+    def test_assignment_expression_with_local_variable
+      input = TestInputMethod.new
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      code = "a /1;x=1#/"
+      refute(irb.assignment_expression?(code), "#{code}: should not be an assignment expression")
+      irb.context.workspace.binding.eval('a = 1')
+      assert(irb.assignment_expression?(code), "#{code}: should be an assignment expression")
+      refute(irb.assignment_expression?(""), "empty code should not be an assignment expression")
+    end
+
     def test_echo_on_assignment
       input = TestInputMethod.new([
         "a = 1\n",

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -51,9 +51,7 @@ module TestIRB
       io = proc{ lines.join("\n") }
       ruby_lex.set_input(io, io)
       unless local_variables.empty?
-        binding = OpenStruct.new(local_variables: local_variables)
-        workspace = OpenStruct.new(binding: binding)
-        context = OpenStruct.new(workspace: workspace)
+        context = OpenStruct.new(local_variables: local_variables)
       end
       ruby_lex.lex(context)
       ruby_lex

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -497,6 +497,7 @@ module TestIRB
     end
 
     def test_local_variables_dependent_code
+      pend if RUBY_ENGINE == 'truffleruby'
       lines = ["a /1#/ do", "2"]
       assert_nesting_level(lines, 1)
       assert_code_block_open(lines, true)

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -55,7 +55,7 @@ module TestIRB
         workspace = OpenStruct.new(binding: binding)
         context = OpenStruct.new(workspace: workspace)
       end
-      ruby_lex.lex(context: context)
+      ruby_lex.lex(context)
       ruby_lex
     end
 

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -216,6 +216,25 @@ begin
       EOC
     end
 
+    def test_assignment_expression_truncate
+      write_irbrc <<~'LINES'
+        puts 'start IRB'
+      LINES
+      start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+      # Assignment expression code that turns into non-assignment expression after evaluation
+      code = "a /'/i if false; a=1; x=1000.times.to_a#'.size"
+      write(code + "\n")
+      close
+      assert_screen(<<~EOC)
+        start IRB
+        irb(main):001:0> #{code}
+        =>
+        [0,
+        ...
+        irb(main):002:0>
+      EOC
+    end
+
     private def write_irbrc(content)
       File.open(@irbrc_file, 'w') do |f|
         f.write content


### PR DESCRIPTION
Ruby will parse differently depending on defined local_variables.
```ruby
a = 1
a +1 # a + 1
b +1 # b(+1)
a *a # a * a
b *b # b(*b)
a **a # a ** a
b **b # b(**b)
a %(1) # a % 1
b %(1) # b("1")
a /1/i # a / 1 / i
b /1/i # b(regexp)
```
Therefore coloring, indent, `code_block_open` and `assignment_expression?` needs local_variables in current context.

### assignment expression check

The code below is an assignment expression and the evaluated result (large array) should be truncated.
```ruby
a /"/i if false; a=1; x=1000.times.to_a#".size
```
But once it is evaluated, it turns into a division expression(`a / "string".size`).
Assignment expression check should be done before evaluation.

### semicolon and newline character
There are `;\n` in the code to be parsed. `"a=b=nil;\n#{original_code}"`
Without `\n`, syntax valid code `=begin\n=end` will be syntax error.
Without `;`, `.to_s` will wrongly be syntax ok.
