### PR TITLE
Remove unused context argument from Worksapce#evaluate

### DIFF
--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -499,7 +499,7 @@ module IRB
         line = "#{command} #{command_class.transform_args(args)}"
       end
 
-      set_last_value(@workspace.evaluate(self, line, irb_path, line_no))
+      set_last_value(@workspace.evaluate(line, irb_path, line_no))
     end
 
     def inspect_last_value # :nodoc:

--- a/lib/irb/ext/history.rb
+++ b/lib/irb/ext/history.rb
@@ -24,7 +24,7 @@ module IRB # :nodoc:
 
       if defined?(@eval_history) && @eval_history
         @eval_history_values.push @line_no, @last_value
-        @workspace.evaluate self, "__ = IRB.CurrentContext.instance_eval{@eval_history_values}"
+        @workspace.evaluate "__ = IRB.CurrentContext.instance_eval{@eval_history_values}"
       end
 
       @last_value
@@ -55,7 +55,7 @@ module IRB # :nodoc:
         else
           @eval_history_values = History.new(no)
           IRB.conf[:__TMP__EHV__] = @eval_history_values
-          @workspace.evaluate(self, "__ = IRB.conf[:__TMP__EHV__]")
+          @workspace.evaluate("__ = IRB.conf[:__TMP__EHV__]")
           IRB.conf.delete(:__TMP_EHV__)
         end
       else

--- a/lib/irb/ext/tracer.rb
+++ b/lib/irb/ext/tracer.rb
@@ -70,12 +70,12 @@ module IRB
       if context.use_tracer? && file != nil && line != nil
         Tracer.on
         begin
-          __evaluate__(context, statements, file, line)
+          __evaluate__(statements, file, line)
         ensure
           Tracer.off
         end
       else
-        __evaluate__(context, statements, file || __FILE__, line || __LINE__)
+        __evaluate__(statements, file || __FILE__, line || __LINE__)
       end
     end
   end

--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -115,7 +115,7 @@ EOF
     attr_reader :main
 
     # Evaluate the given +statements+ within the  context of this workspace.
-    def evaluate(context, statements, file = __FILE__, line = __LINE__)
+    def evaluate(statements, file = __FILE__, line = __LINE__)
       eval(statements, @binding, file, line)
     end
 


### PR DESCRIPTION
The context argument was introduced in this change:

https://github.com/ruby/irb/commit/6806669d178f90f38b99c144bdfee06bdb93a229#diff-296327851fb7a2c307c2d0693b769f58c01aaf315972f290500d10081ee200a9

perhaps for potential usages. But after that it's never used.