### PR TITLE
Remove redundant argument defaults from some RubyLex methods

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -219,7 +219,7 @@ class RubyLex
     end
   end
 
-  def check_state(code, tokens = nil, context: nil)
+  def check_state(code, tokens = nil, context:)
     tokens = self.class.ripper_lex_without_warning(code, context: context) unless tokens
     ltype = process_literal_type(tokens)
     indent = process_nesting_level(tokens)
@@ -790,7 +790,7 @@ class RubyLex
     end
   end
 
-  def check_termination_in_prev_line(code, context: nil)
+  def check_termination_in_prev_line(code, context:)
     tokens = self.class.ripper_lex_without_warning(code, context: context)
     past_first_newline = false
     index = tokens.rindex do |t|

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -293,7 +293,7 @@ class RubyLex
     line
   end
 
-  def process_continue(tokens = @tokens)
+  def process_continue(tokens)
     # last token is always newline
     if tokens.size >= 2 and tokens[-2].event == :on_regexp_end
       # end of regexp literal
@@ -314,7 +314,7 @@ class RubyLex
     false
   end
 
-  def check_code_block(code, tokens = @tokens)
+  def check_code_block(code, tokens)
     return true if tokens.empty?
     if tokens.last.event == :on_heredoc_beg
       return true
@@ -406,7 +406,7 @@ class RubyLex
     false
   end
 
-  def process_nesting_level(tokens = @tokens)
+  def process_nesting_level(tokens)
     indent = 0
     in_oneliner_def = nil
     tokens.each_with_index { |t, index|
@@ -762,7 +762,7 @@ class RubyLex
     pending_heredocs.first || start_token.last
   end
 
-  def process_literal_type(tokens = @tokens)
+  def process_literal_type(tokens)
     start_token = check_string_literal(tokens)
     return nil if start_token == ""
 

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -72,7 +72,8 @@ class RubyLex
           end
 
           code.gsub!(/\s*\z/, '').concat("\n")
-          ltype, indent, continue, code_block_open = check_state(code, context: context)
+          tokens = self.class.ripper_lex_without_warning(code, context: context)
+          ltype, indent, continue, code_block_open = check_state(code, tokens, context: context)
           if ltype or indent > 0 or continue or code_block_open
             false
           else
@@ -219,8 +220,7 @@ class RubyLex
     end
   end
 
-  def check_state(code, tokens = nil, context:)
-    tokens = self.class.ripper_lex_without_warning(code, context: context) unless tokens
+  def check_state(code, tokens, context:)
     ltype = process_literal_type(tokens)
     indent = process_nesting_level(tokens)
     continue = process_continue(tokens)


### PR DESCRIPTION
First 2 commits' argument defaults are not necessary because all of their callers specify the argument's value.
Given that these methods are only used within IRB, I feel leaving these defaults could be misleading.

The last commit is a similar cleanup by making one caller generating tokens beforehand.