### PR TITLE
Store context in RubyLex

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -468,7 +468,7 @@ module IRB
       @context = Context.new(self, workspace, input_method)
       @context.main.extend ExtendCommandBundle
       @signal_status = :IN_IRB
-      @scanner = RubyLex.new
+      @scanner = RubyLex.new(@context)
     end
 
     # A hook point for `debug` command's TracePoint after :IRB_EXIT as well as its clean-up
@@ -538,7 +538,7 @@ module IRB
         @context.io.prompt
       end
 
-      @scanner.set_input(@context.io, context: @context) do
+      @scanner.set_input(@context.io) do
         signal_status(:IN_INPUT) do
           if l = @context.io.gets
             print l if @context.verbose?
@@ -556,9 +556,9 @@ module IRB
         end
       end
 
-      @scanner.set_auto_indent(@context) if @context.auto_indent_mode
+      @scanner.set_auto_indent
 
-      @scanner.each_top_level_statement(@context) do |line, line_no|
+      @scanner.each_top_level_statement do |line, line_no|
         signal_status(:IN_EVAL) do
           begin
             line.untaint if RUBY_VERSION < '2.7'

--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -40,15 +40,15 @@ module IRB
             file, line = receiver.method(method).source_location if receiver.respond_to?(method)
           end
           if file && line
-            Source.new(file: file, first_line: line, last_line: find_end(file, line))
+            Source.new(file: file, first_line: line, last_line: find_end(file, line, irb_context))
           end
         end
 
         private
 
-        def find_end(file, first_line)
+        def find_end(file, first_line, irb_context)
           return first_line unless File.exist?(file)
-          lex = RubyLex.new
+          lex = RubyLex.new(irb_context)
           lines = File.read(file).lines[(first_line - 1)..-1]
           tokens = RubyLex.ripper_lex_without_warning(lines.join)
           prev_tokens = []


### PR DESCRIPTION
Some background/assumptions for this refactor:

1. Through a RubyLex instance's lifetime, the context passed to its methods should be the same. Given that `Context` is only initialised once in `Irb#initialize`, this should be true.

2. When `RubyLex` is initialised, the context object should be accessible. This is also true in all 3 of `RubyLex.new`'s invocations.

With the above observations, we should be able to store the context in `RubyLex` as an instance variable. And doing so will make `RubyLex`'s instance methods easier to use and maintain.