### PR TITLE
Make tests more compatible with TruffleRuby

### DIFF
--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -64,7 +64,6 @@ module TestIRB
     end
 
     def test_eval_input
-      pend if RUBY_ENGINE == 'truffleruby'
       verbose, $VERBOSE = $VERBOSE, nil
       input = TestInputMethod.new([
         "raise 'Foo'\n",
@@ -87,7 +86,6 @@ module TestIRB
     end
 
     def test_eval_input_raise2x
-      pend if RUBY_ENGINE == 'truffleruby'
       input = TestInputMethod.new([
         "raise 'Foo'\n",
         "raise 'Bar'\n",
@@ -512,7 +510,6 @@ module TestIRB
     end
 
     def test_eval_input_with_invalid_byte_sequence_exception
-      pend if RUBY_ENGINE == 'truffleruby'
       verbose, $VERBOSE = $VERBOSE, nil
       input = TestInputMethod.new([
         %Q{def hoge() fuga; end; def fuga() raise "A\\xF3B"; end; hoge\n},

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -56,10 +56,9 @@ module TestIRB
       }
     end
 
-    def test_evaluate_with_onigmo_warning
-      pend if RUBY_ENGINE == 'truffleruby'
-      assert_warning("(irb):1: warning: character class has duplicated range: /[aa]/\n") do
-        @context.evaluate('/[aa]/', 1)
+    def test_evaluate_still_emits_warning
+      assert_warning("(irb):1: warning: END in method; use at_exit\n") do
+        @context.evaluate(%q[def foo; END {}; end], 1)
       end
     end
 

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -50,9 +50,8 @@ module TestIRB
     end
 
     def test_evaluate_with_encoding_error_without_lineno
-      pend if RUBY_ENGINE == 'truffleruby'
       assert_raise_with_message(EncodingError, /invalid symbol/) {
-        @context.evaluate(%q[{"\xAE": 1}], 1)
+        @context.evaluate(%q[:"\xAE"], 1)
         # The backtrace of this invalid encoding hash doesn't contain lineno.
       }
     end


### PR DESCRIPTION
1. Some test cases don't fail on TruffleRuby anymore so we can remove the omit/pend conditions.
2. Some test cases can work with TruffleRuby with small tweaks on the test subject/assertion.

By making more tests run against TruffleRuby, we can help it match CRuby's behaviour quicker (example: https://github.com/oracle/truffleruby/issues/2848).

Thanks @nirvdrum for working with me on this. We'll have regular pairing sessions to remove the rest of the skipping conditions.