### PR TITLE
Fix Locale's encoding lookup for ujis/euc encodings

### DIFF
--- a/lib/irb/locale.rb
+++ b/lib/irb/locale.rb
@@ -29,8 +29,9 @@ module IRB # :nodoc:
           begin load 'irb/encoding_aliases.rb'; rescue LoadError; end
           if @encoding = @@legacy_encoding_alias_map[@encoding_name]
             warn(("%s is obsolete. use %s" % ["#{@lang}_#{@territory}.#{@encoding_name}", "#{@lang}_#{@territory}.#{@encoding.name}"]), uplevel: 1)
+          else
+            @encoding = Encoding.find(@encoding_name) rescue nil
           end
-          @encoding = Encoding.find(@encoding_name) rescue nil
         end
       end
       @encoding ||= (Encoding.find('locale') rescue Encoding::ASCII_8BIT)

--- a/test/irb/test_locale.rb
+++ b/test/irb/test_locale.rb
@@ -31,7 +31,7 @@ module TestIRB
 
       assert_equal("ja", locale.lang)
       assert_equal("JP", locale.territory)
-      assert_equal("UTF-8", locale.encoding.name)
+      assert_equal(Encoding::EUC_JP, locale.encoding)
       assert_equal(nil, locale.modifier)
 
       assert_include $stderr.string, "ja_JP.ujis is obsolete. use ja_JP.EUC-JP"
@@ -47,7 +47,7 @@ module TestIRB
 
       assert_equal("ja", locale.lang)
       assert_equal("JP", locale.territory)
-      assert_equal("UTF-8", locale.encoding.name)
+      assert_equal(Encoding::EUC_JP, locale.encoding)
       assert_equal(nil, locale.modifier)
 
       assert_include $stderr.string, "ja_JP.euc is obsolete. use ja_JP.EUC-JP"


### PR DESCRIPTION
In https://github.com/ruby/irb/commit/3ee79e89adb8e21b63d796e53bcc86281685076d, `encoding_aliases.rb` was introduced to return the correct encoding object for `ujis` and `euc` encodings.

However, the return value of `@@legacy_encoding_alias_map[@encoding_name]` is always overridden by a second look up with `Encoding.find(@encoding_name)`. So the logic didn't work as expected.