### PR TITLE
Document a full list of commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,48 @@ irb(main):006:1> end
 
 The Readline extension module can be used with irb. Use of Readline is default if it's installed.
 
+## Commands
+
+The following commands are available on IRB.
+
+* `cwws`
+  * Show the current workspace.
+* `cb`, `cws`, `chws`
+  * Change the current workspace to an object.
+* `bindings`, `workspaces`
+  * Show workspaces.
+* `pushb`, `pushws`
+  * Push an object to the workspace stack.
+* `popb`, `popws`
+  * Pop a workspace from the workspace stack.
+* `load`
+  * Load a Ruby file.
+* `require`
+  * Require a Ruby file.
+* `source`
+  * Loads a given file in the current session.
+* `irb`
+  * Start a child IRB.
+* `jobs`
+  * List of current sessions.
+* `fg`
+  * Switches to the session of the given number.
+* `kill`
+  * Kills the session with the given number.
+* `help`
+  * Enter the mode to look up RI documents.
+* `irb_info`
+  * Show information about IRB.
+* `ls`
+  * Show methods, constants, and variables.
+    `-g [query]` or `-G [query]` allows you to filter out the output.
+* `measure`
+  * `measure` enables the mode to measure processing time. `measure :off` disables it.
+* `$`, `show_source`
+  * Show the source code of a given method or constant.
+* `@`, `whereami`
+  * Show the source code around binding.irb again.
+
 ## Documentation
 
 https://docs.ruby-lang.org/en/master/IRB.html

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ The following commands are available on IRB.
   * Show the source code of a given method or constant.
 * `@`, `whereami`
   * Show the source code around binding.irb again.
+* `debug`
+  * Start the debugger of debug.gem.
 
 ## Documentation
 

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -94,6 +94,8 @@ require_relative "irb/easter-egg"
 #   * Show the source code of a given method or constant.
 # * @, whereami
 #   * Show the source code around binding.irb again.
+# * debug
+#   * Start the debugger of debug.gem.
 #
 # == Configuration
 #

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -53,6 +53,48 @@ require_relative "irb/easter-egg"
 #
 #   :include: ./irb/lc/help-message
 #
+# == Commands
+#
+# The following commands are available on IRB.
+#
+# * cwws
+#   * Show the current workspace.
+# * cb, cws, chws
+#   * Change the current workspace to an object.
+# * bindings, workspaces
+#   * Show workspaces.
+# * pushb, pushws
+#   * Push an object to the workspace stack.
+# * popb, popws
+#   * Pop a workspace from the workspace stack.
+# * load
+#   * Load a Ruby file.
+# * require
+#   * Require a Ruby file.
+# * source
+#   * Loads a given file in the current session.
+# * irb
+#   * Start a child IRB.
+# * jobs
+#   * List of current sessions.
+# * fg
+#   * Switches to the session of the given number.
+# * kill
+#   * Kills the session with the given number.
+# * help
+#   * Enter the mode to look up RI documents.
+# * irb_info
+#   * Show information about IRB.
+# * ls
+#   * Show methods, constants, and variables.
+#     -g [query] or -G [query] allows you to filter out the output.
+# * measure
+#   * measure enables the mode to measure processing time. measure :off disables it.
+# * $, show_source
+#   * Show the source code of a given method or constant.
+# * @, whereami
+#   * Show the source code around binding.irb again.
+#
 # == Configuration
 #
 # IRB reads a personal initialization file when it's invoked.

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -165,27 +165,7 @@ module IRB # :nodoc:
       nil
     end
 
-    # Installs the default irb commands:
-    #
-    # +irb_current_working_workspace+::   Context#main
-    # +irb_change_workspace+::            Context#change_workspace
-    # +irb_workspaces+::                  Context#workspaces
-    # +irb_push_workspace+::              Context#push_workspace
-    # +irb_pop_workspace+::               Context#pop_workspace
-    # +irb_load+::                        #irb_load
-    # +irb_require+::                     #irb_require
-    # +irb_source+::                      IrbLoader#source_file
-    # +irb+::                             IRB.irb
-    # +irb_jobs+::                        JobManager
-    # +irb_fg+::                          JobManager#switch
-    # +irb_kill+::                        JobManager#kill
-    # +irb_help+::                        IRB@Command+line+options
-    # +irb_info+::                        #inspect
-    # +irb_ls+::                          Output#dump
-    # +irb_measure+::                     IRB::unset_measure_callback
-    # +irb_show_source+::                 #find_source, #show_source
-    # +irb_whereami+::                    Workspace#code_around_binding
-    # +irb_debug+::                       #debugger
+    # Installs the default irb commands.
     def self.install_extend_commands
       for args in @EXTEND_COMMANDS
         def_extend_command(*args)

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -185,6 +185,7 @@ module IRB # :nodoc:
     # +irb_measure+::                     IRB::unset_measure_callback
     # +irb_show_source+::                 #find_source, #show_source
     # +irb_whereami+::                    Workspace#code_around_binding
+    # +irb_debug+::                       #debugger
     def self.install_extend_commands
       for args in @EXTEND_COMMANDS
         def_extend_command(*args)


### PR DESCRIPTION
Partly address this problem https://github.com/ruby/irb/pull/449#issuecomment-1320589869:

> How can we help users discover them? debug has help command to help users learn all the commands' usages. But irb doesn't have it and we also don't have good documentation atm. 

With the current way of README format, I haven't noticed IRB had a long document at https://docs.ruby-lang.org/en/master/IRB.html until today. I find it more discoverable to just write them down in README like debug.gem https://github.com/ruby/debug#debug-command-on-the-debug-console.

So, while I added the list to the official documentation for its readers, I also added it to the README as well. This should be useful even after https://github.com/ruby/irb/issues/450 since you'll somehow need to discover `help` command itself. Having that in README could be a good help.

Note that this list is based on [this comment](https://github.com/ruby/irb/blob/ff8b6fe4d49b746175961fd60675112e5c250a58/lib/irb/extend-command.rb#L170-L187). I think we could document this even better, e.g. have categories or show commonly-used commands first, but that shouldn't stop this PR from being merged. I'd like to focus on having something first, and then improve it in other PRs.