### PR TITLE
Require pathname in test helper

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -1,4 +1,6 @@
 require "test/unit"
+require "pathname"
+
 begin
   require_relative "../lib/helper"
 rescue LoadError # ruby/ruby defines helpers differently


### PR DESCRIPTION
It should fix [this build](https://github.com/ruby/ruby/runs/9855874830).