### PR TITLE
Allow alias warnings to be silenced

### DIFF
--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -306,7 +306,7 @@ module IRB # :nodoc:
           end
           alias_method to, from
         }
-      else
+      elsif !defined?(HushAliasWarning)
         Kernel.print "irb: warn: can't alias #{to} from #{from}.\n"
       end
     end


### PR DESCRIPTION
Allow a user to silence the warning that certain methods cannot be aliased. The use case is for tools that use `irb` and are already aware of the warning, but deem it acceptable and just want to suppress it.

Code would need to do the following to hush these warnings:

```
IRB::ExtendCommandBundle::HushAliasWarning = true
```