### PR TITLE
Make sure Encoding's defaults are restored

### DIFF
--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -11,19 +11,22 @@ module TestIRB
 
       # RelineInputMethod#initialize calls IRB.set_encoding, which mutates standard input/output's encoding
       # so we need to make sure we set them back
-      @original_encodings = {
+      @original_io_encodings = {
         STDIN => [STDIN.external_encoding, STDIN.internal_encoding],
         STDOUT => [STDOUT.external_encoding, STDOUT.internal_encoding],
         STDERR => [STDERR.external_encoding, STDERR.internal_encoding],
       }
+      @original_default_encodings = [Encoding.default_external, Encoding.default_internal]
     end
 
     def teardown
       IRB.conf.replace(@conf_backup)
 
-      @original_encodings.each do |io, (external_encoding, internal_encoding)|
+      @original_io_encodings.each do |io, (external_encoding, internal_encoding)|
         io.set_encoding(external_encoding, internal_encoding)
       end
+
+      EnvUtil.suppress_warning { Encoding.default_external, Encoding.default_internal = @original_default_encodings }
     end
 
     def test_initialization


### PR DESCRIPTION
Fixes CI: http://ci.rvm.jp/logfiles/brlog.trunk-random0.20221025-193254