### PR TITLE
Refactor RubyLex and its tests

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -48,7 +48,7 @@ class RubyLex
   end
 
   # io functions
-  def set_input(io, p = nil, context: nil, &block)
+  def set_input(io, p = nil, context:, &block)
     @io = io
     if @io.respond_to?(:check_termination)
       @io.check_termination do |code|
@@ -216,7 +216,7 @@ class RubyLex
     ltype = process_literal_type(tokens)
     indent = process_nesting_level(tokens)
     continue = process_continue(tokens)
-    lvars_code = self.class.generate_local_variables_assign_code(context&.local_variables || [])
+    lvars_code = self.class.generate_local_variables_assign_code(context.local_variables)
     code = "#{lvars_code}\n#{code}" if lvars_code
     code_block_open = check_code_block(code, tokens)
     [ltype, indent, continue, code_block_open]


### PR DESCRIPTION
#### [Make sure RubyLex#set_input's context is always present in tests](https://github.com/ruby/irb/commit/e23740538b8913026b3c6f8566eb041f52b7568f)

In real-world scenarios, the context should [always be non-nil](https://github.com/ruby/irb/blob/master/lib/irb.rb#L489), so we should make sure our test setup reflects that.

#### [Make context a required keyword](https://github.com/ruby/irb/commit/9d6be6ebb36b050d06e4d08043f4ce02a55d0f8f)

Since in practice, `set_input`'s context should always be non-nil, its parameters should reflect that.
And because `RubyLex#check_state` is only called by `#lex` and `#set_input`, both of which now always require context, we can assume its context should be non-nil too.
