### PR TITLE
Silent the noise created when building Context in tests

### DIFF
--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -721,6 +721,7 @@ module TestIRB
         end
       end
 
+      IRB.conf[:VERBOSE] = false
       IRB::Context.new(nil, workspace)
     end
   end


### PR DESCRIPTION
This eliminates noise like `unknown command: "Switch to inspect mode."`