### PR TITLE
Bump version to 1.4.2

### DIFF
--- a/lib/irb/version.rb
+++ b/lib/irb/version.rb
@@ -11,7 +11,7 @@
 #
 
 module IRB # :nodoc:
-  VERSION = "1.4.1"
+  VERSION = "1.4.2"
   @RELEASE_VERSION = VERSION
-  @LAST_UPDATE_DATE = "2021-12-25"
+  @LAST_UPDATE_DATE = "2022-10-03"
 end


### PR DESCRIPTION
Since there's been a couple of crashing fixes merged after `v1.4.1`, like:

- https://github.com/ruby/irb/pull/353
- https://github.com/ruby/irb/pull/369
- https://github.com/ruby/irb/pull/391
- https://github.com/ruby/irb/pull/400

I think it'd be great if we can cut a patch release for them.

From the [diff between current master and `v1.4.1`](https://github.com/ruby/irb/compare/v1.4.1...master), all PRs are either fixes, refactorings, or document updates. 