### PR TITLE
Remove unused Struct

### DIFF
--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -421,8 +421,6 @@ module IRB # :nodoc:
     end
   end
 
-
-  DefaultEncodings = Struct.new(:external, :internal)
   class << IRB
     private
     def set_encoding(extern, intern = nil, override: true)


### PR DESCRIPTION
`DefaultEncodings` is not used, so remove it.

```
~/ghq/github.com/ruby/irb remove-defaultencodings
❯ git grep DefaultEncodings

```

It was created with this commit. But it is no longer in use.
https://github.com/ruby/irb/commit/3ee79e89adb8e21b63d796e53bcc86281685076d
