### PR TITLE
Add timeout minutes for CI

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
+    timeout-minutes: 30
     steps:
       - name: Set up latest ruby head
         uses: ruby/setup-ruby@de6f5b9c340068d049670c6b6ae8dc94cff4667a # v1.125.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       WITH_LATEST_RELINE: ${{matrix.with_latest_reline}}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@master
       - name: Set up Ruby
@@ -53,6 +54,7 @@ jobs:
       fail-fast: false
     env:
       WITH_LATEST_RELINE: ${{matrix.with_latest_reline}}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby


### PR DESCRIPTION
Because it may run up to the default timeout of 6 hours.
https://github.com/ruby/irb/actions/runs/3874332006

The most recent run time was about 5 minutes; I don't think it will run for 30 minutes.