### PR TITLE
Allow disabling autocompletion with `IRB_USE_AUTOCOMPLETE=false` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ The following commands are available on IRB.
 * `break`, `delete`, `next`, `step`, `continue`, `finish`, `backtrace`, `info`, `catch`
   * Start the debugger of debug.gem and run the command on it.
 
+## Configuration
+
+### Environment Variables
+
+- `NO_COLOR`: Assigning a value to it disables IRB's colorization.
+- `IRB_USE_AUTOCOMPLETE`: Setting it to `false` disables IRB's autocompletion.
+- `EDITOR`: Its value would be used to open files by the `edit` command.
+- `IRBRC`: The file specified would be evaluated as IRB's rc-file.
+
 ## Documentation
 
 https://docs.ruby-lang.org/en/master/IRB.html

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -45,7 +45,7 @@ module IRB # :nodoc:
 
     @CONF[:USE_SINGLELINE] = false unless defined?(ReadlineInputMethod)
     @CONF[:USE_COLORIZE] = (nc = ENV['NO_COLOR']).nil? || nc.empty?
-    @CONF[:USE_AUTOCOMPLETE] = true
+    @CONF[:USE_AUTOCOMPLETE] = ENV.fetch("IRB_USE_AUTOCOMPLETE", "true") != "false"
     @CONF[:INSPECT_MODE] = true
     @CONF[:USE_TRACER] = false
     @CONF[:USE_LOADER] = false

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -96,6 +96,30 @@ module TestIRB
       IRB.conf[:USE_COLORIZE] = orig_use_colorize
     end
 
+    def test_use_autocomplete_environment_variable
+      orig_use_autocomplete_env = ENV['IRB_USE_AUTOCOMPLETE']
+      orig_use_autocomplete_conf = IRB.conf[:USE_AUTOCOMPLETE]
+
+      ENV['IRB_USE_AUTOCOMPLETE'] = nil
+      IRB.setup(__FILE__)
+      assert IRB.conf[:USE_AUTOCOMPLETE]
+
+      ENV['IRB_USE_AUTOCOMPLETE'] = ''
+      IRB.setup(__FILE__)
+      assert IRB.conf[:USE_AUTOCOMPLETE]
+
+      ENV['IRB_USE_AUTOCOMPLETE'] = 'false'
+      IRB.setup(__FILE__)
+      refute IRB.conf[:USE_AUTOCOMPLETE]
+
+      ENV['IRB_USE_AUTOCOMPLETE'] = 'true'
+      IRB.setup(__FILE__)
+      assert IRB.conf[:USE_AUTOCOMPLETE]
+    ensure
+      ENV["IRB_USE_AUTOCOMPLETE"] = orig_use_autocomplete_env
+      IRB.conf[:USE_AUTOCOMPLETE] = orig_use_autocomplete_conf
+    end
+
     def test_noscript
       argv = %w[--noscript -- -f]
       IRB.setup(eval("__FILE__"), argv: argv)


### PR DESCRIPTION
Currently, the only 2 ways to disable autocompletion are:

1. Create `.irbrc` and set `IRB.conf[:USE_AUTOCOMPLETE] = false`
2. Add the `--noautocomplete` flag when using the `irb` executable

Both of them are less convenient than setting a env var and are lesser known to devs.

And given the number of problems the autocompletion has (see #445), I think we should allow disabling it with a simple `IRB_USE_AUTOCOMPLETE=false`.