### PR TITLE
Add test for the help command

### DIFF
--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -406,6 +406,57 @@ module TestIRB
         ], out)
     end
 
+    def test_help
+      IRB.init_config(nil)
+      input = TestInputMethod.new([
+          "help 'String#gsub'\n",
+          "\n",
+        ])
+      IRB.conf[:VERBOSE] = false
+      IRB.conf[:PROMPT_MODE] = :SIMPLE
+      irb = IRB::Irb.new(IRB::WorkSpace.new(self), input)
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+      out, err = capture_output do
+        irb.eval_input
+      end
+
+      # the help command lazily loads rdoc by redefining the execute method
+      assert_match(/discarding old execute/, err) unless RUBY_ENGINE == 'truffleruby'
+
+      # the former is what we'd get without document content installed, like on CI
+      # the latter is what we may get locally
+      possible_rdoc_output = [/Nothing known about String#gsub/, /Returns a copy of self with all occurrences of the given pattern/]
+      assert(possible_rdoc_output.any? { |output| output.match?(out) }, "Expect the help command to match one of the possible outputs")
+    ensure
+      # this is the only way to reset the redefined method without coupling the test with its implementation
+      load "irb/cmd/help.rb"
+    end
+
+    def test_help_without_rdoc
+      IRB.init_config(nil)
+      input = TestInputMethod.new([
+          "help 'String#gsub'\n",
+          "\n",
+        ])
+      IRB.conf[:VERBOSE] = false
+      IRB.conf[:PROMPT_MODE] = :SIMPLE
+      irb = IRB::Irb.new(IRB::WorkSpace.new(self), input)
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+      out, err = capture_output do
+        without_rdoc do
+          irb.eval_input
+        end
+      end
+
+      # since LoadError will be raised, the execute won't be redefined
+      assert_no_match(/discarding old execute/, err)
+      # if it fails to require rdoc, it only returns the command object
+      assert_match(/=> IRB::ExtendCommand::Help\n/, out)
+    ensure
+      # this is the only way to reset the redefined method without coupling the test with its implementation
+      load "irb/cmd/help.rb"
+    end
+
     def test_irb_load
       IRB.init_config(nil)
       File.write("#{@tmpdir}/a.rb", "a = 'hi'\n")

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -429,7 +429,7 @@ module TestIRB
       assert(possible_rdoc_output.any? { |output| output.match?(out) }, "Expect the help command to match one of the possible outputs")
     ensure
       # this is the only way to reset the redefined method without coupling the test with its implementation
-      load "irb/cmd/help.rb"
+      EnvUtil.suppress_warning { load "irb/cmd/help.rb" }
     end
 
     def test_help_without_rdoc
@@ -454,7 +454,7 @@ module TestIRB
       assert_match(/=> IRB::ExtendCommand::Help\n/, out)
     ensure
       # this is the only way to reset the redefined method without coupling the test with its implementation
-      load "irb/cmd/help.rb"
+      EnvUtil.suppress_warning { load "irb/cmd/help.rb" }
     end
 
     def test_irb_load

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -412,10 +412,8 @@ module TestIRB
           "help 'String#gsub'\n",
           "\n",
         ])
-      IRB.conf[:VERBOSE] = false
       IRB.conf[:PROMPT_MODE] = :SIMPLE
       irb = IRB::Irb.new(IRB::WorkSpace.new(self), input)
-      IRB.conf[:MAIN_CONTEXT] = irb.context
       out, err = capture_output do
         irb.eval_input
       end
@@ -438,10 +436,8 @@ module TestIRB
           "help 'String#gsub'\n",
           "\n",
         ])
-      IRB.conf[:VERBOSE] = false
       IRB.conf[:PROMPT_MODE] = :SIMPLE
       irb = IRB::Irb.new(IRB::WorkSpace.new(self), input)
-      IRB.conf[:MAIN_CONTEXT] = irb.context
       out, err = capture_output do
         without_rdoc do
           irb.eval_input

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -3,6 +3,8 @@ require "test/unit"
 require "irb"
 require "irb/extend-command"
 
+require_relative "test_helper"
+
 module TestIRB
   class ExtendCommand < Test::Unit::TestCase
     class TestInputMethod < ::IRB::InputMethod
@@ -439,7 +441,7 @@ module TestIRB
       IRB.conf[:PROMPT_MODE] = :SIMPLE
       irb = IRB::Irb.new(IRB::WorkSpace.new(self), input)
       out, err = capture_output do
-        without_rdoc do
+        IRB::TestHelper.without_rdoc do
           irb.eval_input
         end
       end

--- a/test/irb/test_helper.rb
+++ b/test/irb/test_helper.rb
@@ -1,0 +1,16 @@
+module IRB
+  module TestHelper
+    def self.without_rdoc(&block)
+      ::Kernel.send(:alias_method, :old_require, :require)
+
+      ::Kernel.define_method(:require) do |name|
+        raise LoadError, "cannot load such file -- rdoc (test)" if name.match?("rdoc") || name.match?(/^rdoc\/.*/)
+        ::Kernel.send(:old_require, name)
+      end
+
+      yield
+    ensure
+      EnvUtil.suppress_warning { ::Kernel.send(:alias_method, :require, :old_require) }
+    end
+  end
+end

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -3,6 +3,8 @@
 require "test/unit"
 require "irb"
 
+require_relative "test_helper"
+
 module TestIRB
   class TestRelineInputMethod < Test::Unit::TestCase
     def setup
@@ -73,7 +75,7 @@ module TestIRB
 
       IRB.conf[:USE_AUTOCOMPLETE] = true
 
-      without_rdoc do
+      IRB::TestHelper.without_rdoc do
         IRB::RelineInputMethod.new
       end
 

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -83,19 +83,6 @@ module TestIRB
     ensure
       Reline.add_dialog_proc(:show_doc, original_show_doc_proc, Reline::DEFAULT_DIALOG_CONTEXT)
     end
-
-    def without_rdoc(&block)
-      ::Kernel.send(:alias_method, :old_require, :require)
-
-      ::Kernel.define_method(:require) do |name|
-        raise LoadError, "cannot load such file -- rdoc (test)" if name == "rdoc"
-        original_require(name)
-      end
-
-      yield
-    ensure
-      ::Kernel.send(:alias_method, :require, :old_require)
-    end
   end
 end
 

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -9,6 +9,19 @@ module Test
       def windows? platform = RUBY_PLATFORM
         /mswin|mingw/ =~ platform
       end
+
+      def without_rdoc(&block)
+        ::Kernel.send(:alias_method, :old_require, :require)
+
+        ::Kernel.define_method(:require) do |name|
+          raise LoadError, "cannot load such file -- rdoc (test)" if name.match?("rdoc") || name.match?(/^rdoc\/.*/)
+          ::Kernel.send(:old_require, name)
+        end
+
+        yield
+      ensure
+        ::Kernel.send(:alias_method, :require, :old_require)
+      end
     end
   end
 end

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -20,7 +20,7 @@ module Test
 
         yield
       ensure
-        ::Kernel.send(:alias_method, :require, :old_require)
+        EnvUtil.suppress_warning { ::Kernel.send(:alias_method, :require, :old_require) }
       end
     end
   end

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -9,19 +9,7 @@ module Test
       def windows? platform = RUBY_PLATFORM
         /mswin|mingw/ =~ platform
       end
-
-      def without_rdoc(&block)
-        ::Kernel.send(:alias_method, :old_require, :require)
-
-        ::Kernel.define_method(:require) do |name|
-          raise LoadError, "cannot load such file -- rdoc (test)" if name.match?("rdoc") || name.match?(/^rdoc\/.*/)
-          ::Kernel.send(:old_require, name)
-        end
-
-        yield
-      ensure
-        EnvUtil.suppress_warning { ::Kernel.send(:alias_method, :require, :old_require) }
-      end
     end
   end
 end
+


### PR DESCRIPTION
This PR adds tests for 2 of 3 possible `help` command outcomes:

- [x] When executed without `rdoc`: it returns the command constant directly
    - It probably should return some useful message, but that's for another day.
- [x] When executed with argument, like `help String#gsub`: it renders the argument's document via `rdoc`
- [ ] When executed without argument: it starts rdoc's interactive mode, which intercepts stdin and is not testable under the current test framework

Because the `help` command [redefines itself based on if rdoc is required succesfully](https://github.com/ruby/irb/blob/master/lib/irb/cmd/help.rb), there's no easy way to recover it to the pre-test state. I think the best way is to reload the command file, but any alternative is welcome.