### PR TITLE
workspace.rb cleanup

### DIFF
--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -142,11 +142,7 @@ EOF
     end
 
     def code_around_binding
-      if @binding.respond_to?(:source_location)
-        file, pos = @binding.source_location
-      else
-        file, pos = @binding.eval('[__FILE__, __LINE__]')
-      end
+      file, pos = @binding.source_location
 
       if defined?(::SCRIPT_LINES__[file]) && lines = ::SCRIPT_LINES__[file]
         code = ::SCRIPT_LINES__[file].join('')

--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -169,8 +169,5 @@ EOF
 
       "\nFrom: #{file} @ line #{pos + 1} :\n\n#{body}#{Color.clear}\n"
     end
-
-    def IRB.delete_caller
-    end
   end
 end


### PR DESCRIPTION
Found 2 pieces of dead code in `workspace.rb` while going through code:

1. `Binding#source_location` was added in 2.6, which is the minimum supported version now. So the `respond_to?` check is no longer necessary.
2. `IRB.delete_caller` was added in the [earliest version of IRB](https://github.com/ruby/irb/commit/f47808999d24865fba1929dea1a7011ff5a517d6). But it's not currently referenced by anything. We can verify this with a [org-wide search result](https://github.com/search?q=org%3Aruby+delete_caller&type=code).

