### PR TITLE
Support non-string input in show_source

### DIFF
--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -9,6 +9,24 @@ module IRB
 
   module ExtendCommand
     class ShowSource < Nop
+      class << self
+        def transform_args(args)
+          # Return a string literal as is for backward compatibility
+          if args.empty? || string_literal?(args)
+            args
+          else # Otherwise, consider the input as a String for convenience
+            args.strip.dump
+          end
+        end
+
+        private
+
+        def string_literal?(args)
+          sexp = Ripper.sexp(args)
+          sexp && sexp.size == 2 && sexp.last&.first&.first == :string_literal
+        end
+      end
+
       def execute(str = nil)
         unless str.is_a?(String)
           puts "Error: Expected a string but got #{str.inspect}"

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -484,9 +484,16 @@ module IRB
       end
 
       # Transform a non-identifier alias (ex: @, $)
-      command = line.split(/\s/, 2).first
+      command, args = line.split(/\s/, 2)
       if original = symbol_alias(command)
         line = line.gsub(/\A#{Regexp.escape(command)}/, original.to_s)
+        command = original
+      end
+
+      # Hook command-specific transformation
+      command_class = ExtendCommandBundle.load_command(command)
+      if command_class&.respond_to?(:transform_args)
+        line = "#{command} #{command_class.transform_args(args)}"
       end
 
       set_last_value(@workspace.evaluate(self, line, irb_path, line_no))

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -147,6 +147,20 @@ module IRB # :nodoc:
 
     ]
 
+    # Convert a command name to its implementation class if such command exists
+    def self.load_command(command)
+      command = command.to_sym
+      @EXTEND_COMMANDS.each do |cmd_name, cmd_class, load_file, *aliases|
+        next if cmd_name != command && aliases.all? { |alias_name, _| alias_name != command }
+
+        if !defined?(ExtendCommand) || !ExtendCommand.const_defined?(cmd_class, false)
+          require_relative load_file
+        end
+        return ExtendCommand.const_get(cmd_class, false)
+      end
+      nil
+    end
+
     # Installs the default irb commands:
     #
     # +irb_current_working_workspace+::   Context#main

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -548,6 +548,23 @@ module TestIRB
 
     def test_show_source
       input = TestInputMethod.new([
+        "show_source IRB.conf\n",
+      ])
+      IRB.init_config(nil)
+      workspace = IRB::WorkSpace.new(self)
+      IRB.conf[:VERBOSE] = false
+      irb = IRB::Irb.new(workspace, input)
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+      irb.context.return_format = "=> %s\n"
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(%r[/irb\.rb], out)
+    end
+
+    def test_show_source_string
+      input = TestInputMethod.new([
         "show_source 'IRB.conf'\n",
       ])
       IRB.init_config(nil)

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -563,6 +563,23 @@ module TestIRB
       assert_match(%r[/irb\.rb], out)
     end
 
+    def test_show_source_method
+      input = TestInputMethod.new([
+        "p show_source('IRB.conf')\n",
+      ])
+      IRB.init_config(nil)
+      workspace = IRB::WorkSpace.new(self)
+      IRB.conf[:VERBOSE] = false
+      irb = IRB::Irb.new(workspace, input)
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+      irb.context.return_format = "=> %s\n"
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(%r[/irb\.rb], out)
+    end
+
     def test_show_source_string
       input = TestInputMethod.new([
         "show_source 'IRB.conf'\n",


### PR DESCRIPTION
This PR allows a non-String literal input in `show_source`, just like Pry.

## Example

```rb
$ irb -rerb
irb(main)[01:0]> show_source ERB#result

From: /home/k0kubun/.rbenv/versions/3.1.2/lib/ruby/3.1.0/erb.rb:901

  def result(b=new_toplevel)
    unless @_init.equal?(self.class.singleton_class)
      raise ArgumentError, "not initialized"
    end
    eval(@src, b, (@filename || '(erb)'), @lineno)
  end

=> nil
```