### PR TITLE
Fix step command

### DIFF
--- a/lib/irb/cmd/debug.rb
+++ b/lib/irb/cmd/debug.rb
@@ -55,6 +55,13 @@ module IRB
         end
       end
 
+      module SkipPathHelperForIRB
+        def skip_internal_path?(path)
+          # The latter can be removed once https://github.com/ruby/debug/issues/866 is resolved
+          super || path.match?(IRB_DIR) || path.match?('<internal:prelude>')
+        end
+      end
+
       def setup_debugger
         unless defined?(DEBUGGER__::SESSION)
           begin
@@ -75,6 +82,8 @@ module IRB
             end
             frames
           end
+
+          DEBUGGER__::ThreadClient.prepend(SkipPathHelperForIRB)
         end
 
         true

--- a/lib/irb/cmd/step.rb
+++ b/lib/irb/cmd/step.rb
@@ -8,8 +8,7 @@ module IRB
   module ExtendCommand
     class Step < DebugCommand
       def execute(*args)
-        # Run `next` first to move out of binding.irb
-        super(pre_cmds: "next", do_cmds: ["step", *args].join(" "))
+        super(do_cmds: ["step", *args].join(" "))
       end
     end
   end

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -119,11 +119,13 @@ module TestIRB
 
       output = run_ruby_file do
         type "step"
+        type "step"
         type "continue"
       end
 
       assert_match(/\(rdbg:irb\) step/, output)
-      assert_match(/=>   2|   puts "Hello"/, output)
+      assert_match(/=>   5\| foo/, output)
+      assert_match(/=>   2\|   puts "Hello"/, output)
     end
 
     def test_continue


### PR DESCRIPTION
The current `next` pre-command workaround on IRB source stepping moves the location by 1 extra line. 

```
From: test.rb @ line 1 :

 => 1: binding.irb
    2:
    3: c = 3
    4: d = 4

irb(main):001:0> step
(rdbg:irb) next
[1, 4] in test.rb
     1| binding.irb
     2|
=>   3| c = 3
     4| d = 4
=>#0    <main> at test.rb:3
(rdbg:irb) step
[1, 4] in test.rb
     1| binding.irb
     2|
     3| c = 3
=>   4| d = 4
=>#0    <main> at test.rb:4
(rdbg)
```

A better way is to make `debug` skip IRB frames completely. This PR does it by making `debug` think IRB paths as internal. This ensures users won't accidentally stepping into IRB frames in any way.

It also fixes the step command's test. The `|` in regexp was not escaped so it was always incorrectly matched.