### PR TITLE
Remove needless headers

### DIFF
--- a/exe/irb
+++ b/exe/irb
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 #
 #   irb.rb - interactive ruby
-#   	$Release Version: 0.9.6 $
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb.rb - irb main module
-#       $Release Version: 0.9.6 $
-#       $Revision$
 #       by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -3,10 +3,7 @@
 #   irb.rb - irb main module
 #       by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
+
 require "ripper"
 require "reline"
 

--- a/lib/irb/cmd/chws.rb
+++ b/lib/irb/cmd/chws.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   change-ws.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/cmd/chws.rb
+++ b/lib/irb/cmd/chws.rb
@@ -3,10 +3,6 @@
 #   change-ws.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 require_relative "nop"
 require_relative "../ext/change-ws"

--- a/lib/irb/cmd/fork.rb
+++ b/lib/irb/cmd/fork.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   fork.rb -
-#   	$Release Version: 0.9.6 $
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/cmd/fork.rb
+++ b/lib/irb/cmd/fork.rb
@@ -3,10 +3,6 @@
 #   fork.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 require_relative "nop"
 

--- a/lib/irb/cmd/help.rb
+++ b/lib/irb/cmd/help.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   help.rb - helper using ri
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #
 # --
 #

--- a/lib/irb/cmd/help.rb
+++ b/lib/irb/cmd/help.rb
@@ -2,10 +2,6 @@
 #
 #   help.rb - helper using ri
 #
-# --
-#
-#
-#
 
 require_relative "nop"
 

--- a/lib/irb/cmd/load.rb
+++ b/lib/irb/cmd/load.rb
@@ -3,10 +3,6 @@
 #   load.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 require_relative "nop"
 require_relative "../ext/loader"

--- a/lib/irb/cmd/load.rb
+++ b/lib/irb/cmd/load.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   load.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   nop.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -3,10 +3,7 @@
 #   nop.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
+
 module IRB
   # :stopdoc:
 

--- a/lib/irb/cmd/pushws.rb
+++ b/lib/irb/cmd/pushws.rb
@@ -3,10 +3,6 @@
 #   change-ws.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 require_relative "nop"
 require_relative "../ext/workspaces"

--- a/lib/irb/cmd/pushws.rb
+++ b/lib/irb/cmd/pushws.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   change-ws.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/cmd/subirb.rb
+++ b/lib/irb/cmd/subirb.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: false
+#
 #   multi.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
-#
-# --
-#
-#
 #
 
 require_relative "nop"

--- a/lib/irb/cmd/subirb.rb
+++ b/lib/irb/cmd/subirb.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: false
 #   multi.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/completion.rb -
-#   	$Release Version: 0.9$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ishitsuka.com)
 #       From Original Idea of shugo@ruby-lang.org
 #

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -3,10 +3,7 @@
 #   irb/context.rb - irb context
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
+
 require_relative "workspace"
 require_relative "inspector"
 require_relative "input-method"

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/context.rb - irb context
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/ext/change-ws.rb
+++ b/lib/irb/ext/change-ws.rb
@@ -3,10 +3,6 @@
 #   irb/ext/cb.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 module IRB # :nodoc:
   class Context

--- a/lib/irb/ext/change-ws.rb
+++ b/lib/irb/ext/change-ws.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/ext/cb.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/ext/history.rb
+++ b/lib/irb/ext/history.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   history.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/ext/history.rb
+++ b/lib/irb/ext/history.rb
@@ -3,10 +3,6 @@
 #   history.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 module IRB # :nodoc:
 

--- a/lib/irb/ext/loader.rb
+++ b/lib/irb/ext/loader.rb
@@ -3,11 +3,6 @@
 #   loader.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
-
 
 module IRB # :nodoc:
   # Raised in the event of an exception in a file loaded from an Irb session

--- a/lib/irb/ext/loader.rb
+++ b/lib/irb/ext/loader.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   loader.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/ext/multi-irb.rb
+++ b/lib/irb/ext/multi-irb.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/multi-irb.rb - multiple irb module
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/ext/multi-irb.rb
+++ b/lib/irb/ext/multi-irb.rb
@@ -3,10 +3,6 @@
 #   irb/multi-irb.rb - multiple irb module
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 module IRB
   class JobManager

--- a/lib/irb/ext/save-history.rb
+++ b/lib/irb/ext/save-history.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: false
+#
 #   save-history.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
-#
-# --
-#
-#
 #
 
 module IRB

--- a/lib/irb/ext/save-history.rb
+++ b/lib/irb/ext/save-history.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: false
 #   save-history.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/ext/tracer.rb
+++ b/lib/irb/ext/tracer.rb
@@ -3,10 +3,7 @@
 #   irb/lib/tracer.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
+
 begin
   require "tracer"
 rescue LoadError

--- a/lib/irb/ext/tracer.rb
+++ b/lib/irb/ext/tracer.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/lib/tracer.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/ext/use-loader.rb
+++ b/lib/irb/ext/use-loader.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   use-loader.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/ext/use-loader.rb
+++ b/lib/irb/ext/use-loader.rb
@@ -3,10 +3,6 @@
 #   use-loader.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 require_relative "../cmd/load"
 require_relative "loader"

--- a/lib/irb/ext/workspaces.rb
+++ b/lib/irb/ext/workspaces.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   push-ws.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/ext/workspaces.rb
+++ b/lib/irb/ext/workspaces.rb
@@ -3,10 +3,6 @@
 #   push-ws.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 module IRB # :nodoc:
   class Context

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -3,10 +3,7 @@
 #   irb/extend-command.rb - irb extend command
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
+
 module IRB # :nodoc:
   # Installs the default irb extensions command bundle.
   module ExtendCommandBundle

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/extend-command.rb - irb extend command
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/frame.rb
+++ b/lib/irb/frame.rb
@@ -3,10 +3,6 @@
 #   frame.rb -
 #   	by Keiju ISHITSUKA(Nihon Rational Software Co.,Ltd)
 #
-# --
-#
-#
-#
 
 module IRB
   class Frame

--- a/lib/irb/frame.rb
+++ b/lib/irb/frame.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   frame.rb -
-#   	$Release Version: 0.9$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(Nihon Rational Software Co.,Ltd)
 #
 # --

--- a/lib/irb/help.rb
+++ b/lib/irb/help.rb
@@ -3,10 +3,6 @@
 #   irb/help.rb - print usage module
 #   	by Keiju ISHITSUKA(keiju@ishitsuka.com)
 #
-# --
-#
-#
-#
 
 require_relative 'magic-file'
 

--- a/lib/irb/help.rb
+++ b/lib/irb/help.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/help.rb - print usage module
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ishitsuka.com)
 #
 # --

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -3,10 +3,6 @@
 #   irb/init.rb - irb initialize module
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 module IRB # :nodoc:
 

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/init.rb - irb initialize module
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/input-method.rb - input methods used irb
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -3,10 +3,7 @@
 #   irb/input-method.rb - input methods used irb
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
+
 require_relative 'src_encoding'
 require_relative 'magic-file'
 require_relative 'completion'

--- a/lib/irb/inspector.rb
+++ b/lib/irb/inspector.rb
@@ -3,10 +3,6 @@
 #   irb/inspector.rb - inspect methods
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 module IRB # :nodoc:
 

--- a/lib/irb/inspector.rb
+++ b/lib/irb/inspector.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/inspector.rb - inspect methods
-#   	$Release Version: 0.9.6$
-#   	$Revision: 1.19 $
-#   	$Date: 2002/06/11 07:51:31 $
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/lc/error.rb
+++ b/lib/irb/lc/error.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/lc/error.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/lc/error.rb
+++ b/lib/irb/lc/error.rb
@@ -3,10 +3,6 @@
 #   irb/lc/error.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 module IRB
   # :stopdoc:

--- a/lib/irb/lc/ja/error.rb
+++ b/lib/irb/lc/ja/error.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # frozen_string_literal: false
 #   irb/lc/ja/error.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)

--- a/lib/irb/lc/ja/error.rb
+++ b/lib/irb/lc/ja/error.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: false
+#
 #   irb/lc/ja/error.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
-#
-# --
-#
-#
 #
 
 module IRB

--- a/lib/irb/lc/ja/error.rb
+++ b/lib/irb/lc/ja/error.rb
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # frozen_string_literal: false
 #   irb/lc/ja/error.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/locale.rb
+++ b/lib/irb/locale.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/locale.rb - internationalization module
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/locale.rb
+++ b/lib/irb/locale.rb
@@ -3,10 +3,7 @@
 #   irb/locale.rb - internationalization module
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
+
 module IRB # :nodoc:
   class Locale
 

--- a/lib/irb/notifier.rb
+++ b/lib/irb/notifier.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   notifier.rb - output methods used by irb
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/notifier.rb
+++ b/lib/irb/notifier.rb
@@ -3,10 +3,6 @@
 #   notifier.rb - output methods used by irb
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 require_relative "output-method"
 

--- a/lib/irb/output-method.rb
+++ b/lib/irb/output-method.rb
@@ -3,10 +3,6 @@
 #   output-method.rb - output methods used by irb
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 module IRB
   # An abstract output class for IO in irb. This is mainly used internally by

--- a/lib/irb/output-method.rb
+++ b/lib/irb/output-method.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   output-method.rb - output methods used by irb
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/ruby-lex.rb - ruby lexcal analyzer
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -3,10 +3,6 @@
 #   irb/ruby-lex.rb - ruby lexcal analyzer
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 require "ripper"
 require "jruby" if RUBY_ENGINE == "jruby"

--- a/lib/irb/version.rb
+++ b/lib/irb/version.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/version.rb - irb version definition file
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ishitsuka.com)
 #
 # --

--- a/lib/irb/version.rb
+++ b/lib/irb/version.rb
@@ -3,10 +3,6 @@
 #   irb/version.rb - irb version definition file
 #   	by Keiju ISHITSUKA(keiju@ishitsuka.com)
 #
-# --
-#
-#
-#
 
 module IRB # :nodoc:
   VERSION = "1.6.2"

--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -3,10 +3,6 @@
 #   irb/workspace-binding.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 require "delegate"
 

--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/workspace-binding.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/ws-for-case-2.rb
+++ b/lib/irb/ws-for-case-2.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   irb/ws-for-case-2.rb -
-#   	$Release Version: 0.9.6$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 # --

--- a/lib/irb/ws-for-case-2.rb
+++ b/lib/irb/ws-for-case-2.rb
@@ -3,10 +3,6 @@
 #   irb/ws-for-case-2.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-# --
-#
-#
-#
 
 while true
   IRB::BINDING_QUEUE.push _ = binding

--- a/lib/irb/xmp.rb
+++ b/lib/irb/xmp.rb
@@ -3,10 +3,6 @@
 #   xmp.rb - irb version of gotoken xmp
 #   	by Keiju ISHITSUKA(Nippon Rational Inc.)
 #
-# --
-#
-#
-#
 
 require_relative "../irb"
 require_relative "frame"

--- a/lib/irb/xmp.rb
+++ b/lib/irb/xmp.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 #
 #   xmp.rb - irb version of gotoken xmp
-#   	$Release Version: 0.9$
-#   	$Revision$
 #   	by Keiju ISHITSUKA(Nippon Rational Inc.)
 #
 # --


### PR DESCRIPTION
The current `irb` files keep some headers for old VCS system. The users confused by `0.9.6` revision different with `irb` version. 

We should remove them for the future development. And I styled their headers.