### PR TITLE
Discover and load debug.gem even if it's not in Gemfile

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -393,8 +393,6 @@ module IRB
   end
 
   class Irb
-    DIR_NAME = __dir__
-
     ASSIGNMENT_NODE_TYPES = [
       # Local, instance, global, class, constant, instance, and index assignment:
       #   "foo = bar",
@@ -436,13 +434,14 @@ module IRB
       @scanner = RubyLex.new
     end
 
+    # A hook point for `debug` command's TracePoint after :IRB_EXIT as well as its clean-up
     def debug_break
       # it means the debug command is executed
-      if defined?(DEBUGGER__) && DEBUGGER__.respond_to?(:original_capture_frames)
+      if defined?(DEBUGGER__) && DEBUGGER__.respond_to?(:capture_frames_without_irb)
         # after leaving this initial breakpoint, revert the capture_frames patch
-        DEBUGGER__.singleton_class.send(:alias_method, :capture_frames, :original_capture_frames)
+        DEBUGGER__.singleton_class.send(:alias_method, :capture_frames, :capture_frames_without_irb)
         # and remove the redundant method
-        DEBUGGER__.singleton_class.send(:undef_method, :original_capture_frames)
+        DEBUGGER__.singleton_class.send(:undef_method, :capture_frames_without_irb)
       end
     end
 

--- a/lib/irb/cmd/debug.rb
+++ b/lib/irb/cmd/debug.rb
@@ -5,28 +5,68 @@ module IRB
 
   module ExtendCommand
     class Debug < Nop
-      def execute(*args)
-        require "debug/session"
-        DEBUGGER__.start(nonstop: true)
-        DEBUGGER__.singleton_class.send(:alias_method, :original_capture_frames, :capture_frames)
+      BINDING_IRB_FRAME_REGEXPS = [
+        '<internal:prelude>',
+        binding.method(:irb).source_location.first,
+      ].map { |file| /\A#{Regexp.escape(file)}:\d+:in `irb'\z/ }
+      IRB_DIR = File.expand_path('..', __dir__)
 
-        def DEBUGGER__.capture_frames(skip_path_prefix)
-          frames = original_capture_frames(skip_path_prefix)
-          frames.reject! do |frame|
-            frame.realpath&.start_with?(::IRB::Irb::DIR_NAME) || frame.path.match?(/internal:prelude/)
-          end
-          frames
+      def execute(*args)
+        unless binding_irb?
+          puts "`debug` command is supported only on binding.irb"
+          return
         end
 
+        unless setup_debugger
+          puts <<~MSG
+            You need to install the debug gem before using this command.
+            If you use `bundle exec`, please add `gem "debug"` into your Gemfile.
+          MSG
+          return
+        end
+
+        # To make debugger commands like `next` or `continue` work without asking
+        # the user to quit IRB after that, we need to exit IRB first and then hit
+        # a TracePoint on #debug_break.
         file, lineno = IRB::Irb.instance_method(:debug_break).source_location
         DEBUGGER__::SESSION.add_line_breakpoint(file, lineno + 1, oneshot: true, hook_call: false)
         # exit current Irb#run call
         throw :IRB_EXIT
-      rescue LoadError => e
-        puts <<~MSG
-          You need to install the debug gem before using this command.
-          If you use `bundle exec`, please add `gem "debug"` into your Gemfile.
-        MSG
+      end
+
+      private
+
+      def binding_irb?
+        caller.any? do |frame|
+          BINDING_IRB_FRAME_REGEXPS.any? do |regexp|
+            frame.match?(regexp)
+          end
+        end
+      end
+
+      def setup_debugger
+        unless defined?(DEBUGGER__::SESSION)
+          begin
+            require "debug/session"
+          rescue LoadError
+            return false
+          end
+          DEBUGGER__.start(nonstop: true)
+        end
+
+        unless DEBUGGER__.respond_to?(:capture_frames_without_irb)
+          DEBUGGER__.singleton_class.send(:alias_method, :capture_frames_without_irb, :capture_frames)
+
+          def DEBUGGER__.capture_frames(*args)
+            frames = capture_frames_without_irb(*args)
+            frames.reject! do |frame|
+              frame.realpath&.start_with?(IRB_DIR) || frame.path == "<internal:prelude>"
+            end
+            frames
+          end
+        end
+
+        true
       end
     end
   end

--- a/lib/irb/cmd/debug.rb
+++ b/lib/irb/cmd/debug.rb
@@ -73,10 +73,12 @@ module IRB
       # installed by `bundle install`, debug.gem is installed by default because
       # it's a bundled gem. This method tries to activate and load that.
       def load_bundled_debug_gem
-        # Discover debug.gem in GEM_HOME
-        debug_gem = Dir.glob("#{Gem.paths.home}/gems/debug-*").sort.reverse.find do |path|
+        # Discover latest debug.gem under GEM_PATH
+        debug_gem = Gem.paths.path.map { |path| Dir.glob("#{path}/gems/debug-*") }.flatten.select do |path|
           File.basename(path).match?(/\Adebug-\d+\.\d+\.\d+\z/)
-        end
+        end.sort_by do |path|
+          Gem::Version.new(File.basename(path).delete_prefix('debug-'))
+        end.last
         return false unless debug_gem
 
         # Attempt to forcibly load the bundled gem

--- a/lib/irb/cmd/debug.rb
+++ b/lib/irb/cmd/debug.rb
@@ -83,11 +83,10 @@ module IRB
         $LOAD_PATH << "#{debug_gem}/lib"
         begin
           require "debug/session"
-        rescue LoadError
-          false
-        else
           puts "Loaded #{File.basename(debug_gem)}"
           true
+        rescue LoadError
+          false
         end
       end
     end


### PR DESCRIPTION
Note: This PR contains the diff of https://github.com/ruby/irb/pull/447 as well. Please look at that first, and ignore the first commit when reviewing this PR.

So this is what I wanted to do in this command. The most useful and unique feature of `binding.irb` is that you don't need to write that in Gemfile. This `load_bundled_debug_gem` implementation applies it to the `debug` command on `binding.irb`.

This is a bit hacky for sure, but you can always avoid the risk by just adding debug.gem to Gemfile. Thus I believe this is a superset in terms of supported use cases.