### PR TITLE
Increase completion's test coverage and add some minor improvements

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -255,7 +255,7 @@ module IRB
             candidates = []
           end
 
-          select_message(receiver, message, candidates, "::")
+          select_message(receiver, message, candidates.sort, "::")
         end
 
       when /^(:[^:.]+)(\.|::)([^.]*)$/

--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -171,10 +171,10 @@ module IRB
         receiver = $1
         message = $3
 
-        candidates = String.instance_methods.collect{|m| m.to_s}
         if doc_namespace
           "String.#{message}"
         else
+          candidates = String.instance_methods.collect{|m| m.to_s}
           select_message(receiver, message, candidates)
         end
 
@@ -183,10 +183,10 @@ module IRB
         receiver = $1
         message = $2
 
-        candidates = Regexp.instance_methods.collect{|m| m.to_s}
         if doc_namespace
           "Regexp.#{message}"
         else
+          candidates = Regexp.instance_methods.collect{|m| m.to_s}
           select_message(receiver, message, candidates)
         end
 
@@ -195,10 +195,10 @@ module IRB
         receiver = $1
         message = $2
 
-        candidates = Array.instance_methods.collect{|m| m.to_s}
         if doc_namespace
           "Array.#{message}"
         else
+          candidates = Array.instance_methods.collect{|m| m.to_s}
           select_message(receiver, message, candidates)
         end
 
@@ -207,29 +207,33 @@ module IRB
         receiver = $1
         message = $2
 
-        proc_candidates = Proc.instance_methods.collect{|m| m.to_s}
-        hash_candidates = Hash.instance_methods.collect{|m| m.to_s}
         if doc_namespace
           ["Proc.#{message}", "Hash.#{message}"]
         else
+          proc_candidates = Proc.instance_methods.collect{|m| m.to_s}
+          hash_candidates = Hash.instance_methods.collect{|m| m.to_s}
           select_message(receiver, message, proc_candidates | hash_candidates)
         end
 
       when /^(:[^:.]*)$/
         # Symbol
-        return nil if doc_namespace
-        sym = $1
-        candidates = Symbol.all_symbols.collect do |s|
-          ":" + s.id2name.encode(Encoding.default_external)
-        rescue EncodingError
-          # ignore
+        if doc_namespace
+          nil
+        else
+          sym = $1
+          candidates = Symbol.all_symbols.collect do |s|
+            ":" + s.id2name.encode(Encoding.default_external)
+          rescue EncodingError
+            # ignore
+          end
+          candidates.grep(/^#{Regexp.quote(sym)}/)
         end
-        candidates.grep(/^#{Regexp.quote(sym)}/)
-
       when /^::([A-Z][^:\.\(\)]*)$/
         # Absolute Constant or class methods
         receiver = $1
+
         candidates = Object.constants.collect{|m| m.to_s}
+
         if doc_namespace
           candidates.find { |i| i == receiver }
         else
@@ -240,15 +244,17 @@ module IRB
         # Constant or class methods
         receiver = $1
         message = $2
-        begin
-          candidates = eval("#{receiver}.constants.collect{|m| m.to_s}", bind)
-          candidates |= eval("#{receiver}.methods.collect{|m| m.to_s}", bind)
-        rescue Exception
-          candidates = []
-        end
+
         if doc_namespace
           "#{receiver}::#{message}"
         else
+          begin
+            candidates = eval("#{receiver}.constants.collect{|m| m.to_s}", bind)
+            candidates |= eval("#{receiver}.methods.collect{|m| m.to_s}", bind)
+          rescue Exception
+            candidates = []
+          end
+
           select_message(receiver, message, candidates, "::")
         end
 
@@ -258,10 +264,10 @@ module IRB
         sep = $2
         message = $3
 
-        candidates = Symbol.instance_methods.collect{|m| m.to_s}
         if doc_namespace
           "Symbol.#{message}"
         else
+          candidates = Symbol.instance_methods.collect{|m| m.to_s}
           select_message(receiver, message, candidates, sep)
         end
 
@@ -273,6 +279,7 @@ module IRB
 
         begin
           instance = eval(receiver, bind)
+
           if doc_namespace
             "#{instance.class.name}.#{message}"
           else
@@ -283,7 +290,7 @@ module IRB
           if doc_namespace
             nil
           else
-            candidates = []
+            []
           end
         end
 
@@ -305,7 +312,7 @@ module IRB
           if doc_namespace
             nil
           else
-            candidates = []
+            []
           end
         end
 
@@ -313,6 +320,7 @@ module IRB
         # global var
         gvar = $1
         all_gvars = global_variables.collect{|m| m.to_s}
+
         if doc_namespace
           all_gvars.find{ |i| i == gvar }
         else
@@ -356,6 +364,7 @@ module IRB
           candidates.sort!
           candidates.uniq!
         end
+
         if doc_namespace
           rec_class = rec.is_a?(Module) ? rec : rec.class
           "#{rec_class.name}#{sep}#{candidates.find{ |i| i == message }}"
@@ -370,6 +379,7 @@ module IRB
         message = $1
 
         candidates = String.instance_methods(true).collect{|m| m.to_s}
+
         if doc_namespace
           "String.#{candidates.find{ |i| i == message }}"
         else

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -30,50 +30,50 @@ module TestIRB
     class TestMethodCompletion < TestCompletion
       def test_complete_string
         assert_include(IRB::InputCompletor.retrieve_completion_data("'foo'.up", bind: binding), "'foo'.upcase")
-        assert_equal(IRB::InputCompletor.retrieve_completion_data("'foo'.upcase", bind: binding, doc_namespace: true), "String.upcase")
+        assert_equal("String.upcase", IRB::InputCompletor.retrieve_completion_data("'foo'.upcase", bind: binding, doc_namespace: true))
       end
 
       def test_complete_regexp
         assert_include(IRB::InputCompletor.retrieve_completion_data("/foo/.ma", bind: binding), "/foo/.match")
-        assert_equal(IRB::InputCompletor.retrieve_completion_data("/foo/.match", bind: binding, doc_namespace: true), "Regexp.match")
+        assert_equal("Regexp.match", IRB::InputCompletor.retrieve_completion_data("/foo/.match", bind: binding, doc_namespace: true))
       end
 
       def test_complete_array
         assert_include(IRB::InputCompletor.retrieve_completion_data("[].an", bind: binding), "[].any?")
-        assert_equal(IRB::InputCompletor.retrieve_completion_data("[].any?", bind: binding, doc_namespace: true), "Array.any?")
+        assert_equal("Array.any?", IRB::InputCompletor.retrieve_completion_data("[].any?", bind: binding, doc_namespace: true))
       end
 
       def test_complete_hash_and_proc
         # hash
         assert_include(IRB::InputCompletor.retrieve_completion_data("{}.an", bind: binding), "{}.any?")
-        assert_include(IRB::InputCompletor.retrieve_completion_data("{}.any?", bind: binding, doc_namespace: true), "Proc.any?", "Hash.any?")
+        assert_equal(["Proc.any?", "Hash.any?"], IRB::InputCompletor.retrieve_completion_data("{}.any?", bind: binding, doc_namespace: true))
 
         # proc
         assert_include(IRB::InputCompletor.retrieve_completion_data("{}.bin", bind: binding), "{}.binding")
-        assert_include(IRB::InputCompletor.retrieve_completion_data("{}.binding", bind: binding, doc_namespace: true), "Proc.binding", "Hash.binding")
+        assert_equal(["Proc.binding", "Hash.binding"], IRB::InputCompletor.retrieve_completion_data("{}.binding", bind: binding, doc_namespace: true))
       end
 
       def test_complete_numeric
         assert_include(IRB::InputCompletor.retrieve_completion_data("1.positi", bind: binding), "1.positive?")
-        assert_equal(IRB::InputCompletor.retrieve_completion_data("1.positive?", bind: binding, doc_namespace: true), "Integer.positive?")
+        assert_equal("Integer.positive?", IRB::InputCompletor.retrieve_completion_data("1.positive?", bind: binding, doc_namespace: true))
 
         assert_include(IRB::InputCompletor.retrieve_completion_data("1r.positi", bind: binding), "1r.positive?")
-        assert_equal(IRB::InputCompletor.retrieve_completion_data("1r.positive?", bind: binding, doc_namespace: true), "Rational.positive?")
+        assert_equal("Rational.positive?", IRB::InputCompletor.retrieve_completion_data("1r.positive?", bind: binding, doc_namespace: true))
 
         assert_include(IRB::InputCompletor.retrieve_completion_data("0xFFFF.positi", bind: binding), "0xFFFF.positive?")
-        assert_equal(IRB::InputCompletor.retrieve_completion_data("0xFFFF.positive?", bind: binding, doc_namespace: true), "Integer.positive?")
+        assert_equal("Integer.positive?", IRB::InputCompletor.retrieve_completion_data("0xFFFF.positive?", bind: binding, doc_namespace: true))
 
         assert_empty(IRB::InputCompletor.retrieve_completion_data("1i.positi", bind: binding))
       end
 
       def test_complete_symbol
         assert_include(IRB::InputCompletor.retrieve_completion_data(":foo.to_p", bind: binding), ":foo.to_proc")
-        assert_equal(IRB::InputCompletor.retrieve_completion_data(":foo.to_proc", bind: binding, doc_namespace: true), "Symbol.to_proc")
+        assert_equal("Symbol.to_proc", IRB::InputCompletor.retrieve_completion_data(":foo.to_proc", bind: binding, doc_namespace: true))
       end
 
       def test_complete_class
         assert_include(IRB::InputCompletor.retrieve_completion_data("String.ne", bind: binding), "String.new")
-        assert_equal(IRB::InputCompletor.retrieve_completion_data("String.new", bind: binding, doc_namespace: true), "String.new")
+        assert_equal("String.new", IRB::InputCompletor.retrieve_completion_data("String.new", bind: binding, doc_namespace: true))
       end
     end
 
@@ -174,12 +174,12 @@ module TestIRB
         instance_variables.clear
 
         assert_include(IRB::InputCompletor.retrieve_completion_data("str_examp", bind: binding), "str_example")
-        assert_equal(IRB::InputCompletor.retrieve_completion_data("str_example", bind: binding, doc_namespace: true), "String")
-        assert_equal(IRB::InputCompletor.retrieve_completion_data("str_example.to_s", bind: binding, doc_namespace: true), "String.to_s")
+        assert_equal("String", IRB::InputCompletor.retrieve_completion_data("str_example", bind: binding, doc_namespace: true))
+        assert_equal("String.to_s", IRB::InputCompletor.retrieve_completion_data("str_example.to_s", bind: binding, doc_namespace: true))
 
         assert_include(IRB::InputCompletor.retrieve_completion_data("@str_examp", bind: binding), "@str_example")
-        assert_equal(IRB::InputCompletor.retrieve_completion_data("@str_example", bind: binding, doc_namespace: true), "String")
-        assert_equal(IRB::InputCompletor.retrieve_completion_data("@str_example.to_s", bind: binding, doc_namespace: true), "String.to_s")
+        assert_equal("String", IRB::InputCompletor.retrieve_completion_data("@str_example", bind: binding, doc_namespace: true))
+        assert_equal("String.to_s", IRB::InputCompletor.retrieve_completion_data("@str_example.to_s", bind: binding, doc_namespace: true))
       end
 
       def test_complete_sort_variables
@@ -190,7 +190,7 @@ module TestIRB
         xzy2.clear
 
         candidates = IRB::InputCompletor.retrieve_completion_data("xz", bind: binding, doc_namespace: false)
-        assert_equal(candidates, %w[xzy xzy2 xzy_1])
+        assert_equal(%w[xzy xzy2 xzy_1], candidates)
       end
     end
 

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -194,6 +194,22 @@ module TestIRB
       end
     end
 
+    class TestConstantCompletion < TestCompletion
+      class Foo
+        B1 = 1
+        B2 = 2
+      end
+
+      def test_complete_constants
+        assert_equal(["Foo"], IRB::InputCompletor.retrieve_completion_data("Fo", bind: binding))
+        assert_equal(["Foo::B1", "Foo::B2"], IRB::InputCompletor.retrieve_completion_data("Foo::B", bind: binding))
+        assert_equal(["Foo::B1.positive?"], IRB::InputCompletor.retrieve_completion_data("Foo::B1.pos", bind: binding))
+
+        assert_equal(["::Forwardable"], IRB::InputCompletor.retrieve_completion_data("::Fo", bind: binding))
+        assert_equal("Forwardable", IRB::InputCompletor.retrieve_completion_data("::Forwardable", bind: binding, doc_namespace: true))
+      end
+    end
+
     def test_complete_symbol
       %w"UTF-16LE UTF-7".each do |enc|
         "K".force_encoding(enc).to_sym

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -196,13 +196,14 @@ module TestIRB
 
     class TestConstantCompletion < TestCompletion
       class Foo
+        B3 = 1
         B1 = 1
-        B2 = 2
+        B2 = 1
       end
 
       def test_complete_constants
         assert_equal(["Foo"], IRB::InputCompletor.retrieve_completion_data("Fo", bind: binding))
-        assert_equal(["Foo::B1", "Foo::B2"], IRB::InputCompletor.retrieve_completion_data("Foo::B", bind: binding))
+        assert_equal(["Foo::B1", "Foo::B2", "Foo::B3"], IRB::InputCompletor.retrieve_completion_data("Foo::B", bind: binding))
         assert_equal(["Foo::B1.positive?"], IRB::InputCompletor.retrieve_completion_data("Foo::B1.pos", bind: binding))
 
         assert_equal(["::Forwardable"], IRB::InputCompletor.retrieve_completion_data("::Fo", bind: binding))


### PR DESCRIPTION
## Changes

1. Add tests to cover primitive types' completion
2. Group some completion tests together
3. Evaluate completion candidates only when we really need them (usually when `doc_namespace == false`)
4. Correct `assert_equal`'s argument order in completion tests (I'll go through other tests in follow up PRs)
5. Sort constant completion's candidates like #379 does