### PR TITLE
Drop unused arguments in `RubyLex`

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -48,7 +48,7 @@ class RubyLex
   end
 
   # io functions
-  def set_input(io, p = nil, context:, &block)
+  def set_input(io, context:, &block)
     @io = io
     if @io.respond_to?(:check_termination)
       @io.check_termination do |code|
@@ -116,9 +116,7 @@ class RubyLex
       end
     end
 
-    if p.respond_to?(:call)
-      @input = p
-    elsif block_given?
+    if block_given?
       @input = block
     else
       @input = Proc.new{@io.gets}

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -125,13 +125,8 @@ class RubyLex
     end
   end
 
-  def set_prompt(p = nil, &block)
-    p = block if block_given?
-    if p.respond_to?(:call)
-      @prompt = p
-    else
-      @prompt = Proc.new{print p}
-    end
+  def set_prompt(&block)
+    @prompt = block
   end
 
   ERROR_TOKENS = [

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -62,7 +62,9 @@ module TestIRB
 
       context = build_context(local_variables)
       io = proc{ lines.join("\n") }
-      ruby_lex.set_input(io, io, context: context)
+      ruby_lex.set_input(io, context: context) do
+        lines.join("\n")
+      end
       ruby_lex.lex(context)
       ruby_lex
     end


### PR DESCRIPTION
Some of `RubyLex`'s methods have unused/test-only arguments, so I remove them in this PR to simplify things.