### PR TITLE
Remove duplicated TestInputMethod definitions

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -2,6 +2,32 @@ require "test/unit"
 
 module TestIRB
   class TestCase < Test::Unit::TestCase
+    class TestInputMethod < ::IRB::InputMethod
+      attr_reader :list, :line_no
+
+      def initialize(list = [])
+        super("test")
+        @line_no = 0
+        @list = list
+      end
+
+      def gets
+        @list[@line_no]&.tap {@line_no += 1}
+      end
+
+      def eof?
+        @line_no >= @list.size
+      end
+
+      def encoding
+        Encoding.default_external
+      end
+
+      def reset
+        @line_no = 0
+      end
+    end
+
     def save_encodings
       @default_encoding = [Encoding.default_external, Encoding.default_internal]
       @stdio_encodings = [STDIN, STDOUT, STDERR].map {|io| [io.external_encoding, io.internal_encoding] }

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -6,32 +6,6 @@ require_relative "helper"
 
 module TestIRB
   class ExtendCommandTest < TestCase
-    class TestInputMethod < ::IRB::InputMethod
-      attr_reader :list, :line_no
-
-      def initialize(list = [])
-        super("test")
-        @line_no = 0
-        @list = list
-      end
-
-      def gets
-        @list[@line_no]&.tap {@line_no += 1}
-      end
-
-      def eof?
-        @line_no >= @list.size
-      end
-
-      def encoding
-        Encoding.default_external
-      end
-
-      def reset
-        @line_no = 0
-      end
-    end
-
     def setup
       @pwd = Dir.pwd
       @tmpdir = File.join(Dir.tmpdir, "test_reline_config_#{$$}")

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -7,32 +7,6 @@ require_relative "helper"
 
 module TestIRB
   class TestContext < TestCase
-    class TestInputMethod < ::IRB::InputMethod
-      attr_reader :list, :line_no
-
-      def initialize(list = [])
-        super("test")
-        @line_no = 0
-        @list = list
-      end
-
-      def gets
-        @list[@line_no]&.tap {@line_no += 1}
-      end
-
-      def eof?
-        @line_no >= @list.size
-      end
-
-      def encoding
-        Encoding.default_external
-      end
-
-      def reset
-        @line_no = 0
-      end
-    end
-
     def setup
       IRB.init_config(nil)
       IRB.conf[:USE_SINGLELINE] = false

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -15,38 +15,10 @@ module TestIRB
       IRB.conf[:RC_NAME_GENERATOR] = nil
     end
 
-    class TestInputMethod < ::IRB::InputMethod
+    class TestInputMethodWithHistory < TestInputMethod
       HISTORY = Array.new
 
       include IRB::HistorySavingAbility
-
-      attr_reader :list, :line_no
-
-      def initialize(list = [])
-        super("test")
-        @line_no = 0
-        @list = list
-      end
-
-      def gets
-        @list[@line_no]&.tap {@line_no += 1}
-      end
-
-      def eof?
-        @line_no >= @list.size
-      end
-
-      def encoding
-        Encoding.default_external
-      end
-
-      def reset
-        @line_no = 0
-      end
-
-      def winsize
-        [10, 20]
-      end
     end
 
     def test_history_save_1
@@ -167,7 +139,7 @@ module TestIRB
       IRB.conf[:SAVE_HISTORY] = 1
       Dir.mktmpdir("test_irb_history_") do |tmpdir|
         ENV["HOME"] = tmpdir
-        io = TestInputMethod.new
+        io = TestInputMethodWithHistory.new
         io.class::HISTORY.clear
         io.load_history
         io.class::HISTORY.concat(%w"line1 line2")
@@ -198,7 +170,7 @@ module TestIRB
           f.write(initial_irb_history)
         end
 
-        io = TestInputMethod.new
+        io = TestInputMethodWithHistory.new
         io.class::HISTORY.clear
         io.load_history
         if block_given?


### PR DESCRIPTION
The `TestInputMethod` is defined in 3 different test files, which is now unnecessary given we have a shared helper file.