### PR TITLE
Rename IDB::ReidlineInputMethod to IRB::RelineInputMethod

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -13,7 +13,7 @@ irb(main):001:0> irb_info
 =>
 Ruby version: 3.0.0
 IRB version: irb 1.2.7 (2020-09-19)
-InputMethod: ReidlineInputMethod with Reline 0.1.9 and /home/aycabta/.inputrc
+InputMethod: RelineInputMethod with Reline 0.1.9 and /home/aycabta/.inputrc
 .irbrc path: /home/aycabta/.irbrc
 ```
 

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -22,7 +22,7 @@ module IRB
     #
     # The optional +input_method+ argument:
     #
-    # +nil+::     uses stdin or Reidline or Readline
+    # +nil+::     uses stdin or Reline or Readline
     # +String+::  uses a File
     # +other+::   uses this as InputMethod
     def initialize(irb, workspace = nil, input_method = nil)
@@ -48,8 +48,13 @@ module IRB
       end
       if IRB.conf.has_key?(:USE_MULTILINE)
         @use_multiline = IRB.conf[:USE_MULTILINE]
-      elsif IRB.conf.has_key?(:USE_REIDLINE) # backward compatibility
-        @use_multiline = IRB.conf[:USE_REIDLINE]
+      elsif IRB.conf.has_key?(:USE_RELINE) # backward compatibility
+        @use_multiline = IRB.conf[:USE_RELINE]
+      elsif IRB.conf.has_key?(:USE_REIDLINE)
+        warn <<~MSG.strip
+          USE_REIDLINE is deprecated, please use USE_RELINE instead.
+        MSG
+        @use_multiline = IRB.conf[:USE_RELINE]
       else
         @use_multiline = nil
       end
@@ -83,14 +88,14 @@ module IRB
         when nil
           if STDIN.tty? && IRB.conf[:PROMPT_MODE] != :INF_RUBY && !use_singleline?
             # Both of multiline mode and singleline mode aren't specified.
-            @io = ReidlineInputMethod.new
+            @io = RelineInputMethod.new
           else
             @io = nil
           end
         when false
           @io = nil
         when true
-          @io = ReidlineInputMethod.new
+          @io = RelineInputMethod.new
         end
         unless @io
           case use_singleline?
@@ -160,7 +165,7 @@ module IRB
     # The current input method.
     #
     # Can be either StdioInputMethod, ReadlineInputMethod,
-    # ReidlineInputMethod, FileInputMethod or other specified when the
+    # RelineInputMethod, FileInputMethod or other specified when the
     # context is created. See ::new for more # information on +input_method+.
     attr_accessor :io
 
@@ -326,9 +331,9 @@ module IRB
     # Alias for #use_singleline
     alias use_singleline? use_singleline
     # backward compatibility
-    alias use_reidline use_multiline
+    alias use_reline use_multiline
     # backward compatibility
-    alias use_reidline? use_multiline
+    alias use_reline? use_multiline
     # backward compatibility
     alias use_readline use_singleline
     # backward compatibility
@@ -346,7 +351,7 @@ module IRB
     # Returns whether messages are displayed or not.
     def verbose?
       if @verbose.nil?
-        if @io.kind_of?(ReidlineInputMethod)
+        if @io.kind_of?(RelineInputMethod)
           false
         elsif defined?(ReadlineInputMethod) && @io.kind_of?(ReadlineInputMethod)
           false
@@ -361,11 +366,11 @@ module IRB
     end
 
     # Whether #verbose? is +true+, and +input_method+ is either
-    # StdioInputMethod or ReidlineInputMethod or ReadlineInputMethod, see #io
+    # StdioInputMethod or RelineInputMethod or ReadlineInputMethod, see #io
     # for more information.
     def prompting?
       verbose? || (STDIN.tty? && @io.kind_of?(StdioInputMethod) ||
-                   @io.kind_of?(ReidlineInputMethod) ||
+                   @io.kind_of?(RelineInputMethod) ||
                    (defined?(ReadlineInputMethod) && @io.kind_of?(ReadlineInputMethod)))
     end
 

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -261,7 +261,7 @@ module IRB
     end
   end
 
-  class ReidlineInputMethod < InputMethod
+  class RelineInputMethod < InputMethod
     include Reline
 
     # Creates a new input method object using Reline
@@ -468,6 +468,15 @@ module IRB
       end
       str += " and #{inputrc_path}" if File.exist?(inputrc_path)
       str
+    end
+  end
+
+  class ReidlineInputMethod < RelineInputMethod
+    def initialize
+      warn <<~MSG.strip
+        IRB::ReidlineInputMethod is deprecated, please use IRB::RelineInputMethod instead.
+      MSG
+      super
     end
   end
 end


### PR DESCRIPTION
Deprecates IDB::ReidlineInputMethod and USE_REIDLINE in favor of IRB::RelineInputMethod and USE_RELINE. The Input method uses Reline to read input from the console, so it can be named directly after the Reline library like other inputs methods are (Readline, Stdio, etc.).