### PR TITLE
Cleanup completion tests

### DIFF
--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -114,7 +114,6 @@ module TestIRB
       end
 
       def test_complete_require_library_name_first
-        pend 'Need to use virtual library paths'
         candidates = IRB::InputCompletor::CompletionProc.("'csv", "require ", "")
         assert_equal "'csv", candidates.first
       end

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -11,23 +11,6 @@ module TestIRB
       IRB::InputCompletor.class_variable_set(:@@files_from_load_path, nil)
     end
 
-    def test_nonstring_module_name
-      begin
-        require "irb/completion"
-        bug5938 = '[ruby-core:42244]'
-        bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []
-        cmds = bundle_exec + %W[-W0 -rirb -rirb/completion -e IRB.setup(__FILE__)
-         -e IRB.conf[:MAIN_CONTEXT]=IRB::Irb.new.context
-         -e module\sFoo;def\sself.name;//;end;end
-         -e IRB::InputCompletor::CompletionProc.call("[1].first.")
-         -- -f --]
-        status = assert_in_out_err(cmds, "", //, [], bug5938)
-        assert(status.success?, bug5938)
-      rescue LoadError
-        pend "cannot load irb/completion"
-      end
-    end
-
     class TestMethodCompletion < TestCompletion
       def test_complete_string
         assert_include(IRB::InputCompletor.retrieve_completion_data("'foo'.up", bind: binding), "'foo'.upcase")


### PR DESCRIPTION
- The first test was added for an implementation's edge case that's been replaced a few years ago. So I think it's not needed anymore. Please see the commit message for more info.

- The `pend` doesn't seem to be needed as tests can pass without it.