### PR TITLE
Simplify command method definition

### DIFF
--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -258,15 +258,7 @@ module IRB # :nodoc:
       line = __LINE__; eval %[
         def #{cmd_name}(*opts, **kwargs, &b)
           Kernel.require_relative "#{load_file}"
-          line = __LINE__; eval %[
-            unless singleton_class.class_variable_defined?(:@@#{cmd_name}_)
-              singleton_class.class_variable_set(:@@#{cmd_name}_, true)
-              def self.#{cmd_name}_(*opts, **kwargs, &b)
-                ::IRB::ExtendCommand::#{cmd_class}.execute(irb_context, *opts, **kwargs, &b)
-              end
-            end
-          ], nil, __FILE__, line
-          __send__ :#{cmd_name}_, *opts, **kwargs, &b
+          ::IRB::ExtendCommand::#{cmd_class}.execute(irb_context, *opts, **kwargs, &b)
         end
       ], nil, __FILE__, line
 

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -259,16 +259,11 @@ module IRB # :nodoc:
         line = __LINE__; eval %[
           def #{cmd_name}(*opts, **kwargs, &b)
             Kernel.require_relative "#{load_file}"
-            arity = ::IRB::ExtendCommand::#{cmd_class}.instance_method(:execute).arity
-            args = (1..(arity < 0 ? ~arity : arity)).map {|i| "arg" + i.to_s }
-            args << "*opts, **kwargs" if arity < 0
-            args << "&block"
-            args = args.join(", ")
             line = __LINE__; eval %[
               unless singleton_class.class_variable_defined?(:@@#{cmd_name}_)
                 singleton_class.class_variable_set(:@@#{cmd_name}_, true)
-                def self.#{cmd_name}_(\#{args})
-                  ::IRB::ExtendCommand::#{cmd_class}.execute(irb_context, \#{args})
+                def self.#{cmd_name}_(*opts, **kwargs, &b)
+                  ::IRB::ExtendCommand::#{cmd_class}.execute(irb_context, *opts, **kwargs, &b)
                 end
               end
             ], nil, __FILE__, line


### PR DESCRIPTION
I took incremental steps on this and explained reasons in each commit. I think this simplification should help the command extension API plan and avoid the definition of confusing `#{cmd}_` methods (e.g. `irb_info_` after running `irb_info`).