### PR TITLE
Allow non-identifier aliases like Pry's @ and $

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -426,6 +426,9 @@ module IRB
     def initialize(workspace = nil, input_method = nil)
       @context = Context.new(self, workspace, input_method)
       @context.main.extend ExtendCommandBundle
+      @context.command_aliases.each do |alias_name, cmd_name|
+        @context.main.install_alias_method(alias_name, cmd_name)
+      end
       @signal_status = :IN_IRB
       @scanner = RubyLex.new
     end
@@ -433,9 +436,6 @@ module IRB
     def run(conf = IRB.conf)
       conf[:IRB_RC].call(context) if conf[:IRB_RC]
       conf[:MAIN_CONTEXT] = context
-      conf[:COMMAND_ALIASES].each do |alias_name, cmd_name|
-        context.main.install_alias_method(alias_name, cmd_name)
-      end
 
       prev_trap = trap("SIGINT") do
         signal_handle

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -433,6 +433,9 @@ module IRB
     def run(conf = IRB.conf)
       conf[:IRB_RC].call(context) if conf[:IRB_RC]
       conf[:MAIN_CONTEXT] = context
+      conf[:COMMAND_ALIASES].each do |alias_name, cmd_name|
+        context.main.install_alias_method(alias_name, cmd_name)
+      end
 
       prev_trap = trap("SIGINT") do
         signal_handle

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -477,6 +477,13 @@ module IRB
         line = "begin ::Kernel.raise _; rescue _.class\n#{line}\n""end"
         @workspace.local_variable_set(:_, exception)
       end
+
+      # Transform a non-identifier alias (ex: @, $)
+      command = line.split(/\s/, 2).first
+      if !command.match?(/\A\w+\z/) && main.respond_to?(command)
+        line = line.gsub(/\A#{Regexp.escape(command)}/, main.method(command).original_name.to_s)
+      end
+
       set_last_value(@workspace.evaluate(self, line, irb_path, line_no))
     end
 

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -150,9 +150,7 @@ module IRB
         @newline_before_multiline_output = true
       end
 
-      @symbol_aliases = IRB.conf[:COMMAND_ALIASES].select do |alias_name, _|
-        !alias_name.match?(/\A\w+\z/)
-      end
+      @command_aliases = IRB.conf[:COMMAND_ALIASES]
     end
 
     # The top-level workspace, see WorkSpace#main
@@ -329,6 +327,9 @@ module IRB
     #
     # See IRB@Command+line+options for more command line options.
     attr_accessor :back_trace_limit
+
+    # User-defined IRB command aliases
+    attr_accessor :command_aliases
 
     # Alias for #use_multiline
     alias use_multiline? use_multiline
@@ -535,8 +536,9 @@ module IRB
     end
 
     # Return a command name if it's aliased from the argument and it's not an identifier.
-    def symbol_alias(alias_name)
-      @symbol_aliases[alias_name.to_sym]
+    def symbol_alias(command)
+      return nil if command.match?(/\A\w+\z/)
+      command_aliases[command.to_sym]
     end
   end
 end

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -485,7 +485,7 @@ module IRB
       # Transform a non-identifier alias (ex: @, $)
       command = line.split(/\s/, 2).first
       if original = symbol_alias(command)
-        line = line.gsub(/\A#{Regexp.escape(command)}/, original)
+        line = line.gsub(/\A#{Regexp.escape(command)}/, original.to_s)
       end
 
       set_last_value(@workspace.evaluate(self, line, irb_path, line_no))
@@ -536,7 +536,7 @@ module IRB
 
     # Return a command name if it's aliased from the argument and it's not an identifier.
     def symbol_alias(alias_name)
-      @symbol_aliases[alias_name.to_sym]&.to_s
+      @symbol_aliases[alias_name.to_sym]
     end
   end
 end

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -222,10 +222,6 @@ module IRB # :nodoc:
       end
     end
 
-    def self.def_alias_command(alias_name, cmd_name, flag = NO_OVERRIDE)
-      @ALIASES.push [alias_name, cmd_name, flag]
-    end
-
     # Installs alias methods for the default irb commands, see
     # ::install_extend_commands.
     def install_alias_method(to, from, override = NO_OVERRIDE)

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -222,6 +222,10 @@ module IRB # :nodoc:
       end
     end
 
+    def self.def_alias_command(alias_name, cmd_name, flag = NO_OVERRIDE)
+      @ALIASES.push [alias_name, cmd_name, flag]
+    end
+
     # Installs alias methods for the default irb commands, see
     # ::install_extend_commands.
     def install_alias_method(to, from, override = NO_OVERRIDE)

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -158,6 +158,8 @@ module IRB # :nodoc:
     @CONF[:LC_MESSAGES] = Locale.new
 
     @CONF[:AT_EXIT] = []
+
+    @CONF[:COMMAND_ALIASES] = {}
   end
 
   def IRB.set_measure_callback(type = nil, arg = nil, &block)

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -67,7 +67,7 @@ class RubyLex
         else
           # Accept any single-line input starting with a non-identifier alias (ex: @, $)
           command = code.split(/\s/, 2).first
-          if context&.symbol_alias(command)
+          if context.symbol_alias(command)
             next true
           end
 

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -65,6 +65,12 @@ class RubyLex
             false
           end
         else
+          # Accept any single-line input starting with a non-identifier alias (ex: @, $)
+          command = code.split(/\s/, 2).first
+          if !command.match?(/\A\w+\z/) && context&.main&.respond_to?(command)
+            next true
+          end
+
           code.gsub!(/\s*\z/, '').concat("\n")
           ltype, indent, continue, code_block_open = check_state(code, context: context)
           if ltype or indent > 0 or continue or code_block_open

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -67,7 +67,7 @@ class RubyLex
         else
           # Accept any single-line input starting with a non-identifier alias (ex: @, $)
           command = code.split(/\s/, 2).first
-          if !command.match?(/\A\w+\z/) && context&.main&.respond_to?(command)
+          if context&.symbol_alias(command)
             next true
           end
 

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -576,7 +576,7 @@ module TestIRB
       ])
       IRB.init_config(nil)
       IRB.conf[:COMMAND_ALIASES] = { :'$' => :show_source }
-      workspace = IRB::WorkSpace.new(build_main)
+      workspace = IRB::WorkSpace.new(Object.new)
       IRB.conf[:VERBOSE] = false
       irb = IRB::Irb.new(workspace, input)
       IRB.conf[:MAIN_CONTEXT] = irb.context
@@ -635,7 +635,7 @@ module TestIRB
       ])
       IRB.init_config(nil)
       IRB.conf[:COMMAND_ALIASES] = { :'@' => :whereami }
-      workspace = IRB::WorkSpace.new(build_main)
+      workspace = IRB::WorkSpace.new(Object.new)
       irb = IRB::Irb.new(workspace, input)
       IRB.conf[:MAIN_CONTEXT] = irb.context
       out, err = capture_output do
@@ -655,7 +655,7 @@ module TestIRB
         :'@' => :whereami,
         :'$' => :show_source,
       }
-      main = build_main
+      main = Object.new
       main.instance_variable_set(:@foo, "foo")
       $bar = "bar"
       workspace = IRB::WorkSpace.new(main)
@@ -667,18 +667,6 @@ module TestIRB
       assert_empty err
       assert_match(/"foo"/, out)
       assert_match(/"bar"/, out)
-    end
-
-    private
-
-    def build_main
-      main = Object.new
-      main.extend(IRB::ExtendCommandBundle)
-      # Simulate part of the IRB::Irb#run behavior
-      IRB.conf[:COMMAND_ALIASES].each do |alias_name, cmd_name|
-        main.install_alias_method(alias_name, cmd_name)
-      end
-      main
     end
   end
 end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -610,5 +610,26 @@ module TestIRB
       assert_empty err
       assert_match(/^From: .+ @ line \d+ :\n/, out)
     end
+
+    def test_alias_at
+      pend if RUBY_ENGINE == 'truffleruby' # missing Method#original_name
+
+      IRB::ExtendCommandBundle.def_alias_command(:'@', :whereami)
+      main = Object.new
+      main.extend(IRB::ExtendCommandBundle)
+
+      input = TestInputMethod.new([
+        "@\n",
+      ])
+      IRB.init_config(nil)
+      workspace = IRB::WorkSpace.new(main)
+      irb = IRB::Irb.new(workspace, input)
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(/^From: .+ @ line \d+ :\n/, out)
+    end
   end
 end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -570,6 +570,24 @@ module TestIRB
       assert_match(%r[/irb\.rb], out)
     end
 
+    def test_show_source_alias
+      input = TestInputMethod.new([
+        "$ 'IRB.conf'\n",
+      ])
+      IRB.init_config(nil)
+      IRB.conf[:COMMAND_ALIASES] = { :'$' => :show_source }
+      workspace = IRB::WorkSpace.new(build_main)
+      IRB.conf[:VERBOSE] = false
+      irb = IRB::Irb.new(workspace, input)
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+      irb.context.return_format = "=> %s\n"
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(%r[/irb\.rb], out)
+    end
+
     def test_show_source_end_finder
       pend if RUBY_ENGINE == 'truffleruby'
       eval(code = <<-EOS, binding, __FILE__, __LINE__ + 1)
@@ -611,7 +629,7 @@ module TestIRB
       assert_match(/^From: .+ @ line \d+ :\n/, out)
     end
 
-    def test_alias_at
+    def test_whereami_alias
       input = TestInputMethod.new([
         "@\n",
       ])
@@ -625,6 +643,30 @@ module TestIRB
       end
       assert_empty err
       assert_match(/^From: .+ @ line \d+ :\n/, out)
+    end
+
+    def test_vars_with_aliases
+      input = TestInputMethod.new([
+        "@foo\n",
+        "$bar\n",
+      ])
+      IRB.init_config(nil)
+      IRB.conf[:COMMAND_ALIASES] = {
+        :'@' => :whereami,
+        :'$' => :show_source,
+      }
+      main = build_main
+      main.instance_variable_set(:@foo, "foo")
+      $bar = "bar"
+      workspace = IRB::WorkSpace.new(main)
+      irb = IRB::Irb.new(workspace, input)
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(/"foo"/, out)
+      assert_match(/"bar"/, out)
     end
 
     private

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -612,8 +612,6 @@ module TestIRB
     end
 
     def test_alias_at
-      pend if RUBY_ENGINE == 'truffleruby' # missing Method#original_name
-
       input = TestInputMethod.new([
         "@\n",
       ])


### PR DESCRIPTION
## Background
At DevMeeting-2022-08-25, We decided to start accepting inputs that are not valid as a Ruby expression at https://bugs.ruby-lang.org/issues/18975#note-5:

> We also discussed the idea of handling IRB command inputs that are not valid as a Ruby expression, and the meeting attendees agreed to make this change.

## Changes
* Introduce API for `~/.irbrc` to define an alias: `IRB::ExtendCommandBundle.def_alias_command`
* When a line starts with a non-identifier (not matching `/A\w+\z`) alias command, skip the Ruby-based termination check and replace the alias with the target command.

### Example
If you define an alias like:

```rb
IRB.conf[:COMMAND_ALIASES] = { :"@" => :whereami }
```

You can use it as a shorthand of `whereami` like Pry:

```rb
irb(main)[01:0]> @

From: /tmp/a.rb @ line 2 :

    1: def test
 => 2:   binding.irb
    3: end
    4: test

=> nil
```