### PR TITLE
Changing command execution survay

### DIFF
--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -56,8 +56,26 @@ module IRB
         @irb_context.irb
       end
 
-      def execute(*opts)
-        #nop
+      def execute_command(string_arg)
+        if respond_to?(:execute)
+          # workaround for legacy command implementation
+          if self.class.respond_to?(:transform_args)
+            string_arg = self.class.transform_args(string_arg)
+          end
+          args, kwargs, block = extract_args(string_arg)
+          execute(*args, **kwargs, &block)
+        else
+          puts 'Not Implemented'
+        end
+      end
+
+      private
+      def evaluate(str)
+        eval(str, @irb_context.workspace.binding)
+      end
+
+      def extract_args(string_arg)
+        evaluate("->(*args,**kwargs,&block){[args,kwargs,block]}.call #{string_arg}")
       end
     end
   end

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -62,7 +62,7 @@ class RubyLex
         else
           # Accept any single-line input for symbol aliases or commands that transform args
           command = code.split(/\s/, 2).first
-          if @context.symbol_alias?(command) || @context.transform_args?(command)
+          if @context.command?(command)
             next true
           end
 


### PR DESCRIPTION
This is a survay draft pull request for command implementation.

# Description

There are two types of IRB's command.

- Command called alone or with arguments
  - `whereami`
  - `cws object`
  - `show_source 'Set#to_a'`
  - `$ Set#to_a` (some command accepts non-ruby syntax)
- Command mostly used with method chain
  - `context.echo = false`
  - `app.host` (rails console)
  - `helper.javascript_url('application')` (rails console)

What should IRB command be?

# For the past years

Command is a ruby method installed into current workspace object.

# After `show_source Set#to_a` `$ Set#to_a` is introduced

Comamnd is a ruby method.
Command is also a UNIX-command-like-instruction `command_name free_format_args` for commands that has `transform_args`.

# Command definition in this survey

Command is a UNIX-command-like-instruction `command_name free_format_args`. defined in `@EXTEND_COMMANDS`.
There are some extension methods(≠command) defined as a method of ExtendCommandBundle and aliases are in `@ALIASES`.

## Pros
We can remove `transform_args`.
```ruby
# can execute command directly by `command_class.new.execute(args)` so transform_args seems circuitous approach to me
# Implementation is mostly a boilerplate like `def self.tranform_args(arg)=arg.dump`
command, args = line.split(' ', 2)
line = "#{command} #{command_class.transform_args(args)}" if command? && transform_args?
evaluate(line)
```
Workspace object will less polluted by installed methods.
```ruby
(self.methods - Object.new.methods).size #=> 87 → 8
```
Some inconsistent behavior of command will improve
```ruby
# result of these differs
show_cmds ['Set','#to_a'].join
tap{show_cmds ['Set','#to_a'].join}

# $ foobar` is converted to `show_source "foobar"` even if show_source is not installed to workspace
cws Object.new.tap{def _1.show_source(*a)=puts(a)}
$ hello world #=> "hello world"
```

## Cons
- Command cannot be called as a method anymore `10.times{show_source 'Set#to_a'}`
- Less flexibility. Ruby can call a method like a command style and changing command might not be a ruby way.
- If extension method is not a command, should it be shown in show_cmds?
  - It should be shown for convenience
  - Maybe we should call them `method-command`. (naming...)
  - Need to make an api to define category and description for extension methods

# Other possibility

Specify command type `:command or :method` in command definition
```ruby
@EXTEND_COMMANDS = [
  { name: :irb_whereami, module: :Whereami, path: "path", type: :command, aliases: []},
  { name: :irb_context, module: :ModuleName, path: "path", type: :method, aliases: []},
]
```
This seems better for me, but we should consider how to make no breaking change.
