### PR TITLE
Activate yamatanooroti tests on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,4 +71,4 @@ jobs:
           gem install bundler --no-document
           WITH_VTERM=1 bundle install
       - name: rake test_yamatanooroti
-        run: bundle exec rake test_yamatanooroti
+        run: WITH_VTERM=1 bundle exec rake test_yamatanooroti

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -297,9 +297,9 @@ begin
       write("continue\n")
       write("delete 0\n")
       close
-      assert_include_screen(<<~EOC)
+      assert_include_screen(<<~EOC.strip)
         (rdbg:irb) delete 0
-        deleted: #0  BP - Line  #{@ruby_file}:5 (line)
+        deleted: #0  BP - Line
       EOC
     end
 


### PR DESCRIPTION
The env is also needed for running the tests, otherwise it won't load the `vterm` gem and won't do anything.