### PR TITLE
Disable debug cmd tests based on project structure instead of env

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -36,6 +36,10 @@ module TestIRB
       end
     end
 
+    def ruby_core?
+      !Pathname(__dir__).join("../../", "irb.gemspec").exist?
+    end
+
     def save_encodings
       @default_encoding = [Encoding.default_external, Encoding.default_internal]
       @stdio_encodings = [STDIN, STDOUT, STDERR].map {|io| [io.external_encoding, io.internal_encoding] }

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -16,13 +16,16 @@ module TestIRB
     }
 
     def setup
-      if ENV["GITHUB_ACTION_REPOSITORY"] != "ruby/irb"
-        omit "This test works only on ruby/irb CI"
+      if ruby_core?
+        omit "This test works only under ruby/irb"
+      end
+
+      if RUBY_ENGINE == 'truffleruby'
+        omit "This test runs with ruby/debug, which doesn't work with truffleruby"
       end
     end
 
     def test_backtrace
-      omit if RUBY_ENGINE == 'truffleruby'
       write_ruby <<~'RUBY'
         def foo
           binding.irb
@@ -40,7 +43,6 @@ module TestIRB
     end
 
     def test_debug
-      omit if RUBY_ENGINE == 'truffleruby'
       write_ruby <<~'ruby'
         binding.irb
         puts "hello"
@@ -57,7 +59,6 @@ module TestIRB
     end
 
     def test_next
-      omit if RUBY_ENGINE == 'truffleruby'
       write_ruby <<~'ruby'
         binding.irb
         puts "hello"
@@ -73,7 +74,6 @@ module TestIRB
     end
 
     def test_break
-      omit if RUBY_ENGINE == 'truffleruby'
       write_ruby <<~'RUBY'
         binding.irb
         puts "Hello"
@@ -90,7 +90,6 @@ module TestIRB
     end
 
     def test_delete
-      omit if RUBY_ENGINE == 'truffleruby'
       write_ruby <<~'RUBY'
         binding.irb
         puts "Hello"
@@ -110,7 +109,6 @@ module TestIRB
     end
 
     def test_step
-      omit if RUBY_ENGINE == 'truffleruby'
       write_ruby <<~'RUBY'
         def foo
           puts "Hello"
@@ -129,7 +127,6 @@ module TestIRB
     end
 
     def test_continue
-      omit if RUBY_ENGINE == 'truffleruby'
       write_ruby <<~'RUBY'
         binding.irb
         puts "Hello"
@@ -147,7 +144,6 @@ module TestIRB
     end
 
     def test_finish
-      omit if RUBY_ENGINE == 'truffleruby'
       write_ruby <<~'RUBY'
         def foo
           binding.irb
@@ -166,7 +162,6 @@ module TestIRB
     end
 
     def test_info
-      omit if RUBY_ENGINE == 'truffleruby'
       write_ruby <<~'RUBY'
         def foo
           a = "He" + "llo"
@@ -186,7 +181,6 @@ module TestIRB
     end
 
     def test_catch
-      omit if RUBY_ENGINE == 'truffleruby'
       write_ruby <<~'RUBY'
         binding.irb
         1 / 0


### PR DESCRIPTION
It's hard to find an env var that's universally set in all Ruby CI environments but not in local. Checking gemspec seems to be a better way as `syntax_suggest` already uses it for a while.

https://github.com/ruby/syntax_suggest/blob/d8f1bca297a392b80b5d167e2be07cf6ac4feae3/spec/spec_helper.rb#L47