### PR TITLE
Remove unnecessary Thread presence check

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -389,11 +389,7 @@ module IRB
   #
   # Will raise an Abort exception, or the given +exception+.
   def IRB.irb_abort(irb, exception = Abort)
-    if defined? Thread
-      irb.context.thread.raise exception, "abort then interrupt!"
-    else
-      raise exception, "abort then interrupt!"
-    end
+    irb.context.thread.raise exception, "abort then interrupt!"
   end
 
   class Irb

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -32,7 +32,7 @@ module IRB
       else
         @workspace = WorkSpace.new
       end
-      @thread = Thread.current if defined? Thread
+      @thread = Thread.current
 
       # copy of default configuration
       @ap_name = IRB.conf[:AP_NAME]

--- a/lib/irb/ext/multi-irb.rb
+++ b/lib/irb/ext/multi-irb.rb
@@ -9,7 +9,6 @@
 #
 #
 #
-fail CantShiftToMultiIrbMode unless defined?(Thread)
 
 module IRB
   class JobManager

--- a/lib/irb/lc/error.rb
+++ b/lib/irb/lc/error.rb
@@ -48,11 +48,6 @@ module IRB
       super("No such job(#{val}).")
     end
   end
-  class CantShiftToMultiIrbMode < StandardError
-    def initialize
-      super("Can't shift to multi irb mode.")
-    end
-  end
   class CantChangeBinding < StandardError
     def initialize(val)
       super("Can't change binding to (#{val}).")

--- a/lib/irb/lc/ja/error.rb
+++ b/lib/irb/lc/ja/error.rb
@@ -48,11 +48,6 @@ module IRB
       super("そのようなジョブ(#{val})はありません.")
     end
   end
-  class CantShiftToMultiIrbMode < StandardError
-    def initialize
-      super("multi-irb modeに移れません.")
-    end
-  end
   class CantChangeBinding < StandardError
     def initialize(val)
       super("バインディング(#{val})に変更できません.")


### PR DESCRIPTION
They were introduced around 20 years ago ([example](https://github.com/ruby/irb/commit/8c2a0d89a9865ced0b783655e9eedde0e4c07e50#diff-bbbabb67744c191e5033dbc04e3954c48ff5b7923362892034fb1f98ed57e68dR12)), when Thread is not yet stabilized. So we don't need them anymore.