### PR TITLE
Avoid calling private methods on the main object

### DIFF
--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -264,8 +264,8 @@ module IRB # :nodoc:
         kwargs = ", **kwargs" if RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.7.0"
         line = __LINE__; eval %[
           def #{cmd_name}(*opts#{kwargs}, &b)
-            require_relative "#{load_file}"
-            arity = ExtendCommand::#{cmd_class}.instance_method(:execute).arity
+            Kernel.require_relative "#{load_file}"
+            arity = ::IRB::ExtendCommand::#{cmd_class}.instance_method(:execute).arity
             args = (1..(arity < 0 ? ~arity : arity)).map {|i| "arg" + i.to_s }
             args << "*opts#{kwargs}" if arity < 0
             args << "&block"
@@ -274,7 +274,7 @@ module IRB # :nodoc:
               unless singleton_class.class_variable_defined?(:@@#{cmd_name}_)
                 singleton_class.class_variable_set(:@@#{cmd_name}_, true)
                 def self.#{cmd_name}_(\#{args})
-                  ExtendCommand::#{cmd_class}.execute(irb_context, \#{args})
+                  ::IRB::ExtendCommand::#{cmd_class}.execute(irb_context, \#{args})
                 end
               end
             ], nil, __FILE__, line
@@ -284,7 +284,7 @@ module IRB # :nodoc:
       else
         line = __LINE__; eval %[
           def #{cmd_name}(*opts, &b)
-            ExtendCommand::#{cmd_class}.execute(irb_context, *opts, &b)
+            ::IRB::ExtendCommand::#{cmd_class}.execute(irb_context, *opts, &b)
           end
         ], nil, __FILE__, line
       end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -49,6 +49,19 @@ module TestIRB
     end
   end
 
+  class FrozenObjectTest < CommandTestCase
+    def test_calling_command_on_a_frozen_main
+      main = Object.new.freeze
+
+      out, err = execute_lines(
+        "irb_info",
+        main: main
+      )
+      assert_empty err
+      assert_match(/RUBY_PLATFORM/, out)
+    end
+  end
+
   class CommnadAliasTest < CommandTestCase
     def test_vars_with_aliases
       @foo = "foo"


### PR DESCRIPTION
Fixes #497 

When the main object is frozen, `IRB` wraps a `SimpleDelegator` around it. But because `SimpleDelegator` doesn't delegate private methods, methods like `require_relative` or `const_get` would cause error, which are needed for lazily loading commands.

This commit works around this limitation by avoiding those private method calls when setting up command execution.
