### PR TITLE
Gracefully handle missing command argument

### DIFF
--- a/lib/irb/cmd/load.rb
+++ b/lib/irb/cmd/load.rb
@@ -17,24 +17,29 @@ module IRB
   # :stopdoc:
 
   module ExtendCommand
-    class Load < Nop
+    class LoaderCommand < Nop
       include IrbLoader
 
-      category "IRB"
-      description "Load a Ruby file."
-
-      def execute(file_name, priv = nil)
-        return irb_load(file_name, priv)
+      def raise_cmd_argument_error
+        raise CommandArgumentError.new("Please specify the file name.")
       end
     end
 
-    class Require < Nop
-      include IrbLoader
+    class Load < LoaderCommand
+      category "IRB"
+      description "Load a Ruby file."
 
+      def execute(file_name = nil, priv = nil)
+        raise_cmd_argument_error unless file_name
+        irb_load(file_name, priv)
+      end
+    end
+
+    class Require < LoaderCommand
       category "IRB"
       description "Require a Ruby file."
-
-      def execute(file_name)
+      def execute(file_name = nil)
+        raise_cmd_argument_error unless file_name
 
         rex = Regexp.new("#{Regexp.quote(file_name)}(\.o|\.rb)?")
         return false if $".find{|f| f =~ rex}
@@ -62,17 +67,16 @@ module IRB
       end
     end
 
-    class Source < Nop
-      include IrbLoader
-
+    class Source < LoaderCommand
       category "IRB"
       description "Loads a given file in the current session."
 
-      def execute(file_name)
+      def execute(file_name = nil)
+        raise_cmd_argument_error unless file_name
+
         source_file(file_name)
       end
     end
   end
-
   # :startdoc:
 end

--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -13,6 +13,8 @@ module IRB
   # :stopdoc:
 
   module ExtendCommand
+    class CommandArgumentError < StandardError; end
+
     class Nop
       class << self
         def category(category = nil)
@@ -30,11 +32,15 @@ module IRB
         def self.execute(conf, *opts, **kwargs, &block)
           command = new(conf)
           command.execute(*opts, **kwargs, &block)
+        rescue CommandArgumentError => e
+          puts e.message
         end
       else
         def self.execute(conf, *opts, &block)
           command = new(conf)
           command.execute(*opts, &block)
+        rescue CommandArgumentError => e
+          puts e.message
         end
       end
 

--- a/lib/irb/cmd/subirb.rb
+++ b/lib/irb/cmd/subirb.rb
@@ -51,7 +51,8 @@ module IRB
       category "IRB"
       description "Switches to the session of the given number."
 
-      def execute(key)
+      def execute(key = nil)
+        raise CommandArgumentError.new("Please specify the id of target IRB job (listed in the `jobs` command).") unless key
         IRB.JobManager.switch(key)
       end
     end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -368,6 +368,14 @@ module TestIRB
       ], out)
     end
 
+    def test_irb_source_without_argument
+      out, err = execute_lines(
+        "irb_source\n",
+      )
+      assert_empty err
+      assert_match(/Please specify the file name./, out)
+    end
+
     def test_help
       out, _ = execute_lines(
         "help 'String#gsub'\n",
@@ -414,6 +422,15 @@ module TestIRB
           /   => nil\n/,
           /=> "bug17564"\n/,
         ], out)
+    end
+
+    def test_irb_load_without_argument
+      out, err = execute_lines(
+        "irb_load\n",
+      )
+
+      assert_empty err
+      assert_match(/Please specify the file name./, out)
     end
 
     def test_ls


### PR DESCRIPTION
Currently, if users fail to provide a command's required argument(s), IRB treats it as normal `ArgumentError` and prints confusing message with full stacktrace:

```
irb(main):001:0> fg
/Users/hung-wulo/src/github.com/ruby/irb/lib/irb/extend-command.rb:242:in `irb_fg_': wrong number of arguments (given 0, expected 1) (ArgumentError)
        from /Users/hung-wulo/src/github.com/ruby/irb/lib/irb/extend-command.rb:247:in `irb_fg'
        from (irb):1:in `<main>'
        from /Users/hung-wulo/src/github.com/ruby/irb/lib/irb/workspace.rb:119:in `eval'
        from /Users/hung-wulo/src/github.com/ruby/irb/lib/irb/workspace.rb:119:in `evaluate'
        from /Users/hung-wulo/src/github.com/ruby/irb/lib/irb/context.rb:502:in `evaluate'
        .....
        from /Users/hung-wulo/.gem/ruby/3.1.2/bin/bundle:25:in `load'
        from /Users/hung-wulo/.gem/ruby/3.1.2/bin/bundle:25:in `<main>'
Maybe IRB bug!
```

This is not helpful because:

1. It's the same message users would see when they do hit an IRB bug.
1. The message doesn't tell users how to avoid the error.

So I want to introduce a new `CommandArgumentError` class as a separation from `ArgumentError`.
And commands with required argument(s), they should raise this error specifically when it's not supplied with clear message.

```
irb(main):001:0> fg
Please specify the id of target IRB job (listed in the `jobs` command).
=> nil
```