### PR TITLE
Specify metadata to provide richer information on rubygems.org

### DIFF
--- a/irb.gemspec
+++ b/irb.gemspec
@@ -16,6 +16,11 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/irb"
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
 
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["documentation_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/releases"
+
   spec.files         = [
     ".document",
     "Gemfile",


### PR DESCRIPTION
Since we're encouraging users to use `irb` as a gem, I feel it'd be worth enriching its rubygems.org page a bit and we can customise the sidebar items with the [`metadata` attribute](https://guides.rubygems.org/specification-reference/#metadata).