### PR TITLE
Fix: cannot paste code correctly when it contains heredoc 

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -152,17 +152,13 @@ class RubyLex
       lexer = Ripper::Lexer.new(inner_code, '-', line_no)
       if lexer.respond_to?(:scan) # Ruby 2.7+
         tokens = []
-        pos_to_index = {}
         lexer.scan.each do |t|
           next if t.pos.first == 0
-          if pos_to_index.has_key?(t.pos)
-            index = pos_to_index[t.pos]
-            found_tk = tokens[index]
-            if ERROR_TOKENS.include?(found_tk.event) && !ERROR_TOKENS.include?(t.event)
-              tokens[index] = t
-            end
+          prev_tk = tokens.last
+          position_overlapped = prev_tk && t.pos[0] == prev_tk.pos[0] && t.pos[1] < prev_tk.pos[1] + prev_tk.tok.bytesize
+          if position_overlapped
+            tokens[-1] = t if ERROR_TOKENS.include?(prev_tk.event) && !ERROR_TOKENS.include?(t.event)
           else
-            pos_to_index[t.pos] = tokens.size
             tokens << t
           end
         end

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -619,5 +619,18 @@ module TestIRB
         pos_to_index[t.pos] = i
       }
     end
+
+    def test_unterminated_code
+      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
+        pend 'This test needs Ripper::Lexer#scan to take broken tokens'
+      end
+
+      ['do', '<<A'].each do |code|
+        tokens = RubyLex.ripper_lex_without_warning(code)
+        assert_equal(code, tokens.map(&:tok).join, "Cannot reconstruct code from tokens")
+        error_tokens = tokens.map(&:event).grep(/error/)
+        assert_empty(error_tokens, 'Error tokens must be ignored if there is corresponding non-error token')
+      end
+    end
   end
 end


### PR DESCRIPTION
### Problem
When I paste the code below,
```
123
<<EOS
EOS
```
I got
```
irb(main):001:0> 123
=> 123
irb(main):002:0" <<EOSEOS
irb(main):003:0" EOS
irb(main):004:0" 
```

RubyLex.ripper_lex_without_warning tries to ignore error tokens if possible, but the current implementation fails with `<<EOS`
```ruby
RubyLex.ripper_lex_without_warning('<<EOS').map(&:tok)
#=> ["<<EOS", "EOS"] # should be ["<<EOS"]
```

### Changes
Result of `lexer.scan` are sorted by pos, so we only need to look at prev token.
If there is overlap, error token should be ignored.
In the original code, it does not check overlap, but checks if start positions are the same
