### PR TITLE
Fix the debug.gem force-loader for Ruby 3.2

### DIFF
--- a/lib/irb/cmd/debug.rb
+++ b/lib/irb/cmd/debug.rb
@@ -82,14 +82,22 @@ module IRB
       # it's a bundled gem. This method tries to activate and load that.
       def load_bundled_debug_gem
         # Discover latest debug.gem under GEM_PATH
-        debug_gem = Gem.paths.path.map { |path| Dir.glob("#{path}/gems/debug-*") }.flatten.select do |path|
+        debug_gem = Gem.paths.path.flat_map { |path| Dir.glob("#{path}/gems/debug-*") }.select do |path|
           File.basename(path).match?(/\Adebug-\d+\.\d+\.\d+\z/)
         end.sort_by do |path|
           Gem::Version.new(File.basename(path).delete_prefix('debug-'))
         end.last
         return false unless debug_gem
 
+        # Discover debug/debug.so under extensions for Ruby 3.2+
+        debug_so = Gem.paths.path.flat_map do |path|
+          Dir.glob("#{path}/extensions/**/#{File.basename(debug_gem)}/debug/debug.so")
+        end.first
+
         # Attempt to forcibly load the bundled gem
+        if debug_so
+          $LOAD_PATH << debug_so.delete_suffix('/debug/debug.so')
+        end
         $LOAD_PATH << "#{debug_gem}/lib"
         begin
           require "debug/session"

--- a/lib/irb/cmd/debug.rb
+++ b/lib/irb/cmd/debug.rb
@@ -83,7 +83,7 @@ module IRB
       def load_bundled_debug_gem
         # Discover latest debug.gem under GEM_PATH
         debug_gem = Gem.paths.path.flat_map { |path| Dir.glob("#{path}/gems/debug-*") }.select do |path|
-          File.basename(path).match?(/\Adebug-\d+\.\d+\.\d+\z/)
+          File.basename(path).match?(/\Adebug-\d+\.\d+\.\d+(\w+)?\z/)
         end.sort_by do |path|
           Gem::Version.new(File.basename(path).delete_prefix('debug-'))
         end.last


### PR DESCRIPTION
Follows up https://github.com/ruby/irb/pull/448.

Ruby 3.1.3 has a debug.gem installation like:

```
$ find /opt/rubies/3.1.3 |grep "debug\.so"
/opt/rubies/3.1.3/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0-static/debug-1.6.3/debug/debug.so
/opt/rubies/3.1.3/lib/ruby/gems/3.1.0/gems/debug-1.6.3/ext/debug/debug.so
/opt/rubies/3.1.3/lib/ruby/gems/3.1.0/gems/debug-1.6.3/lib/debug/debug.so
```

On the other hand, Ruby 3.2.0-preview3 has only:

```
$ find /opt/rubies/3.2.0-preview3 |grep "debug\.so"
/opt/rubies/3.2.0-preview3/lib/ruby/gems/3.2.0+3/extensions/x86_64-linux/3.2.0+3-static/debug-1.6.3/debug/debug.so
```

We'd need to support the `extensions` path for Ruby 3.2.