### PR TITLE
Transform ls's --grep/-G option to keyword args

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -427,6 +427,7 @@ module IRB
       @context = Context.new(self, workspace, input_method)
       @context.main.extend ExtendCommandBundle
       @context.command_aliases.each do |alias_name, cmd_name|
+        next if @context.symbol_alias(alias_name)
         @context.main.install_alias_method(alias_name, cmd_name)
       end
       @signal_status = :IN_IRB

--- a/lib/irb/cmd/ls.rb
+++ b/lib/irb/cmd/ls.rb
@@ -10,8 +10,8 @@ module IRB
   module ExtendCommand
     class Ls < Nop
       def self.transform_args(args)
-        if match = args&.match(/\A(?<prefix>.+\s|)(--grep|-G)\s+(?<grep>[^\s]+)(?<suffix>\s.+|)\n\z/)
-          args = match[:prefix] + match[:suffix]
+        if match = args&.match(/\A(?<args>.+\s|)(--grep|-G)\s+(?<grep>[^\s]+)\s*\n\z/)
+          args = match[:args]
           "#{args}#{',' unless args.chomp.empty?} grep: /#{match[:grep]}/"
         else
           args

--- a/lib/irb/cmd/ls.rb
+++ b/lib/irb/cmd/ls.rb
@@ -10,7 +10,7 @@ module IRB
   module ExtendCommand
     class Ls < Nop
       def self.transform_args(args)
-        if match = args&.match(/\A(?<args>.+\s|)(--grep|-G)\s+(?<grep>[^\s]+)\s*\n\z/)
+        if match = args&.match(/\A(?<args>.+\s|)(-g|-G)\s+(?<grep>[^\s]+)\s*\n\z/)
           args = match[:args]
           "#{args}#{',' unless args.chomp.empty?} grep: /#{match[:grep]}/"
         else

--- a/lib/irb/cmd/ls.rb
+++ b/lib/irb/cmd/ls.rb
@@ -9,6 +9,15 @@ module IRB
 
   module ExtendCommand
     class Ls < Nop
+      def self.transform_args(args)
+        if match = args&.match(/\A(?<prefix>.+\s|)(--grep|-G)\s+(?<grep>[^\s]+)(?<suffix>\s.+|)\n\z/)
+          args = match[:prefix] + match[:suffix]
+          "#{args}#{',' unless args.chomp.empty?} grep: /#{match[:grep]}/"
+        else
+          args
+        end
+      end
+
       def execute(*arg, grep: nil)
         o = Output.new(grep: grep)
 

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -489,7 +489,7 @@ module TestIRB
 
       [
         "ls 42, grep: /times/\n",
-        "ls 42 --grep times\n",
+        "ls 42 -g times\n",
         "ls 42 -G times\n",
       ].each do |line|
         out, err = execute_lines(line)
@@ -508,7 +508,7 @@ module TestIRB
 
       [
         "ls grep: /whereami/\n",
-        "ls --grep whereami\n",
+        "ls -g whereami\n",
         "ls -G whereami\n",
       ].each do |line|
         out, err = execute_lines(line)

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -480,6 +480,46 @@ module TestIRB
       assert_match(/C.methods:\s+m5\n/m, out)
     end
 
+    def test_ls_grep
+      pend if RUBY_ENGINE == 'truffleruby'
+      out, err = execute_lines("ls 42\n")
+      assert_empty err
+      assert_match(/times/, out)
+      assert_match(/polar/, out)
+
+      [
+        "ls 42, grep: /times/\n",
+        "ls 42 --grep times\n",
+        "ls 42 -G times\n",
+        "ls --grep times 42\n",
+        "ls -G times 42\n",
+      ].each do |line|
+        out, err = execute_lines(line)
+        assert_empty err
+        assert_match(/times/, out)
+        assert_not_match(/polar/, out)
+      end
+    end
+
+    def test_ls_grep_empty
+      pend if RUBY_ENGINE == 'truffleruby'
+      out, err = execute_lines("ls\n")
+      assert_empty err
+      assert_match(/whereami/, out)
+      assert_match(/show_source/, out)
+
+      [
+        "ls grep: /whereami/\n",
+        "ls --grep whereami\n",
+        "ls -G whereami\n",
+      ].each do |line|
+        out, err = execute_lines(line)
+        assert_empty err
+        assert_match(/whereami/, out)
+        assert_not_match(/show_source/, out)
+      end
+    end
+
     def test_ls_with_no_singleton_class
       out, err = execute_lines(
         "ls 42",

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -491,8 +491,6 @@ module TestIRB
         "ls 42, grep: /times/\n",
         "ls 42 --grep times\n",
         "ls 42 -G times\n",
-        "ls --grep times 42\n",
-        "ls -G times 42\n",
       ].each do |line|
         out, err = execute_lines(line)
         assert_empty err


### PR DESCRIPTION
Leveraging the `transform_args` capability in https://github.com/ruby/irb/pull/430, this PR introduces `--grep` / `-G` option to `ls` to pass `grep` option.

```rb
irb(main)[01:0]> erb = ERB.new('src')
=>
#<ERB:0x00007f009bf992f8
...
irb(main)[02:0]> ls erb
ERB#methods:
  def_class  def_method   def_module  encoding  filename  filename=  lineno  lineno=  location=  make_compiler  result  result_with_hash
  run        set_eoutvar  src
instance variables: @_init  @encoding  @filename  @frozen_string  @lineno  @src
=> nil
irb(main)[03:0]> ls erb -G result
ERB#methods: result  result_with_hash
=> nil
```