### PR TITLE
Add show_doc as an alias to the help command

### DIFF
--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -162,6 +162,7 @@ module IRB # :nodoc:
 
       [
         :irb_help, :Help, "cmd/help",
+        [:show_doc, NO_OVERRIDE],
         [:help, NO_OVERRIDE],
       ],
 

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -376,16 +376,18 @@ module TestIRB
       assert_match(/Please specify the file name./, out)
     end
 
-    def test_help
-      out, _ = execute_lines(
-        "help 'String#gsub'\n",
-        "\n",
-      )
+    def test_help_and_show_doc
+      ["help", "show_doc"].each do |cmd|
+        out, _ = execute_lines(
+          "#{cmd} 'String#gsub'\n",
+          "\n",
+        )
 
-      # the former is what we'd get without document content installed, like on CI
-      # the latter is what we may get locally
-      possible_rdoc_output = [/Nothing known about String#gsub/, /Returns a copy of self with all occurrences of the given pattern/]
-      assert(possible_rdoc_output.any? { |output| output.match?(out) }, "Expect the help command to match one of the possible outputs")
+        # the former is what we'd get without document content installed, like on CI
+        # the latter is what we may get locally
+        possible_rdoc_output = [/Nothing known about String#gsub/, /Returns a copy of self with all occurrences of the given pattern/]
+        assert(possible_rdoc_output.any? { |output| output.match?(out) }, "Expect the `#{cmd}` command to match one of the possible outputs")
+      end
     ensure
       # this is the only way to reset the redefined method without coupling the test with its implementation
       EnvUtil.suppress_warning { load "irb/cmd/help.rb" }


### PR DESCRIPTION
In the long-term, we want to align with `Pry`, `byebug` and `debug` to use the `help` command to list all commands, which is what `show_cmds` currently does. And `show_doc` will be the command to look up Ruby APIs.

By aliasing `show_doc` to the current `help` and replacing it in the `show_cmds` output, users will have time to get use to it.

**`show_cmds`'s output after the change:**

```
irb(main):001:0> show_cmds
IRB
  cwws           Show the current workspace.
  chws           Change the current workspace to an object.
  workspaces     Show workspaces.
  pushws         Push an object to the workspace stack.
  popws          Pop a workspace from the workspace stack.
  irb_load       Load a Ruby file.
  irb_require    Require a Ruby file.
  source         Loads a given file in the current session.
  irb            Start a child IRB.
  jobs           List of current sessions.
  fg             Switches to the session of the given number.
  kill           Kills the session with the given number.
  irb_info       Show information about IRB.
  show_cmds      List all available commands and their description.

Debugging
  debug          Start the debugger of debug.gem.
  break          Start the debugger of debug.gem and run its `break` command.
  catch          Start the debugger of debug.gem and run its `catch` command.
  next           Start the debugger of debug.gem and run its `next` command.
  delete         Start the debugger of debug.gem and run its `delete` command.
  step           Start the debugger of debug.gem and run its `step` command.
  continue       Start the debugger of debug.gem and run its `continue` command.
  finish         Start the debugger of debug.gem and run its `finish` command.
  backtrace      Start the debugger of debug.gem and run its `backtrace` command.
  info           Start the debugger of debug.gem and run its `info` command.

Misc
  edit           Open a file with the editor command defined with `ENV["EDITOR"]`.
  measure        `measure` enables the mode to measure processing time. `measure :off` disables it.

Context
  show_doc       Enter the mode to look up RI documents.
  ls             Show methods, constants, and variables. `-g [query]` or `-G [query]` allows you to filter out the output.
  show_source    Show the source code of a given method or constant.
  whereami       Show the source code around binding.irb again.

```