### PR TITLE
Don't check RUBY_ENGINE when deciding whether to accept kwargs

### DIFF
--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -30,7 +30,7 @@ module IRB
         end
       end
 
-      if RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.7.0"
+      if RUBY_VERSION >= "2.7.0"
         def self.execute(conf, *opts, **kwargs, &block)
           command = new(conf)
           command.execute(*opts, **kwargs, &block)

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -256,7 +256,7 @@ module IRB # :nodoc:
       end
 
       if load_file
-        kwargs = ", **kwargs" if RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.7.0"
+        kwargs = ", **kwargs" if RUBY_VERSION >= "2.7.0"
         line = __LINE__; eval %[
           def #{cmd_name}(*opts#{kwargs}, &b)
             Kernel.require_relative "#{load_file}"

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -733,7 +733,6 @@ module TestIRB
     end
 
     def test_ls_grep
-      pend if RUBY_ENGINE == 'truffleruby'
       out, err = execute_lines("ls 42\n")
       assert_empty err
       assert_match(/times/, out)
@@ -752,7 +751,6 @@ module TestIRB
     end
 
     def test_ls_grep_empty
-      pend if RUBY_ENGINE == 'truffleruby'
       out, err = execute_lines("ls\n")
       assert_empty err
       assert_match(/whereami/, out)


### PR DESCRIPTION
Ruby implementations like JRuby and TruffleRuby already indicate their compatibility target with RUBY_VERSION. We don't need to exclude them from accepting keyword arguments as long as they target 2.7+.

cc @nirvdrum 