### PR TITLE
Drop Ruby 2.6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby-truffleruby
-      min_version: 2.6
+      min_version: 2.7
 
   irb:
     needs: ruby-versions
@@ -48,7 +48,6 @@ jobs:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         with_latest_reline: [true, false]
         exclude:
-          - ruby: 2.6
           - ruby: truffleruby
           - ruby: truffleruby-head
       fail-fast: false

--- a/irb.gemspec
+++ b/irb.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.6")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7")
 
   spec.add_dependency "reline", ">= 0.3.0"
 end

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -560,7 +560,6 @@ module IRB
       @scanner.each_top_level_statement do |line, line_no|
         signal_status(:IN_EVAL) do
           begin
-            line.untaint if RUBY_VERSION < '2.7'
             if IRB.conf[:MEASURE] && IRB.conf[:MEASURE_CALLBACKS].empty?
               IRB.set_measure_callback
             end

--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -30,20 +30,11 @@ module IRB
         end
       end
 
-      if RUBY_VERSION >= "2.7.0"
-        def self.execute(conf, *opts, **kwargs, &block)
-          command = new(conf)
-          command.execute(*opts, **kwargs, &block)
-        rescue CommandArgumentError => e
-          puts e.message
-        end
-      else
-        def self.execute(conf, *opts, &block)
-          command = new(conf)
-          command.execute(*opts, &block)
-        rescue CommandArgumentError => e
-          puts e.message
-        end
+      def self.execute(conf, *opts, **kwargs, &block)
+        command = new(conf)
+        command.execute(*opts, **kwargs, &block)
+      rescue CommandArgumentError => e
+        puts e.message
       end
 
       def initialize(conf)

--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -27,7 +27,7 @@ module IRB
           when /\A[A-Z]\w*(::[A-Z]\w*)*\z/ # Const::Name
             eval(str, irb_context.workspace.binding) # trigger autoload
             base = irb_context.workspace.binding.receiver.yield_self { |r| r.is_a?(Module) ? r : Object }
-            file, line = base.const_source_location(str) if base.respond_to?(:const_source_location) # Ruby 2.7+
+            file, line = base.const_source_location(str)
           when /\A(?<owner>[A-Z]\w*(::[A-Z]\w*)*)#(?<method>[^ :.]+)\z/ # Class#method
             owner = eval(Regexp.last_match[:owner], irb_context.workspace.binding)
             method = Regexp.last_match[:method]

--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -197,15 +197,9 @@ module IRB # :nodoc:
             end
           end
 
-          if lexer.respond_to?(:scan) # Ruby 2.7+
-            lexer.scan.each do |elem|
-              next if allow_last_error and /meets end of file|unexpected end-of-input/ =~ elem.message
-              on_scan.call(elem)
-            end
-          else
-            lexer.parse.sort_by(&:pos).each do |elem|
-              on_scan.call(elem)
-            end
+          lexer.scan.each do |elem|
+            next if allow_last_error and /meets end of file|unexpected end-of-input/ =~ elem.message
+            on_scan.call(elem)
           end
           # yield uncolorable DATA section
           yield(nil, inner_code.byteslice(byte_pos...inner_code.bytesize), nil) if byte_pos < inner_code.bytesize

--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -58,19 +58,11 @@ module IRB
 
     BASIC_WORD_BREAK_CHARACTERS = " \t\n`><=;|&{("
 
-    def self.absolute_path?(p) # TODO Remove this method after 2.6 EOL.
-      if File.respond_to?(:absolute_path?)
-        File.absolute_path?(p)
-      else
-        File.absolute_path(p) == p
-      end
-    end
-
     GEM_PATHS =
       if defined?(Gem::Specification)
         Gem::Specification.latest_specs(true).map { |s|
           s.require_paths.map { |p|
-            if absolute_path?(p)
+            if File.absolute_path?(p)
               p
             else
               File.join(s.full_gem_path, p)

--- a/lib/irb/ext/loader.rb
+++ b/lib/irb/ext/loader.rb
@@ -24,31 +24,8 @@ module IRB # :nodoc:
       load_file(path, priv)
     end
 
-    if File.respond_to?(:absolute_path?)
-      def absolute_path?(path)
-        File.absolute_path?(path)
-      end
-    else
-      separator =
-        if File::ALT_SEPARATOR
-          "[#{Regexp.quote(File::SEPARATOR + File::ALT_SEPARATOR)}]"
-        else
-          File::SEPARATOR
-        end
-      ABSOLUTE_PATH_PATTERN = # :nodoc:
-        case Dir.pwd
-        when /\A\w:/, /\A#{separator}{2}/
-          /\A(?:\w:|#{separator})#{separator}/
-        else
-          /\A#{separator}/
-        end
-      def absolute_path?(path)
-        ABSOLUTE_PATH_PATTERN =~ path
-      end
-    end
-
     def search_file_from_ruby_path(fn) # :nodoc:
-      if absolute_path?(fn)
+      if File.absolute_path?(fn)
         return fn if File.exist?(fn)
         return nil
       end

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -256,13 +256,12 @@ module IRB # :nodoc:
       end
 
       if load_file
-        kwargs = ", **kwargs" if RUBY_VERSION >= "2.7.0"
         line = __LINE__; eval %[
-          def #{cmd_name}(*opts#{kwargs}, &b)
+          def #{cmd_name}(*opts, **kwargs, &b)
             Kernel.require_relative "#{load_file}"
             arity = ::IRB::ExtendCommand::#{cmd_class}.instance_method(:execute).arity
             args = (1..(arity < 0 ? ~arity : arity)).map {|i| "arg" + i.to_s }
-            args << "*opts#{kwargs}" if arity < 0
+            args << "*opts, **kwargs" if arity < 0
             args << "&block"
             args = args.join(", ")
             line = __LINE__; eval %[
@@ -273,7 +272,7 @@ module IRB # :nodoc:
                 end
               end
             ], nil, __FILE__, line
-            __send__ :#{cmd_name}_, *opts#{kwargs}, &b
+            __send__ :#{cmd_name}_, *opts, **kwargs, &b
           end
         ], nil, __FILE__, line
       else

--- a/lib/irb/inspector.rb
+++ b/lib/irb/inspector.rb
@@ -98,8 +98,7 @@ module IRB # :nodoc:
       puts "An error occurred when inspecting the object: #{e.inspect}"
 
       begin
-        # TODO: change this to bind_call when we drop support for Ruby 2.6
-        puts "Result of Kernel#inspect: #{KERNEL_INSPECT.bind(v).call}"
+        puts "Result of Kernel#inspect: #{KERNEL_INSPECT.bind_call(v)}"
         ''
       rescue => e
         puts "An error occurred when running Kernel#inspect: #{e.inspect}"

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -148,19 +148,15 @@ class RubyLex
 
     compile_with_errors_suppressed(code, line_no: line_no) do |inner_code, line_no|
       lexer = Ripper::Lexer.new(inner_code, '-', line_no)
-      if lexer.respond_to?(:scan) # Ruby 2.7+
-        lexer.scan.each_with_object([]) do |t, tokens|
-          next if t.pos.first == 0
-          prev_tk = tokens.last
-          position_overlapped = prev_tk && t.pos[0] == prev_tk.pos[0] && t.pos[1] < prev_tk.pos[1] + prev_tk.tok.bytesize
-          if position_overlapped
-            tokens[-1] = t if ERROR_TOKENS.include?(prev_tk.event) && !ERROR_TOKENS.include?(t.event)
-          else
-            tokens << t
-          end
+      lexer.scan.each_with_object([]) do |t, tokens|
+        next if t.pos.first == 0
+        prev_tk = tokens.last
+        position_overlapped = prev_tk && t.pos[0] == prev_tk.pos[0] && t.pos[1] < prev_tk.pos[1] + prev_tk.tok.bytesize
+        if position_overlapped
+          tokens[-1] = t if ERROR_TOKENS.include?(prev_tk.event) && !ERROR_TOKENS.include?(t.event)
+        else
+          tokens << t
         end
-      else
-        lexer.parse.reject { |it| it.pos.first == 0 }.sort_by(&:pos)
       end
     end
   ensure

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -855,9 +855,6 @@ module TestIRB
     end
 
     def test_edit_with_constant
-      # const_source_location is supported after Ruby 2.7
-      omit if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
-
       out, err = execute_lines(
         "edit IRB::Irb"
       )

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -109,14 +109,11 @@ module TestIRB
         "<<A+1\nA" => "#{RED}<<A#{CLEAR}+#{BLUE}#{BOLD}1#{CLEAR}\n#{RED}A#{CLEAR}",
       }
 
-      # specific to Ruby 2.7+
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-        tests.merge!({
-          "4.5.6" => "#{MAGENTA}#{BOLD}4.5#{CLEAR}#{RED}#{REVERSE}.6#{CLEAR}",
-          "\e[0m\n" => "#{RED}#{REVERSE}^[#{CLEAR}[#{BLUE}#{BOLD}0#{CLEAR}#{RED}#{REVERSE}m#{CLEAR}\n",
-          "<<EOS\nhere\nEOS" => "#{RED}<<EOS#{CLEAR}\n#{RED}here#{CLEAR}\n#{RED}EOS#{CLEAR}",
-        })
-      end
+      tests.merge!({
+        "4.5.6" => "#{MAGENTA}#{BOLD}4.5#{CLEAR}#{RED}#{REVERSE}.6#{CLEAR}",
+        "\e[0m\n" => "#{RED}#{REVERSE}^[#{CLEAR}[#{BLUE}#{BOLD}0#{CLEAR}#{RED}#{REVERSE}m#{CLEAR}\n",
+        "<<EOS\nhere\nEOS" => "#{RED}<<EOS#{CLEAR}\n#{RED}here#{CLEAR}\n#{RED}EOS#{CLEAR}",
+      })
 
       # specific to Ruby 3.0+
       if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
@@ -136,18 +133,9 @@ module TestIRB
           })
         end
       else
-        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-          tests.merge!({
-            "[1]]]\u0013" => "[#{BLUE}#{BOLD}1#{CLEAR}]#{RED}#{REVERSE}]#{CLEAR}]^S",
-            "def req(true) end" => "#{GREEN}def#{CLEAR} #{BLUE}#{BOLD}req#{CLEAR}(#{RED}#{REVERSE}true#{CLEAR}) end",
-          })
-        else
-          tests.merge!({
-            "[1]]]\u0013" => "[#{BLUE}#{BOLD}1#{CLEAR}]]]^S",
-            "def req(true) end" => "#{GREEN}def#{CLEAR} #{BLUE}#{BOLD}req#{CLEAR}(#{CYAN}#{BOLD}true#{CLEAR}) end",
-          })
-        end
         tests.merge!({
+          "[1]]]\u0013" => "[#{BLUE}#{BOLD}1#{CLEAR}]#{RED}#{REVERSE}]#{CLEAR}]^S",
+          "def req(true) end" => "#{GREEN}def#{CLEAR} #{BLUE}#{BOLD}req#{CLEAR}(#{RED}#{REVERSE}true#{CLEAR}) end",
           "nil = 1" => "#{CYAN}#{BOLD}nil#{CLEAR} = #{BLUE}#{BOLD}1#{CLEAR}",
           "alias $x $1" => "#{GREEN}alias#{CLEAR} #{GREEN}#{BOLD}$x#{CLEAR} $1",
           "class bad; end" => "#{GREEN}class#{CLEAR} bad; #{GREEN}end#{CLEAR}",
@@ -184,10 +172,6 @@ module TestIRB
     end
 
     def test_colorize_code_complete_true
-      unless complete_option_supported?
-        pend '`complete: true` is the same as `complete: false` in Ruby 2.6-'
-      end
-
       # `complete: true` behaviors. Warn end-of-file.
       {
         "'foo' + 'bar" => "#{RED}#{BOLD}'#{CLEAR}#{RED}foo#{CLEAR}#{RED}#{BOLD}'#{CLEAR} + #{RED}#{BOLD}'#{CLEAR}#{RED}#{REVERSE}bar#{CLEAR}",
@@ -216,16 +200,6 @@ module TestIRB
         assert_equal_with_term(code, code, complete: false, colorable: false)
 
         assert_equal_with_term(result, code, complete: false, tty: false, colorable: true)
-
-        unless complete_option_supported?
-          assert_equal_with_term(result, code, complete: true)
-
-          assert_equal_with_term(code, code, complete: true, tty: false)
-
-          assert_equal_with_term(code, code, complete: true, colorable: false)
-
-          assert_equal_with_term(result, code, complete: true, tty: false, colorable: true)
-        end
       end
     end
 
@@ -250,11 +224,6 @@ module TestIRB
     end
 
     private
-
-    # `complete: true` is the same as `complete: false` in Ruby 2.6-
-    def complete_option_supported?
-      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-    end
 
     def with_term(tty: true)
       stdout = $stdout

--- a/test/irb/test_color_printer.rb
+++ b/test/irb/test_color_printer.rb
@@ -38,9 +38,6 @@ module TestIRB
     IRBTestColorPrinter = Struct.new(:a)
 
     def test_color_printer
-      unless ripper_lexer_scan_supported?
-        pend 'Ripper::Lexer#scan is supported in Ruby 2.7+'
-      end
       {
         1 => "#{BLUE}#{BOLD}1#{CLEAR}\n",
         "a\nb" => %[#{RED}#{BOLD}"#{CLEAR}#{RED}a\\nb#{CLEAR}#{RED}#{BOLD}"#{CLEAR}\n],
@@ -54,10 +51,6 @@ module TestIRB
     end
 
     private
-
-    def ripper_lexer_scan_supported?
-      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-    end
 
     def with_term
       stdout = $stdout

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -185,7 +185,6 @@ module TestIRB
     end
 
     def test_object_inspection_prints_useful_info_when_kernel_inspect_also_errored
-      omit if RUBY_VERSION < '2.7'
       verbose, $VERBOSE = $VERBOSE, nil
       main = Object.new
       main.singleton_class.module_eval <<~RUBY

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -613,9 +613,6 @@ module TestIRB
     end
 
     def test_broken_heredoc
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
-        pend 'This test needs Ripper::Lexer#scan to take broken tokens'
-      end
       input_with_correct_indents = [
         Row.new(%q(def foo), nil, 2, 1),
         Row.new(%q(  <<~Q), 2, 2, 1),
@@ -721,10 +718,6 @@ module TestIRB
     end
 
     def test_broken_percent_literal
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
-        pend 'This test needs Ripper::Lexer#scan to take broken tokens'
-      end
-
       tokens = RubyLex.ripper_lex_without_warning('%wwww')
       pos_to_index = {}
       tokens.each_with_index { |t, i|
@@ -734,10 +727,6 @@ module TestIRB
     end
 
     def test_broken_percent_literal_in_method
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
-        pend 'This test needs Ripper::Lexer#scan to take broken tokens'
-      end
-
       tokens = RubyLex.ripper_lex_without_warning(<<~EOC.chomp)
         def foo
           %wwww
@@ -751,10 +740,6 @@ module TestIRB
     end
 
     def test_unterminated_code
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
-        pend 'This test needs Ripper::Lexer#scan to take broken tokens'
-      end
-
       ['do', '<<A'].each do |code|
         tokens = RubyLex.ripper_lex_without_warning(code)
         assert_equal(code, tokens.map(&:tok).join, "Cannot reconstruct code from tokens")


### PR DESCRIPTION
As Ruby 2.7 enters EOL, I think it makes sense to drop the support of 2.6, which lacks proper kwargs support and `Ripper#scan` and makes maintenance more complicated.

### Versioning implication

According to the [semver specificaion](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api), updating a dependency without changing any API does NOT need to bump a major version. And given we don't introduce a feature either, I think this change can safely be included in the next patch or minor release.

> **What should I do if I update my own dependencies without changing the public API?**

> That would be considered compatible since it does not affect the public API. Software that explicitly depends on the same dependencies as your package should have their own dependency specifications and the author will notice any conflicts.


**Please let me merge this PR myself in case I found any additional changes to make or undo.**