### PR TITLE
Provide a base test class and let tests restore encodings conveniently

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -2,6 +2,19 @@ require "test/unit"
 
 module TestIRB
   class TestCase < Test::Unit::TestCase
+    def save_encodings
+      @default_encoding = [Encoding.default_external, Encoding.default_internal]
+      @stdio_encodings = [STDIN, STDOUT, STDERR].map {|io| [io.external_encoding, io.internal_encoding] }
+    end
+
+    def restore_encodings
+      EnvUtil.suppress_warning do
+        Encoding.default_external, Encoding.default_internal = *@default_encoding
+        [STDIN, STDOUT, STDERR].zip(@stdio_encodings) do |io, encs|
+          io.set_encoding(*encs)
+        end
+      end
+    end
   end
 
   module TestHelper

--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -1,4 +1,9 @@
-module IRB
+require "test/unit"
+
+module TestIRB
+  class TestCase < Test::Unit::TestCase
+  end
+
   module TestHelper
     def self.without_rdoc(&block)
       ::Kernel.send(:alias_method, :old_require, :require)

--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -15,10 +15,8 @@ module TestIRB
         end
       end
     end
-  end
 
-  module TestHelper
-    def self.without_rdoc(&block)
+    def without_rdoc(&block)
       ::Kernel.send(:alias_method, :old_require, :require)
 
       ::Kernel.define_method(:require) do |name|

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -443,7 +443,7 @@ module TestIRB
       IRB.conf[:VERBOSE] = false
       irb = IRB::Irb.new(IRB::WorkSpace.new(self), input)
       out, _ = capture_output do
-        TestIRB::TestHelper.without_rdoc do
+        without_rdoc do
           irb.eval_input
         end
       end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -45,8 +45,7 @@ module TestIRB
       @home_backup = ENV["HOME"]
       ENV["HOME"] = @tmpdir
       @xdg_config_home_backup = ENV.delete("XDG_CONFIG_HOME")
-      @default_encoding = [Encoding.default_external, Encoding.default_internal]
-      @stdio_encodings = [STDIN, STDOUT, STDERR].map {|io| [io.external_encoding, io.internal_encoding] }
+      save_encodings
       IRB.instance_variable_get(:@CONF).clear
       @is_win = (RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/)
     end
@@ -56,12 +55,7 @@ module TestIRB
       ENV["HOME"] = @home_backup
       Dir.chdir(@pwd)
       FileUtils.rm_rf(@tmpdir)
-      EnvUtil.suppress_warning {
-        Encoding.default_external, Encoding.default_internal = *@default_encoding
-        [STDIN, STDOUT, STDERR].zip(@stdio_encodings) do |io, encs|
-          io.set_encoding(*encs)
-        end
-      }
+      restore_encodings
     end
 
     def test_irb_info_multiline

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: false
-require "test/unit"
 require "irb"
 require "irb/extend-command"
 
 require_relative "helper"
 
 module TestIRB
-  class ExtendCommand < Test::Unit::TestCase
+  class ExtendCommand < TestCase
     class TestInputMethod < ::IRB::InputMethod
       attr_reader :list, :line_no
 
@@ -450,7 +449,7 @@ module TestIRB
       IRB.conf[:VERBOSE] = false
       irb = IRB::Irb.new(IRB::WorkSpace.new(self), input)
       out, _ = capture_output do
-        IRB::TestHelper.without_rdoc do
+        TestIRB::TestHelper.without_rdoc do
           irb.eval_input
         end
       end

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: false
-require 'test/unit'
 require 'irb/color'
 require 'rubygems'
 require 'stringio'
 
+require_relative "helper"
+
 module TestIRB
-  class TestColor < Test::Unit::TestCase
+  class TestColor < TestCase
     CLEAR     = "\e[0m"
     BOLD      = "\e[1m"
     UNDERLINE = "\e[4m"

--- a/test/irb/test_color_printer.rb
+++ b/test/irb/test_color_printer.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: false
-require 'test/unit'
 require 'irb/color_printer'
 require 'rubygems'
 require 'stringio'
 
+require_relative "helper"
+
 module TestIRB
-  class TestColorPrinter < Test::Unit::TestCase
+  class TestColorPrinter < TestCase
     CLEAR     = "\e[0m"
     BOLD      = "\e[1m"
     RED       = "\e[31m"

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: false
-require "test/unit"
 require "pathname"
 require "irb"
 
 require_relative "helper"
 
 module TestIRB
-  class TestCompletion < Test::Unit::TestCase
+  class TestCompletion < TestCase
     def setup
       # make sure require completion candidates are not cached
       IRB::InputCompletor.class_variable_set(:@@files_from_load_path, nil)
@@ -276,7 +275,7 @@ module TestIRB
         result = nil
 
         out, err = capture_output do
-          IRB::TestHelper.without_rdoc do
+          TestIRB::TestHelper.without_rdoc do
             result = IRB::InputCompletor::PerfectMatchedProc.("String", bind: binding)
           end
         end

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -275,7 +275,7 @@ module TestIRB
         result = nil
 
         out, err = capture_output do
-          TestIRB::TestHelper.without_rdoc do
+          without_rdoc do
             result = IRB::InputCompletor::PerfectMatchedProc.("String", bind: binding)
           end
         end

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: false
-require 'test/unit'
 require 'tempfile'
 require 'irb'
 require 'rubygems' if defined?(Gem)
 
+require_relative "helper"
+
 module TestIRB
-  class TestContext < Test::Unit::TestCase
+  class TestContext < TestCase
     class TestInputMethod < ::IRB::InputMethod
       attr_reader :list, :line_no
 

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: false
-require 'test/unit'
 require 'irb'
 require 'irb/ext/save-history'
 require 'readline'
 
+require_relative "helper"
+
 module TestIRB
-  class TestHistory < Test::Unit::TestCase
+  class TestHistory < TestCase
     def setup
       IRB.conf[:RC_NAME_GENERATOR] = nil
     end

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: false
-require "test/unit"
 require "irb"
 require "fileutils"
 
+require_relative "helper"
+
 module TestIRB
-  class TestInit < Test::Unit::TestCase
+  class TestInit < TestCase
     def setup
       # IRBRC is for RVM...
       @backup_env = %w[HOME XDG_CONFIG_HOME IRBRC].each_with_object({}) do |env, hash|

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: false
 
-require "test/unit"
 require "irb"
 
 require_relative "helper"
 
 module TestIRB
-  class TestRelineInputMethod < Test::Unit::TestCase
+  class TestRelineInputMethod < TestCase
     def setup
       @conf_backup = IRB.conf.dup
       IRB.conf[:LC_MESSAGES] = IRB::Locale.new
@@ -78,7 +77,7 @@ module TestIRB
 
       IRB.conf[:USE_AUTOCOMPLETE] = true
 
-      IRB::TestHelper.without_rdoc do
+      TestIRB::TestHelper.without_rdoc do
         IRB::RelineInputMethod.new
       end
 

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -64,7 +64,7 @@ module TestIRB
 
       IRB.conf[:USE_AUTOCOMPLETE] = true
 
-      TestIRB::TestHelper.without_rdoc do
+      without_rdoc do
         IRB::RelineInputMethod.new
       end
 

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -9,25 +9,12 @@ module TestIRB
     def setup
       @conf_backup = IRB.conf.dup
       IRB.conf[:LC_MESSAGES] = IRB::Locale.new
-
-      # RelineInputMethod#initialize calls IRB.set_encoding, which mutates standard input/output's encoding
-      # so we need to make sure we set them back
-      @original_io_encodings = {
-        STDIN => [STDIN.external_encoding, STDIN.internal_encoding],
-        STDOUT => [STDOUT.external_encoding, STDOUT.internal_encoding],
-        STDERR => [STDERR.external_encoding, STDERR.internal_encoding],
-      }
-      @original_default_encodings = [Encoding.default_external, Encoding.default_internal]
+      save_encodings
     end
 
     def teardown
       IRB.conf.replace(@conf_backup)
-
-      @original_io_encodings.each do |io, (external_encoding, internal_encoding)|
-        io.set_encoding(external_encoding, internal_encoding)
-      end
-
-      EnvUtil.suppress_warning { Encoding.default_external, Encoding.default_internal = @original_default_encodings }
+      restore_encodings
     end
 
     def test_initialization

--- a/test/irb/test_option.rb
+++ b/test/irb/test_option.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: false
-require 'test/unit'
+require_relative "helper"
 
 module TestIRB
-  class TestOption < Test::Unit::TestCase
+  class TestOption < TestCase
     def test_end_of_option
       bug4117 = '[ruby-core:33574]'
       bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []

--- a/test/irb/test_raise_no_backtrace_exception.rb
+++ b/test/irb/test_raise_no_backtrace_exception.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: false
-require 'test/unit'
+
+require_relative "helper"
 
 module TestIRB
-  class TestRaiseNoBacktraceException < Test::Unit::TestCase
+  class TestRaiseNoBacktraceException < TestCase
     def test_raise_exception
       bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []
       assert_in_out_err(bundle_exec + %w[-rirb -W0 -e IRB.start(__FILE__) -- -f --], <<-IRB, /Exception: foo/, [])

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -21,6 +21,14 @@ module TestIRB
       end
     end
 
+    def setup
+      save_encodings
+    end
+
+    def teardown
+      restore_encodings
+    end
+
     def assert_indenting(lines, correct_space_count, add_new_line)
       lines = lines + [""] if add_new_line
       last_line_index = lines.length - 1

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -1,11 +1,12 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'irb'
 require 'rubygems'
-require 'test/unit'
 require 'ostruct'
 
+require_relative "helper"
+
 module TestIRB
-  class TestRubyLex < Test::Unit::TestCase
+  class TestRubyLex < TestCase
     Row = Struct.new(:content, :current_line_spaces, :new_line_spaces, :nesting_level)
 
     class MockIO_AutoIndent

--- a/test/irb/test_workspace.rb
+++ b/test/irb/test_workspace.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: false
-require 'test/unit'
 require 'tempfile'
 require 'rubygems'
 require 'irb'
 require 'irb/workspace'
 require 'irb/color'
 
+require_relative "helper"
+
 module TestIRB
-  class TestWorkSpace < Test::Unit::TestCase
+  class TestWorkSpace < TestCase
     def test_code_around_binding
       IRB.conf[:USE_COLORIZE] = false
       Tempfile.create('irb') do |f|


### PR DESCRIPTION
Because `RelineInputMethod#initializes` calls `set_encoding`, which changes stdio/out/err and Encoding's default encoding values, we need to make sure any test that directly or indirectly (e.g. through Context) initializes `RelineInputMethod` restores encodings.

`ReadlineInputMethod` also changes encodings but currently no tests cover it.