### PR TITLE
Fix #295: Ignore Java package reference objects in JRuby

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -329,6 +329,7 @@ module IRB
           to_ignore = ignored_modules
           ObjectSpace.each_object(Module){|m|
             next if (to_ignore.include?(m) rescue true)
+            next unless m.respond_to?(:instance_methods) # JRuby has modules that represent java packages. They don't include many common ruby methods
             candidates.concat m.instance_methods(false).collect{|x| x.to_s}
           }
           candidates.sort!


### PR DESCRIPTION
Ignore modules that don't have instance_methods on them. The same logic can be found in Pry to accommodate core JRuby features. Fixes #295 