### PR TITLE
Update readme's commands section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,56 +42,48 @@ The Readline extension module can be used with irb. Use of Readline is default i
 
 ## Commands
 
-The following commands are available on IRB.
+The following commands are available on IRB. You can get the same output from the `show_cmds` command.
 
-* `cwws`
-  * Show the current workspace.
-* `cb`, `cws`, `chws`
-  * Change the current workspace to an object.
-* `bindings`, `workspaces`
-  * Show workspaces.
-* `edit`
-  * Open a file with the editor command defined with `ENV["EDITOR"]`
-    * `edit` - opens the file the current context belongs to (if applicable)
-    * `edit foo.rb` - opens `foo.rb`
-    * `edit Foo` - opens the location of `Foo`
-    * `edit Foo.bar` - opens the location of `Foo.bar`
-    * `edit Foo#bar` - opens the location of `Foo#bar`
-* `pushb`, `pushws`
-  * Push an object to the workspace stack.
-* `popb`, `popws`
-  * Pop a workspace from the workspace stack.
-* `load`
-  * Load a Ruby file.
-* `require`
-  * Require a Ruby file.
-* `source`
-  * Loads a given file in the current session.
-* `irb`
-  * Start a child IRB.
-* `jobs`
-  * List of current sessions.
-* `fg`
-  * Switches to the session of the given number.
-* `kill`
-  * Kills the session with the given number.
-* `help`
-  * Enter the mode to look up RI documents.
-* `irb_info`
-  * Show information about IRB.
-* `ls`
-  * Show methods, constants, and variables.
-    `-g [query]` or `-G [query]` allows you to filter out the output.
-* `measure`
-  * `measure` enables the mode to measure processing time. `measure :off` disables it.
-* `$`, `show_source`
-  * Show the source code of a given method or constant.
-* `@`, `whereami`
-  * Show the source code around binding.irb again.
-* `debug`
-  * Start the debugger of debug.gem.
-* `break`, `delete`, `next`, `step`, `continue`, `finish`, `backtrace`, `info`, `catch`
-  * Start the debugger of debug.gem and run the command on it.
+
+```
+IRB
+  cwws           Show the current workspace.
+  chws           Change the current workspace to an object.
+  workspaces     Show workspaces.
+  pushws         Push an object to the workspace stack.
+  popws          Pop a workspace from the workspace stack.
+  irb_load       Load a Ruby file.
+  irb_require    Require a Ruby file.
+  source         Loads a given file in the current session.
+  irb            Start a child IRB.
+  jobs           List of current sessions.
+  fg             Switches to the session of the given number.
+  kill           Kills the session with the given number.
+  irb_info       Show information about IRB.
+  show_cmds      List all available commands and their description.
+
+Debugging
+  debug          Start the debugger of debug.gem.
+  break          Start the debugger of debug.gem and run its `break` command.
+  catch          Start the debugger of debug.gem and run its `catch` command.
+  next           Start the debugger of debug.gem and run its `next` command.
+  delete         Start the debugger of debug.gem and run its `delete` command.
+  step           Start the debugger of debug.gem and run its `step` command.
+  continue       Start the debugger of debug.gem and run its `continue` command.
+  finish         Start the debugger of debug.gem and run its `finish` command.
+  backtrace      Start the debugger of debug.gem and run its `backtrace` command.
+  info           Start the debugger of debug.gem and run its `info` command.
+
+Misc
+  edit           Open a file with the editor command defined with `ENV["EDITOR"]`.
+  measure        `measure` enables the mode to measure processing time. `measure :off` disables it.
+
+Context
+  show_doc       Enter the mode to look up RI documents.
+  ls             Show methods, constants, and variables. `-g [query]` or `-G [query]` allows you to filter out the output.
+  show_source    Show the source code of a given method or constant.
+  whereami       Show the source code around binding.irb again.
+```
 
 ## Configuration
 


### PR DESCRIPTION
I feel it's kinda nicer to read and A LOT easier to maintain if we just put the `show_cmds`'s output in the readme. WDYT? @k0kubun 