### PR TITLE
Use USE_REIDLINE for backward compatibility

### DIFF
--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -54,7 +54,7 @@ module IRB
         warn <<~MSG.strip
           USE_REIDLINE is deprecated, please use USE_RELINE instead.
         MSG
-        @use_multiline = IRB.conf[:USE_RELINE]
+        @use_multiline = IRB.conf[:USE_REIDLINE]
       else
         @use_multiline = nil
       end


### PR DESCRIPTION
https://github.com/ruby/irb/pull/409#discussion_r987719287