### PR TITLE
Remove no longer necessary TruffleRuby test exclusions

### DIFF
--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -134,7 +134,6 @@ module TestIRB
     }.each do |scenario, cases|
       cases.each do |inspect_mode, input, expected|
         define_method "test_#{inspect_mode}_inspect_mode_#{scenario}" do
-          pend if RUBY_ENGINE == 'truffleruby'
           verbose, $VERBOSE = $VERBOSE, nil
           irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), TestInputMethod.new([input]))
           irb.context.inspect_mode = inspect_mode
@@ -150,7 +149,6 @@ module TestIRB
     end
 
     def test_object_inspection_falls_back_to_kernel_inspect_when_errored
-      omit if RUBY_ENGINE == "truffleruby"
       verbose, $VERBOSE = $VERBOSE, nil
       main = Object.new
       main.singleton_class.module_eval <<~RUBY
@@ -173,7 +171,7 @@ module TestIRB
     end
 
     def test_object_inspection_prints_useful_info_when_kernel_inspect_also_errored
-      omit if RUBY_VERSION < '2.7' || RUBY_ENGINE == "truffleruby"
+      omit if RUBY_VERSION < '2.7'
       verbose, $VERBOSE = $VERBOSE, nil
       main = Object.new
       main.singleton_class.module_eval <<~RUBY


### PR DESCRIPTION
I've been working through the set of TruffleRuby exclusions in the IRB test suite with @st0012. We've fixed a few compatibility issues upstream that have allowed us to remove test exclusions.

This PR needs https://github.com/oracle/truffleruby/pull/2897 to be merged and integrated into a build before the tests will pass.