### PR TITLE
Drop chained methods' completion support

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -356,14 +356,6 @@ module IRB
         else
           # func1.func2
           candidates = []
-          to_ignore = ignored_modules
-          ObjectSpace.each_object(Module){|m|
-            next if (to_ignore.include?(m) rescue true)
-            next unless m.respond_to?(:instance_methods) # JRuby has modules that represent java packages. They don't include many common ruby methods
-            candidates.concat m.instance_methods(false).collect{|x| x.to_s}
-          }
-          candidates.sort!
-          candidates.uniq!
         end
 
         if doc_namespace

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -334,11 +334,9 @@ module TestIRB
       bind = obj.instance_exec { binding }
 
       assert_include(IRB::InputCompletor.retrieve_completion_data("public_hog", bind: bind), "public_hoge")
-      assert_include(IRB::InputCompletor.retrieve_completion_data("public_hoge.to_s", bind: bind), "public_hoge.to_s")
       assert_include(IRB::InputCompletor.retrieve_completion_data("public_hoge", bind: bind, doc_namespace: true), "public_hoge")
 
       assert_include(IRB::InputCompletor.retrieve_completion_data("private_hog", bind: bind), "private_hoge")
-      assert_include(IRB::InputCompletor.retrieve_completion_data("private_hoge.to_s", bind: bind), "private_hoge.to_s")
       assert_include(IRB::InputCompletor.retrieve_completion_data("private_hoge", bind: bind, doc_namespace: true), "private_hoge")
     end
   end


### PR DESCRIPTION
Consider completion for this example: `foo.bar.b`

Without type information, it is hard to know the return value of the `bar` method, so the current implementation interates through `ObjectSpace` to get all possible candidates for the second method.

In small projects, the performance and accuracy are acceptable. But in bigger projects, the performance is unacceptable and the accuracy is mostly poor.

So this commit drops the support for chained methods' completion.

Closes #339 