### PR TITLE
Handle long inspect and control character in prompt string

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -775,6 +775,15 @@ module IRB
       end
     end
 
+    def truncate_prompt_main(str, size = 32, omission: '...') # :nodoc:
+      str = str.tr("\x00-\x1F", ' ')
+      if str.size <= size
+        str
+      else
+        str[0, size - omission.size] + omission
+      end
+    end
+
     def prompt(prompt, ltype, indent, line_no) # :nodoc:
       p = prompt.dup
       p.gsub!(/%([0-9]+)?([a-zA-Z])/) do
@@ -782,9 +791,9 @@ module IRB
         when "N"
           @context.irb_name
         when "m"
-          @context.main.to_s
+          truncate_prompt_main(@context.main.to_s)
         when "M"
-          @context.main.inspect
+          truncate_prompt_main(@context.main.inspect)
         when "l"
           ltype
         when "i"

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -463,6 +463,10 @@ module IRB
     # be parsed as :assign and echo will be suppressed, but the latter is
     # parsed as a :method_add_arg and the output won't be suppressed
 
+    PROMPT_MAIN_TRUNCATE_LENGTH = 32
+    PROMPT_MAIN_TRUNCATE_OMISSION = '...'.freeze
+    CONTROL_CHARACTERS_PATTERN = "\x00-\x1F".freeze
+
     # Creates a new irb session
     def initialize(workspace = nil, input_method = nil)
       @context = Context.new(self, workspace, input_method)
@@ -775,12 +779,12 @@ module IRB
       end
     end
 
-    def truncate_prompt_main(str, size = 32, omission: '...') # :nodoc:
-      str = str.tr("\x00-\x1F", ' ')
-      if str.size <= size
+    def truncate_prompt_main(str) # :nodoc:
+      str = str.tr(CONTROL_CHARACTERS_PATTERN, ' ')
+      if str.size <= PROMPT_MAIN_TRUNCATE_LENGTH
         str
       else
-        str[0, size - omission.size] + omission
+        str[0, PROMPT_MAIN_TRUNCATE_LENGTH - PROMPT_MAIN_TRUNCATE_OMISSION.size] + PROMPT_MAIN_TRUNCATE_OMISSION
       end
     end
 

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -656,6 +656,23 @@ module TestIRB
       $VERBOSE = verbose
     end
 
+    def test_prompt_main_escape
+      irb = IRB::Irb.new(IRB::WorkSpace.new("main\a\t\r\n"))
+      assert_equal("irb(main    )>", irb.prompt('irb(%m)>', nil, 1, 1))
+    end
+
+    def test_prompt_main_inspect_escape
+      main = Struct.new(:inspect).new("main\\n\nmain")
+      irb = IRB::Irb.new(IRB::WorkSpace.new(main))
+      assert_equal("irb(main\\n main)>", irb.prompt('irb(%M)>', nil, 1, 1))
+    end
+
+    def test_prompt_main_truncate
+      irb = IRB::Irb.new(IRB::WorkSpace.new("a" * 100))
+      assert_match(/irb\(a.+\.\.\.\)>/, irb.prompt('irb(%m)>', nil, 1, 1))
+      assert_match(/irb\("a.+\.\.\.\)>/, irb.prompt('irb(%M)>', nil, 1, 1))
+    end
+
     def test_lineno
       input = TestInputMethod.new([
         "\n",

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -669,8 +669,8 @@ module TestIRB
 
     def test_prompt_main_truncate
       irb = IRB::Irb.new(IRB::WorkSpace.new("a" * 100))
-      assert_match(/irb\(a.+\.\.\.\)>/, irb.prompt('irb(%m)>', nil, 1, 1))
-      assert_match(/irb\("a.+\.\.\.\)>/, irb.prompt('irb(%M)>', nil, 1, 1))
+      assert_equal('irb(aaaaaaaaaaaaaaaaaaaaaaaaaaaaa...)>', irb.prompt('irb(%m)>', nil, 1, 1))
+      assert_equal('irb("aaaaaaaaaaaaaaaaaaaaaaaaaaaa...)>', irb.prompt('irb(%M)>', nil, 1, 1))
     end
 
     def test_lineno


### PR DESCRIPTION
Fixes #153 by replacing `"\x00-\x1F"` to `" "`
I also add truncation because changing workspace to a large array makes input hard.

## Background
Reline fixed #153 by escaping only `\n`. `\\` is not escaped and I think it's an inconsistent behavior.
Other control character should also be escaped or deleted or replaced in IRB side.

## Before
```
irb(main):001:0> cws "c:\\windows\\system32\n"
irb(c:\windows\system32\n):002:0> # only "\n" is escaped, "\\" is not escaped

irb(main):001:0> cws "HTTP/1.1 200 OK\r\n"
):002:0> # broken prompt

irb(main):001:0> cws [1]*100
irb([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
, 1]):005:0> 
```

## After
```
irb(main):001:0> cws "c:\\windows\\system32\n"
irb(c:\windows\system32 ):002:0>

irb(main):001:0> cws "HTTP/1.1 200 OK\r\n"
irb(HTTP/1.1 200 OK  ):002:0> 

irb(main):001:0> cws [1]*100
irb([1, 1, 1, 1, 1, 1, 1, 1, 1, 1...):003:0> 
```
