### PR TITLE
Avoid slow symbol completion when completion target is an empty symbol

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -215,7 +215,7 @@ module IRB
           select_message(receiver, message, proc_candidates | hash_candidates)
         end
 
-      when /^(:[^:.]*)$/
+      when /^(:[^:.]+)$/
         # Symbol
         if doc_namespace
           nil

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -292,6 +292,8 @@ module TestIRB
       _ = :aiueo
       assert_include(IRB::InputCompletor.retrieve_completion_data(":a", bind: binding), ":aiueo")
       assert_empty(IRB::InputCompletor.retrieve_completion_data(":irb_unknown_symbol_abcdefg", bind: binding))
+      # Do not complete empty symbol for performance reason
+      assert_empty(IRB::InputCompletor.retrieve_completion_data(":", bind: binding))
     end
 
     def test_complete_invalid_three_colons


### PR DESCRIPTION
I changed not to complete symbols when you just type `:`. You need one more character to start symbol completion.

If you type `:`, all symbols was shown in the completion dialog and it was slow.
It's because of the completion candidates size.
```
% ruby -e "p Symbol.all_symbols.size"
3737
```

```
% rails c
Loading development environment (Rails 7.0.4.2)
irb(main):001:0> Symbol.all_symbols.size
=> 28738
```

Also, the top completion candidates are non-alphabet symbols. I think it's hard to find a symbol what you want by pressing [tab] in this situation. I always type one more character before looking the completion candidate for symbol. 
```
% ruby -e "p Symbol.all_symbols.take(20)"
[:!, :"\"", :"#", :"$", :%, :&, :"'", :"(", :")", :*, :+, :",", :-, :".", :/, :":", :";", :<, :"=", :>]
```

Changed the regexp `/^(:[^:.]*)$/` → `/^(:[^:.]+)$/`.
It still matches `:a` but does not match to `:` anymore.
