### PR TITLE
Rename leftover reidline references

### DIFF
--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -49,10 +49,13 @@ module IRB
       if IRB.conf.has_key?(:USE_MULTILINE)
         @use_multiline = IRB.conf[:USE_MULTILINE]
       elsif IRB.conf.has_key?(:USE_RELINE) # backward compatibility
+        warn <<~MSG.strip
+          USE_RELINE is deprecated, please use USE_MULTILINE instead.
+        MSG
         @use_multiline = IRB.conf[:USE_RELINE]
       elsif IRB.conf.has_key?(:USE_REIDLINE)
         warn <<~MSG.strip
-          USE_REIDLINE is deprecated, please use USE_RELINE instead.
+          USE_REIDLINE is deprecated, please use USE_MULTILINE instead.
         MSG
         @use_multiline = IRB.conf[:USE_REIDLINE]
       else

--- a/lib/irb/ext/save-history.rb
+++ b/lib/irb/ext/save-history.rb
@@ -73,7 +73,7 @@ module IRB
         open(history_file, "r:#{IRB.conf[:LC_MESSAGES].encoding}") do |f|
           f.each { |l|
             l = l.chomp
-            if self.class == ReidlineInputMethod and history.last&.end_with?("\\")
+            if self.class == RelineInputMethod and history.last&.end_with?("\\")
               history.last.delete_suffix!("\\")
               history.last << "\n" << l
             else

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -260,8 +260,20 @@ module IRB # :nodoc:
       when "--nosingleline", "--noreadline"
         @CONF[:USE_SINGLELINE] = false
       when "--multiline", "--reidline"
+        if opt == "--reidline"
+          warn <<~MSG.strip
+            --reidline is deprecated, please use --multiline instead.
+          MSG
+        end
+
         @CONF[:USE_MULTILINE] = true
       when "--nomultiline", "--noreidline"
+        if opt == "--noreidline"
+          warn <<~MSG.strip
+            --noreidline is deprecated, please use --nomultiline instead.
+          MSG
+        end
+
         @CONF[:USE_MULTILINE] = false
       when /^--extra-doc-dir(?:=(.+))?/
         opt = $1 || argv.shift

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -461,7 +461,7 @@ module IRB
     # For debug message
     def inspect
       config = Reline::Config.new
-      str = "ReidlineInputMethod with Reline #{Reline::VERSION}"
+      str = "RelineInputMethod with Reline #{Reline::VERSION}"
       if config.respond_to?(:inputrc_path)
         inputrc_path = File.expand_path(config.inputrc_path)
       else


### PR DESCRIPTION
I cleaned up a few remaining `reidline` references.

Also, based on https://github.com/ruby/irb/commit/93f87ec65344b44123b0150a5fc07de1fd4c80c4, it appears that the maintainer @aycabta wanted to deprecate any `USE_*LINE` configs in favor of `USE_MULTILINE`. So we should deprecate `USE_RELINE` as well.