### PR TITLE
`show_doc` command should take non-string argument too

### DIFF
--- a/lib/irb/cmd/edit.rb
+++ b/lib/irb/cmd/edit.rb
@@ -18,13 +18,6 @@ module IRB
             args.strip.dump
           end
         end
-
-        private
-
-        def string_literal?(args)
-          sexp = Ripper.sexp(args)
-          sexp && sexp.size == 2 && sexp.last&.first&.first == :string_literal
-        end
       end
 
       def execute(*args)

--- a/lib/irb/cmd/help.rb
+++ b/lib/irb/cmd/help.rb
@@ -16,6 +16,17 @@ module IRB
 
   module ExtendCommand
     class Help < Nop
+      class << self
+        def transform_args(args)
+          # Return a string literal as is for backward compatibility
+          if args.empty? || string_literal?(args)
+            args
+          else # Otherwise, consider the input as a String for convenience
+            args.strip.dump
+          end
+        end
+      end
+
       category "Context"
       description "Enter the mode to look up RI documents."
 

--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -26,6 +26,13 @@ module IRB
           @description = description if description
           @description
         end
+
+        private
+
+        def string_literal?(args)
+          sexp = Ripper.sexp(args)
+          sexp && sexp.size == 2 && sexp.last&.first&.first == :string_literal
+        end
       end
 
       if RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.7.0"

--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -65,11 +65,6 @@ module IRB
           end
           first_line
         end
-
-        def string_literal?(args)
-          sexp = Ripper.sexp(args)
-          sexp && sexp.size == 2 && sexp.last&.first&.first == :string_literal
-        end
       end
 
       def execute(str = nil)

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -379,13 +379,13 @@ module TestIRB
     def test_help_and_show_doc
       ["help", "show_doc"].each do |cmd|
         out, _ = execute_lines(
-          "#{cmd} 'String#gsub'\n",
+          "#{cmd} String#gsub\n",
           "\n",
         )
 
         # the former is what we'd get without document content installed, like on CI
         # the latter is what we may get locally
-        possible_rdoc_output = [/Nothing known about String#gsub/, /Returns a copy of self with all occurrences of the given pattern/]
+        possible_rdoc_output = [/Nothing known about String#gsub/, /str.gsub\(pattern\)/]
         assert(possible_rdoc_output.any? { |output| output.match?(out) }, "Expect the `#{cmd}` command to match one of the possible outputs")
       end
     ensure


### PR DESCRIPTION
Given that `show_doc` already supports syntax like `String#gsub`, it should be able to take it in non-string form too, like `edit` and `show_source` do. This ensures users can have a consistent syntax on argument between different commands.

- Before: `show_doc 'String#gsub'` 
- After: `show_doc 'String#gsub'`  and `show_doc String#gsub`
