### PR TITLE
Fix help-message

### DIFF
--- a/lib/irb/lc/help-message
+++ b/lib/irb/lc/help-message
@@ -22,8 +22,8 @@ Usage:  irb.rb [options] [programfile] [arguments]
                     Show truncated result on assignment (default).
   --inspect         Use 'inspect' for output.
   --noinspect       Don't use 'inspect' for output.
-  --multiline       Use multiline editor module.
-  --nomultiline     Don't use multiline editor module (default).
+  --multiline       Use multiline editor module (default).
+  --nomultiline     Don't use multiline editor module.
   --singleline      Use single line editor module.
   --nosingleline    Don't use single line editor module (default).
   --colorize        Use color-highlighting (default).


### PR DESCRIPTION
The `--multiline` option is the default.

To be exact, under the condition of no `--multiline` option specified, the ~~multiline~~ singleline [edited] mode will be enabled if any of the following is true:
- `STDIN.tty?` returns `false` (which means connected to a pipe?)
- `--inf-ruby-mode` is specified
- `--singleline` or `--readline` or `--legacy` is specified

Ref: https://github.com/ruby/irb/blob/v1.6.2/lib/irb/context.rb#L92

Even so, I think multiline is the default mode.