### PR TITLE
Respect DLEXT to force-load debug.so

### DIFF
--- a/lib/irb/cmd/debug.rb
+++ b/lib/irb/cmd/debug.rb
@@ -102,13 +102,14 @@ module IRB
         return false unless debug_gem
 
         # Discover debug/debug.so under extensions for Ruby 3.2+
-        debug_so = Gem.paths.path.flat_map do |path|
-          Dir.glob("#{path}/extensions/**/#{File.basename(debug_gem)}/debug/debug.so")
+        ext_name = "/debug/debug.#{RbConfig::CONFIG['DLEXT']}"
+        ext_path = Gem.paths.path.flat_map do |path|
+          Dir.glob("#{path}/extensions/**/#{File.basename(debug_gem)}#{ext_name}")
         end.first
 
         # Attempt to forcibly load the bundled gem
-        if debug_so
-          $LOAD_PATH << debug_so.delete_suffix('/debug/debug.so')
+        if ext_path
+          $LOAD_PATH << ext_path.delete_suffix(ext_name)
         end
         $LOAD_PATH << "#{debug_gem}/lib"
         begin


### PR DESCRIPTION
Nobu noticed this in the last developers' meeting. Linux and Windows (not .dll) use `.so`, but macOS uses `.bundle`. So it should read `RbConfig::CONFIG['DLEXT']` to support macOS.