### PR TITLE
Require the entire irb lib in RubyLex tests

### DIFF
--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -1,5 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'irb/ruby-lex'
+require 'irb'
 require 'test/unit'
 require 'ostruct'
 


### PR DESCRIPTION
RubyLex is not designed to be used alone. It's usually used with an IRB context, which requires workspace. So its tests should have access to those components too.