### PR TITLE
Make sure ls doesn't return an array

### DIFF
--- a/lib/irb/cmd/ls.rb
+++ b/lib/irb/cmd/ls.rb
@@ -30,6 +30,7 @@ module IRB
         o.dump("instance variables", obj.instance_variables)
         o.dump("class variables", klass.class_variables)
         o.dump("locals", locals)
+        nil
       end
 
       def dump_methods(o, klass, obj)


### PR DESCRIPTION
Sometimes executing `ls` command returns an array, but this wasn't intended.