### PR TITLE
Simplify the help command's implementation

### DIFF
--- a/lib/irb/cmd/help.rb
+++ b/lib/irb/cmd/help.rb
@@ -26,17 +26,15 @@ module IRB
 
       def execute(*names)
         require 'rdoc/ri/driver'
-        opts = RDoc::RI::Driver.process_args([])
-        IRB::ExtendCommand::Help.const_set(:Ri, RDoc::RI::Driver.new(opts))
-      rescue LoadError, SystemExit
-        IRB::ExtendCommand::Help.remove_method(:execute)
-        # raise NoMethodError in ensure
-      else
-        def execute(*names)
-          if names.empty?
-            Ri.interactive
-            return
-          end
+
+        unless self.class.const_defined?(:Ri)
+          opts = RDoc::RI::Driver.process_args([])
+          self.class.const_set(:Ri, RDoc::RI::Driver.new(opts))
+        end
+
+        if names.empty?
+          Ri.interactive
+        else
           names.each do |name|
             begin
               Ri.display_name(name.to_s)
@@ -44,11 +42,11 @@ module IRB
               puts $!.message
             end
           end
-          nil
         end
+
         nil
-      ensure
-        execute(*names)
+      rescue LoadError, SystemExit
+        warn "Can't display document because `rdoc` is not installed."
       end
     end
   end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -782,7 +782,7 @@ module TestIRB
   class ShowDocTest < CommandTestCase
     def test_help_and_show_doc
       ["help", "show_doc"].each do |cmd|
-        out, _ = execute_lines(
+        out, err = execute_lines(
           "#{cmd} String#gsub\n",
           "\n",
         )
@@ -790,6 +790,7 @@ module TestIRB
         # the former is what we'd get without document content installed, like on CI
         # the latter is what we may get locally
         possible_rdoc_output = [/Nothing known about String#gsub/, /gsub\(pattern\)/]
+        assert_empty err
         assert(possible_rdoc_output.any? { |output| output.match?(out) }, "Expect the `#{cmd}` command to match one of the possible outputs. Got:\n#{out}")
       end
     ensure
@@ -798,7 +799,7 @@ module TestIRB
     end
 
     def test_show_doc_without_rdoc
-      out, _ = without_rdoc do
+      out, err = without_rdoc do
         execute_lines(
           "show_doc String#gsub\n",
           "\n",
@@ -806,7 +807,8 @@ module TestIRB
       end
 
       # if it fails to require rdoc, it only returns the command object
-      assert_match(/=> IRB::ExtendCommand::Help\n/, out)
+      assert_match(/=> nil\n/, out)
+      assert_include(err, "Can't display document because `rdoc` is not installed.\n")
     ensure
       # this is the only way to reset the redefined method without coupling the test with its implementation
       EnvUtil.suppress_warning { load "irb/cmd/help.rb" }


### PR DESCRIPTION
The current method-redefining approach brings little benefit, makes it harder to understand the code, and causes warnings like:

> warning: method redefined; discarding old execute

This patch simplifies it while displaying more helpful message when rdoc couldn't be loaded.