### PR TITLE
Support inspecting BasicObject

### DIFF
--- a/lib/irb/color_printer.rb
+++ b/lib/irb/color_printer.rb
@@ -4,6 +4,10 @@ require_relative 'color'
 
 module IRB
   class ColorPrinter < ::PP
+    METHOD_IS_A = Object.instance_method(:is_a?)
+    METHOD_RESPOND_TO = Object.instance_method(:respond_to?)
+    METHOD_INSPECT = Object.instance_method(:inspect)
+
     class << self
       def pp(obj, out = $>, width = screen_width)
         q = ColorPrinter.new(out, width)
@@ -22,9 +26,11 @@ module IRB
     end
 
     def pp(obj)
-      if obj.is_a?(String)
+      if METHOD_IS_A.bind(obj).call(String)
         # Avoid calling Ruby 2.4+ String#pretty_print that splits a string by "\n"
         text(obj.inspect)
+      elsif !METHOD_RESPOND_TO.bind(obj).call(:inspect)
+        text(METHOD_INSPECT.bind(obj).call)
       else
         super
       end

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -129,7 +129,6 @@ module TestIRB
       failed: [
         [false, "BasicObject.new", /#<NoMethodError: undefined method `to_s' for/],
         [:p, "class Foo; undef inspect ;end; Foo.new", /#<NoMethodError: undefined method `inspect' for/],
-        [true, "BasicObject.new", /#<NoMethodError: undefined method `is_a\?' for/],
         [:yaml, "BasicObject.new", /#<NoMethodError: undefined method `inspect' for/],
         [:marshal, "[Object.new, Class.new]", /#<TypeError: can't dump anonymous class #<Class:/]
       ]
@@ -148,6 +147,19 @@ module TestIRB
           $VERBOSE = verbose
         end
       end
+    end
+
+    def test_object_inspection_handles_basic_object
+      verbose, $VERBOSE = $VERBOSE, nil
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), TestInputMethod.new(["BasicObject.new"]))
+      out, err = capture_output do
+        irb.eval_input
+      end
+      assert_empty err
+      assert_not_match(/NoMethodError/, out)
+      assert_match(/#<BasicObject:.*>/, out)
+    ensure
+      $VERBOSE = verbose
     end
 
     def test_object_inspection_falls_back_to_kernel_inspect_when_errored


### PR DESCRIPTION
When inspecting `BasicObject` in irb, the default inspector `pp` would raise an exception because it [calls `is_a?` on the object](https://github.com/ruby/pp/blob/master/lib/pp.rb#L188). We should help `pp` support `BasicObject` (if that's possible), but in the meantime we can also mitigate the problem from irb.

Closes #540