### PR TITLE
Use symbol.inspect in symbol completion candidate calculation

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -226,7 +226,7 @@ module IRB
         else
           sym = $1
           candidates = Symbol.all_symbols.collect do |s|
-            ":" + s.id2name.encode(Encoding.default_external)
+            s.inspect
           rescue EncodingError
             # ignore
           end

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -289,12 +289,14 @@ module TestIRB
     end
 
     def test_complete_symbol
-      %w"UTF-16LE UTF-7".each do |enc|
+      symbols = %w"UTF-16LE UTF-7".map do |enc|
         "K".force_encoding(enc).to_sym
       rescue
       end
-      _ = :aiueo
-      assert_include(IRB::InputCompletor.retrieve_completion_data(":a", bind: binding), ":aiueo")
+      symbols += [:aiueo, :"aiu eo"]
+      candidates = IRB::InputCompletor.retrieve_completion_data(":a", bind: binding)
+      assert_include(candidates, ":aiueo")
+      assert_not_include(candidates, ":aiu eo")
       assert_empty(IRB::InputCompletor.retrieve_completion_data(":irb_unknown_symbol_abcdefg", bind: binding))
       # Do not complete empty symbol for performance reason
       assert_empty(IRB::InputCompletor.retrieve_completion_data(":", bind: binding))


### PR DESCRIPTION
This pull request change to use `Symbol#inspect` instead of `":" + symbol.id2name` in symbol completion candidate calculation.

IRB sometimes shows syntax-invalid symbol ( `:@`, not `:"@"` ) in symbol completion and this pull request will fix it.
![スクリーンショット 2023-03-11 2 41 09](https://user-images.githubusercontent.com/1780201/224386811-1ca4b07a-8c91-4367-b3de-9fe8e9ca95d5.png)

### Background
When you type `:"aaaaaa` to IRB, symbol `:"aaa\n"` `:"aaaa\n"` `:"aaaaa\n"`  is created, and this was breaking completion dialog rendering when you type `:aa`.
![スクリーンショット 2023-03-11 2 53 15](https://user-images.githubusercontent.com/1780201/224388514-762dec56-b157-4826-a44c-5f20e5e38977.png)

### About EncodingError

~Symbol#inspect seems to return string with encoding=default_external and does not seem to raise EncodingError.
I removed `encode` and `rescue`.~ 
```ruby
Encoding.default_external = Encoding::EUCJP
sym = "K".force_encoding('UTF-7').to_sym
puts sym.inspect #=> :"\x4B"
sym.inspect.encoding #=> #<Encoding:EUC-JP>
sym.id2name.encode(Encoding.default_external) #=> Encoding::ConverterNotFoundError
```
`Symbol#inspect` raise `Encoding::CompatibilityError` only in truffleruby, so I left `rescue` as is.
```
puts RUBY_ENGINE #=> truffleruby
'K'.force_encoding('UTF-7').to_sym.inspect #=> Encoding::CompatibilityError
```