### PR TITLE
Move rdoc require out of repeated execution path

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -296,8 +296,13 @@ module IRB
         end
       Reline.dig_perfect_match_proc = IRB::InputCompletor::PerfectMatchedProc
       Reline.autocompletion = IRB.conf[:USE_AUTOCOMPLETE]
+
       if IRB.conf[:USE_AUTOCOMPLETE]
-        Reline.add_dialog_proc(:show_doc, SHOW_DOC_DIALOG, Reline::DEFAULT_DIALOG_CONTEXT)
+        begin
+          require 'rdoc'
+          Reline.add_dialog_proc(:show_doc, SHOW_DOC_DIALOG, Reline::DEFAULT_DIALOG_CONTEXT)
+        rescue LoadError
+        end
       end
     end
 
@@ -321,11 +326,6 @@ module IRB
         [195, 164], # The "ä" that appears when Alt+d is pressed on xterm.
         [226, 136, 130] # The "∂" that appears when Alt+d in pressed on iTerm2.
       ]
-      begin
-        require 'rdoc'
-      rescue LoadError
-        return nil
-      end
 
       if just_cursor_moving and completion_journey_data.nil?
         return nil

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: false
+
+require "test/unit"
+require "irb"
+
+module TestIRB
+  class TestRelineInputMethod < Test::Unit::TestCase
+    def setup
+      @conf_backup = IRB.conf.dup
+      IRB.conf[:LC_MESSAGES] = IRB::Locale.new
+    end
+
+    def teardown
+      IRB.conf.replace(@conf_backup)
+    end
+
+    def test_initialization
+      IRB::RelineInputMethod.new
+
+      assert_nil Reline.completion_append_character
+      assert_equal '', Reline.completer_quote_characters
+      assert_equal IRB::InputCompletor::BASIC_WORD_BREAK_CHARACTERS, Reline.basic_word_break_characters
+      assert_equal IRB::InputCompletor::CompletionProc, Reline.completion_proc
+      assert_equal IRB::InputCompletor::PerfectMatchedProc, Reline.dig_perfect_match_proc
+    end
+
+    def test_initialization_without_use_autocomplete
+      original_show_doc_proc = Reline.dialog_proc(:show_doc)&.dialog_proc
+      empty_proc = Proc.new {}
+      Reline.add_dialog_proc(:show_doc, empty_proc)
+
+      IRB.conf[:USE_AUTOCOMPLETE] = false
+
+      IRB::RelineInputMethod.new
+
+      refute Reline.autocompletion
+      assert_equal empty_proc, Reline.dialog_proc(:show_doc).dialog_proc
+    ensure
+      Reline.add_dialog_proc(:show_doc, original_show_doc_proc, Reline::DEFAULT_DIALOG_CONTEXT)
+    end
+
+    def test_initialization_with_use_autocomplete
+      original_show_doc_proc = Reline.dialog_proc(:show_doc)&.dialog_proc
+      empty_proc = Proc.new {}
+      Reline.add_dialog_proc(:show_doc, empty_proc)
+
+      IRB.conf[:USE_AUTOCOMPLETE] = true
+
+      IRB::RelineInputMethod.new
+
+      assert Reline.autocompletion
+      assert_equal IRB::RelineInputMethod::SHOW_DOC_DIALOG, Reline.dialog_proc(:show_doc).dialog_proc
+    ensure
+      Reline.add_dialog_proc(:show_doc, original_show_doc_proc, Reline::DEFAULT_DIALOG_CONTEXT)
+    end
+  end
+end
+


### PR DESCRIPTION
`SHOW_DOC_DIALOG` will be called repeatedly whenever the corresponding key is pressed, but we only need to require `rdoc` once. So ideally the require can be put outside of the proc.

And because when `rdoc` is not available the entire proc will be nonfunctional, we can stop registering the SHOW_DOC_DIALOG if we failed to require `rdoc`.