### PR TITLE
Fix RubyLex's heredoc_with_hembexpr test to avoid ripper tokenizing i…

### DIFF
--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -229,9 +229,9 @@ module TestIRB
       input_with_prompt = [
         PromptRow.new('001:0:":* ', %q(<<A+%W[#{<<B)),
         PromptRow.new('002:0:":* ', %q(#{<<C+%W[)),
-        PromptRow.new('003:0:":* ', %q()),
-        PromptRow.new('004:0:":* ', %q(C)),
-        PromptRow.new('005:0:]:* ', %q()),
+        PromptRow.new('003:0:":* ', %q(a)),
+        PromptRow.new('004:0:]:* ', %q(C)),
+        PromptRow.new('005:0:]:* ', %q(a)),
         PromptRow.new('006:0:":* ', %q(]})),
         PromptRow.new('007:0:":* ', %q(})),
         PromptRow.new('008:0:":* ', %q(A)),


### PR DESCRIPTION
Fix `test_heredoc_with_embexpr` because the expected result was wrong.
We also have to avoid ripper's bug https://bugs.ruby-lang.org/issues/19563 in test cases because I want this test to be executed in all supported ruby version.

```ruby
require 'ripper'
code = [
  %q(<<A+%W[#{<<B),
  %q(#{<<C+%W[),
  %q(a),
  %q(C),
  %q(a), # if this line is an empty string `%(),` then `Ripper.tokenize(code).join == code` returns false
  %q(]}),
  %q(}),
  %q(A),
  %q(B),
  %q(}),
  %q(]),
  %q()
].join("\n")
puts RUBY_VERSION
p Ripper.tokenize(code).join == code #=> true in ruby 2.7~3.2
```