### PR TITLE
Improve testing infra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,10 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Run test
+    - name: Run tests
       run: bundle exec rake test
+    - name: Run tests in isolation
+      run: bundle exec rake test_in_isolation
   vterm-yamatanooroti:
     name: >-
       vterm-yamatanooroti ${{ matrix.ruby }} ${{ matrix.with_latest_reline && '(latest reline)' || '' }}

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,31 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/irb/test_*.rb"]
 end
 
+# To make sure they have been correctly setup for Ruby CI.
+desc "Run each irb test file in isolation."
+task :test_in_isolation do
+  failed = false
+
+  FileList["test/irb/test_*.rb"].each do |test_file|
+    ENV["TEST"] = test_file
+    begin
+      Rake::Task["test"].execute
+    rescue => e
+      failed = true
+      msg = "Test '#{test_file}' failed when being executed in isolation. Please make sure 'rake test TEST=#{test_file}' passes."
+      separation_line = '=' * msg.length
+
+      puts <<~MSG
+        #{separation_line}
+        #{msg}
+        #{separation_line}
+      MSG
+    end
+  end
+
+  fail "Some tests failed when being executed in isolation" if failed
+end
+
 Rake::TestTask.new(:test_yamatanooroti) do |t|
   t.libs << 'test' << "test/lib"
   t.libs << 'lib'

--- a/test/irb/test_raise_no_backtrace_exception.rb
+++ b/test/irb/test_raise_no_backtrace_exception.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: false
+require "tmpdir"
 
 require_relative "helper"
 


### PR DESCRIPTION
There's a huge difference between how tests are run in this repo and after being synced to Ruby CI. And that causes Ruby CI failure like [this](https://github.com/ruby/ruby/runs/9496205938) not being detected in the original PR https://github.com/ruby/irb/pull/441. I think the rule of thumb is to have every test file self-contained, which is hard to verify with the current `rake test`. 

So in this PR I added `test_in_isolation` task, which runs each test file in isolation. With this task, we would be able to catch the above failure before the PR is merged.

With this new task, I also caught another undiscovered error:

```
=========================================================================================================================================================================================================================================================================================================================================================================================================================================
Error: test_raise_exception_with_different_encoding_containing_invalid_byte_sequence(TestIRB::TestRaiseNoBacktraceException):
  NoMethodError: undefined method `mktmpdir' for Dir:Class

        Dir.mktmpdir("test_irb_raise_no_backtrace_exception_#{$$}") do |tmpdir|
           ^^^^^^^^^
  Did you mean?  mkdir
/Users/hung-wulo/src/github.com/ruby/irb/test/irb/test_raise_no_backtrace_exception.rb:28:in `test_raise_exception_with_different_encoding_containing_invalid_byte_sequence'
     25:
     26:     def test_raise_exception_with_different_encoding_containing_invalid_byte_sequence
     27:       backup_home = ENV["HOME"]
  => 28:       Dir.mktmpdir("test_irb_raise_no_backtrace_exception_#{$$}") do |tmpdir|
     29:         ENV["HOME"] = tmpdir
     30:
     31:         bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []
=========================================================================================================================================================================================================================================================================================================================================================================================================================================
.
Finished in 0.477298 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
3 tests, 6 assertions, 0 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
66.6667% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
6.29 tests/s, 12.57 assertions/s
=====================================================================================================================================================================================
Test 'test/irb/test_raise_no_backtrace_exception.rb' failed when being executed in isolation. Please make sure 'rake test TEST=test/irb/test_raise_no_backtrace_exception.rb' passes.
=====================================================================================================================================================================================
```

Which is now fixed in the last commit.