### PR TITLE
Simplify Locale#load

### DIFF
--- a/lib/irb/locale.rb
+++ b/lib/irb/locale.rb
@@ -109,7 +109,7 @@ module IRB # :nodoc:
 
     alias toplevel_load load
 
-    def load(file, priv=nil)
+    def load(file)
       found = find(file)
       if found
         unless @@loaded.include?(found)

--- a/lib/irb/locale.rb
+++ b/lib/irb/locale.rb
@@ -114,7 +114,7 @@ module IRB # :nodoc:
       if found
         unless @@loaded.include?(found)
           @@loaded << found # cache
-          return real_load(found, priv)
+          Kernel.load(found)
         end
       else
         raise LoadError, "No such file to load -- #{file}"
@@ -130,16 +130,6 @@ module IRB # :nodoc:
         return each_localized_path(dir, base).find{|full_path| File.readable? full_path}
       else
         return search_file(paths, dir, base)
-      end
-    end
-
-    private
-    def real_load(path, priv)
-      src = MagicFile.open(path){|f| f.read}
-      if priv
-        eval("self", TOPLEVEL_BINDING).extend(Module.new {eval(src, nil, path)})
-      else
-        eval(src, TOPLEVEL_BINDING, path)
       end
     end
 

--- a/lib/irb/locale.rb
+++ b/lib/irb/locale.rb
@@ -82,33 +82,6 @@ module IRB # :nodoc:
       super(*ary)
     end
 
-    def require(file, priv = nil)
-      rex = Regexp.new("lc/#{Regexp.quote(file)}\.(so|o|sl|rb)?")
-      return false if $".find{|f| f =~ rex}
-
-      case file
-      when /\.rb$/
-        begin
-          load(file, priv)
-          $".push file
-          return true
-        rescue LoadError
-        end
-      when /\.(so|o|sl)$/
-        return super
-      end
-
-      begin
-        load(f = file + ".rb")
-        $".push f  #"
-        return true
-      rescue LoadError
-        return ruby_require(file)
-      end
-    end
-
-    alias toplevel_load load
-
     def load(file)
       found = find(file)
       if found


### PR DESCRIPTION
Instead of loading file content with `MagicFile` and then evaluating it, we can just use `Kernel.load` to load the file.

I also removed unused `Locale#require` and `Locale#toplevel_load` methods and removed unused `Locale#load` argument.

