### PR TITLE
Stop using MagicFile for printing help messages

### DIFF
--- a/lib/irb/help.rb
+++ b/lib/irb/help.rb
@@ -12,7 +12,7 @@ module IRB
     lc = IRB.conf[:LC_MESSAGES]
     path = lc.find("irb/help-message")
     space_line = false
-    IRB::MagicFile.open(path){|f|
+    File.open(path){|f|
       f.each_line do |l|
         if /^\s*$/ =~ l
           lc.puts l unless space_line


### PR DESCRIPTION
`MagicFile` was introduced around v0.9.6, which was like 14~15 years ago. It was needed because back then we needed to read a file's magic comment to determine the encoding of it, and read it with that encoding.

Commit: https://github.com/ruby/irb/commit/3ee79e89adb8e21b63d796e53bcc86281685076d

But now both EN and JA's help-message file are UTF-8 and have removed the encoding comment, we don't need to open them with `MagicFile` anymore.

### Manual Tests

- `$ IRB_LANG=eu_US bundle exec irb --help` should print the EN help correctly
- `$ IRB_LANG=ja_JP bundle exec irb --help` should print the JA help correctly
