### PR TITLE
Lazily load the multi-irb extension

### DIFF
--- a/lib/irb/cmd/subirb.rb
+++ b/lib/irb/cmd/subirb.rb
@@ -10,31 +10,42 @@
 #
 
 require_relative "nop"
-require_relative "../ext/multi-irb"
 
 module IRB
   # :stopdoc:
 
   module ExtendCommand
-    class IrbCommand < Nop
+    class MultiIRBCommand < Nop
+      def initialize(conf)
+        super
+        extend_irb_context
+      end
+
+      def extend_irb_context
+        # this extension patches IRB context like IRB.CurrentContext
+        require_relative "../ext/multi-irb"
+      end
+    end
+
+    class IrbCommand < MultiIRBCommand
       def execute(*obj)
         IRB.irb(nil, *obj)
       end
     end
 
-    class Jobs < Nop
+    class Jobs < MultiIRBCommand
       def execute
         IRB.JobManager
       end
     end
 
-    class Foreground < Nop
+    class Foreground < MultiIRBCommand
       def execute(key)
         IRB.JobManager.switch(key)
       end
     end
 
-    class Kill < Nop
+    class Kill < MultiIRBCommand
       def execute(*keys)
         IRB.JobManager.kill(*keys)
       end

--- a/lib/irb/cmd/subirb.rb
+++ b/lib/irb/cmd/subirb.rb
@@ -21,6 +21,8 @@ module IRB
         extend_irb_context
       end
 
+      private
+
       def extend_irb_context
         # this extension patches IRB context like IRB.CurrentContext
         require_relative "../ext/multi-irb"


### PR DESCRIPTION
We now have plan to implement a command that prints all commands'
information, which will need to load all commands files without actually
running them.

But because the `multi-irb` extension patches IRB's top-level methods,
loading it would cause unintentional side-effects.

So this commit moves related requires into command execution to avoid the problem.
