### PR TITLE
Use Pathname objects instead of Object for completion tests

### DIFF
--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -107,8 +107,7 @@ module TestIRB
       def test_complete_require_with_string_convertable_in_load_path
         temp_dir = Dir.mktmpdir
         File.write(File.join(temp_dir, "foo.rb"), "test")
-        object = Object.new
-        object.define_singleton_method(:to_s) { temp_dir }
+        object = Pathname.new temp_dir
         $LOAD_PATH << object
 
         candidates = IRB::InputCompletor::CompletionProc.("'foo", "require ", "")


### PR DESCRIPTION
Passing blank Object could cause random errors on Ruby CI

```
 1) Error:
TestIRB::TestCompletion::TestRequireComepletion#test_complete_require_with_string_convertable_in_load_path:
Test::Unit::ProxyError: no implicit conversion of Object into String
    /Users/peter/src/ruby/lib/rubygems.rb:364:in `paths'
    /Users/peter/src/ruby/lib/rubygems.rb:408:in `path'
```

But passing Pathname objects doesn't have this problem.