### PR TITLE
Provide more useful message when `Inspector#inspect_value` errors

### DIFF
--- a/lib/irb/inspector.rb
+++ b/lib/irb/inspector.rb
@@ -35,6 +35,7 @@ module IRB # :nodoc:
   #     irb(main):001:0> "what?" #=> omg! what?
   #
   class Inspector
+    KERNEL_INSPECT = Object.instance_method(:inspect)
     # Default inspectors available to irb, this includes:
     #
     # +:pp+::       Using Kernel#pretty_inspect
@@ -93,9 +94,18 @@ module IRB # :nodoc:
     # Proc to call when the input is evaluated and output in irb.
     def inspect_value(v)
       @inspect.call(v)
-    rescue
-      puts "(Object doesn't support #inspect)"
-      ''
+    rescue => e
+      puts "An error occurred when inspecting the object: #{e.inspect}"
+
+      begin
+        # TODO: change this to bind_call when we drop support for Ruby 2.6
+        puts "Result of Kernel#inspect: #{KERNEL_INSPECT.bind(v).call}"
+        ''
+      rescue => e
+        puts "An error occurred when running Kernel#inspect: #{e.inspect}"
+        puts e.backtrace.join("\n")
+        ''
+      end
     end
   end
 

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -125,11 +125,11 @@ module TestIRB
         [:marshal, "123", Marshal.dump(123)],
       ],
       failed: [
-        [false, "BasicObject.new", /\(Object doesn't support #inspect\)\n(=> )?\n/],
-        [:p, "class Foo; undef inspect ;end; Foo.new", /\(Object doesn't support #inspect\)\n(=> )?\n/],
-        [true, "BasicObject.new", /\(Object doesn't support #inspect\)\n(=> )?\n/],
-        [:yaml, "BasicObject.new", /\(Object doesn't support #inspect\)\n(=> )?\n/],
-        [:marshal, "[Object.new, Class.new]", /\(Object doesn't support #inspect\)\n(=> )?\n/]
+        [false, "BasicObject.new", /#<NoMethodError: undefined method `to_s' for/],
+        [:p, "class Foo; undef inspect ;end; Foo.new", /#<NoMethodError: undefined method `inspect' for/],
+        [true, "BasicObject.new", /#<NoMethodError: undefined method `is_a\?' for/],
+        [:yaml, "BasicObject.new", /#<NoMethodError: undefined method `inspect' for/],
+        [:marshal, "[Object.new, Class.new]", /#<TypeError: can't dump anonymous class #<Class:/]
       ]
     }.each do |scenario, cases|
       cases.each do |inspect_mode, input, expected|
@@ -147,6 +147,58 @@ module TestIRB
           $VERBOSE = verbose
         end
       end
+    end
+
+    def test_object_inspection_falls_back_to_kernel_inspect_when_errored
+      omit if RUBY_ENGINE == "truffleruby"
+      verbose, $VERBOSE = $VERBOSE, nil
+      main = Object.new
+      main.singleton_class.module_eval <<~RUBY
+        class Foo
+          def inspect
+            raise "foo"
+          end
+        end
+      RUBY
+
+      irb = IRB::Irb.new(IRB::WorkSpace.new(main), TestInputMethod.new(["Foo.new"]))
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(/An error occurred when inspecting the object: #<RuntimeError: foo>/, out)
+      assert_match(/Result of Kernel#inspect: #<#<Class:.*>::Foo:/, out)
+    ensure
+      $VERBOSE = verbose
+    end
+
+    def test_object_inspection_prints_useful_info_when_kernel_inspect_also_errored
+      omit if RUBY_VERSION < '2.7' || RUBY_ENGINE == "truffleruby"
+      verbose, $VERBOSE = $VERBOSE, nil
+      main = Object.new
+      main.singleton_class.module_eval <<~RUBY
+        class Foo
+          def initialize
+            # Kernel#inspect goes through instance variables with #inspect
+            # So this will cause Kernel#inspect to fail
+            @foo = BasicObject.new
+          end
+
+          def inspect
+            raise "foo"
+          end
+        end
+      RUBY
+
+      irb = IRB::Irb.new(IRB::WorkSpace.new(main), TestInputMethod.new(["Foo.new"]))
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_match(/An error occurred when inspecting the object: #<RuntimeError: foo>/, out)
+      assert_match(/An error occurred when running Kernel#inspect: #<NoMethodError: undefined method `inspect' for/, out)
+    ensure
+      $VERBOSE = verbose
     end
 
     def test_default_config


### PR DESCRIPTION

Fixes #509 

**Before**

```
irb(main):001:0> c = Cat.new "foo"
(Object doesn't support #inspect)
```

**After**

```
irb(main):001:0> c = Cat.new "foo"
An error occurred when inspecting the object: #<NoMethodError: undefined method `is_a?' for foo:Cat

      if obj.is_a?(String)
            ^^^^^^>
Result of Kernel#inspect: #<Cat:0x0000000109090d80 @name="foo">
```

And if `Kernel#inspect` also errors, it prints useful error message to help users debug:

```
irb(main):001:0> Foo.new
An error occurred when inspecting the object: #<RuntimeError: foo>
An error occurred when running Kernel#inspect: #<NoMethodError: undefined method `inspect' for #<BasicObject:0x0000000106ce97b0>
                                                     
          puts "Result of Kernel#inspect: #{KERNEL_INSPECT.bind_call(v)}"
                                                          ^^^^^^^^^^>
/Users/hung-wulo/src/github.com/ruby/irb/lib/irb/inspector.rb:102:in `inspect'
/Users/hung-wulo/src/github.com/ruby/irb/lib/irb/inspector.rb:102:in `bind_call'
/Users/hung-wulo/src/github.com/ruby/irb/lib/irb/inspector.rb:102:in `rescue in inspect_value'
....
```
