### PR TITLE
Improve method completion for string and regexp that includes word break characters

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -166,10 +166,10 @@ module IRB
 
     def self.retrieve_completion_data(input, bind: IRB.conf[:MAIN_CONTEXT].workspace.binding, doc_namespace: false)
       case input
-      when /^((["'`]).*\2)\.([^.]*)$/
+      when /^(.*["'`])\.([^.]*)$/
         # String
         receiver = $1
-        message = $3
+        message = $2
 
         if doc_namespace
           "String.#{message}"
@@ -178,7 +178,7 @@ module IRB
           select_message(receiver, message, candidates)
         end
 
-      when /^(\/[^\/]*\/)\.([^.]*)$/
+      when /^(.*\/)\.([^.]*)$/
         # Regexp
         receiver = $1
         message = $2

--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -166,6 +166,8 @@ module IRB
 
     def self.retrieve_completion_data(input, bind: IRB.conf[:MAIN_CONTEXT].workspace.binding, doc_namespace: false)
       case input
+      # this regexp only matches the closing character because of irb's Reline.completer_quote_characters setting
+      # details are described in: https://github.com/ruby/irb/pull/523
       when /^(.*["'`])\.([^.]*)$/
         # String
         receiver = $1

--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -180,6 +180,8 @@ module IRB
           select_message(receiver, message, candidates)
         end
 
+      # this regexp only matches the closing character because of irb's Reline.completer_quote_characters setting
+      # details are described in: https://github.com/ruby/irb/pull/523
       when /^(.*\/)\.([^.]*)$/
         # Regexp
         receiver = $1

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -14,19 +14,15 @@ module TestIRB
     class TestMethodCompletion < TestCompletion
       def test_complete_string
         assert_include(IRB::InputCompletor.retrieve_completion_data("'foo'.up", bind: binding), "'foo'.upcase")
-        assert_not_include(IRB::InputCompletor.retrieve_completion_data("'foo'.up", bind: binding), "'foo'.update")
         # completing 'foo bar'.up
         assert_include(IRB::InputCompletor.retrieve_completion_data("bar'.up", bind: binding), "bar'.upcase")
-        assert_not_include(IRB::InputCompletor.retrieve_completion_data("bar'.up", bind: binding), "bar'.update")
         assert_equal("String.upcase", IRB::InputCompletor.retrieve_completion_data("'foo'.upcase", bind: binding, doc_namespace: true))
       end
 
       def test_complete_regexp
         assert_include(IRB::InputCompletor.retrieve_completion_data("/foo/.ma", bind: binding), "/foo/.match")
-        assert_not_include(IRB::InputCompletor.retrieve_completion_data("/foo/.ma", bind: binding), "/foo/.map")
         # completing /foo bar/.ma
         assert_include(IRB::InputCompletor.retrieve_completion_data("bar/.ma", bind: binding), "bar/.match")
-        assert_not_include(IRB::InputCompletor.retrieve_completion_data("bar/.ma", bind: binding), "bar/.map")
         assert_equal("Regexp.match", IRB::InputCompletor.retrieve_completion_data("/foo/.match", bind: binding, doc_namespace: true))
       end
 

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -14,11 +14,19 @@ module TestIRB
     class TestMethodCompletion < TestCompletion
       def test_complete_string
         assert_include(IRB::InputCompletor.retrieve_completion_data("'foo'.up", bind: binding), "'foo'.upcase")
+        assert_not_include(IRB::InputCompletor.retrieve_completion_data("'foo'.up", bind: binding), "'foo'.update")
+        # completing 'foo bar'.up
+        assert_include(IRB::InputCompletor.retrieve_completion_data("bar'.up", bind: binding), "bar'.upcase")
+        assert_not_include(IRB::InputCompletor.retrieve_completion_data("bar'.up", bind: binding), "bar'.update")
         assert_equal("String.upcase", IRB::InputCompletor.retrieve_completion_data("'foo'.upcase", bind: binding, doc_namespace: true))
       end
 
       def test_complete_regexp
         assert_include(IRB::InputCompletor.retrieve_completion_data("/foo/.ma", bind: binding), "/foo/.match")
+        assert_not_include(IRB::InputCompletor.retrieve_completion_data("/foo/.ma", bind: binding), "/foo/.map")
+        # completing /foo bar/.ma
+        assert_include(IRB::InputCompletor.retrieve_completion_data("bar/.ma", bind: binding), "bar/.match")
+        assert_not_include(IRB::InputCompletor.retrieve_completion_data("bar/.ma", bind: binding), "bar/.map")
         assert_equal("Regexp.match", IRB::InputCompletor.retrieve_completion_data("/foo/.match", bind: binding, doc_namespace: true))
       end
 


### PR DESCRIPTION
## Description

fixes #314

In these case, irb cannot correctly complete string and regexp methods.
- `"()".`
- `"hello world".`
- /hello world/.

This pull request fixes it.

## Background

Readline and Reline has a configuration `completer_quote_characters` and `completer_word_break_characters` of completion target.
It was able to calculate `"()".` completion target correctly.

In this pull request(https://github.com/ruby/irb/pull/212), `Reline.completer_quote_characters = ''` is added, which means reline does not consider quotes in completion target calculation.
Completion target calculated by reline changed from `"hello world".` to `world".` and the regexp needed to be updated.

## Change

I changed string completion regexp to match `anything".` I also changed regexp for regexp completion.
Since array completion regexp matches to `].`, changing string completion regexp to match `".` is acceptable(in my opinion).