### PR TITLE
Simplify each_top_level_statement

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -225,7 +225,9 @@ class RubyLex
     line_offset = 0
     loop do
       line = @input.call
-      return code.empty? ? nil : code unless line
+      unless line
+        return code.empty? ? nil : code
+      end
 
       code << line
       # Accept any single-line input for symbol aliases or commands that transform args

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -18,10 +18,7 @@ class RubyLex
 
   def initialize(context)
     @context = context
-    @exp_line_no = @line_no = 1
-    @indent = 0
-    @continue = false
-    @line = ""
+    @line_no = 1
     @prompt = nil
   end
 
@@ -40,6 +37,11 @@ class RubyLex
       result = yield code, line_no
     end
     result
+  end
+
+  def single_line_command?(code)
+    command = code.split(/\s/, 2).first
+    @context.symbol_alias?(command) || @context.transform_args?(command)
   end
 
   # io functions
@@ -65,10 +67,7 @@ class RubyLex
           end
         else
           # Accept any single-line input for symbol aliases or commands that transform args
-          command = code.split(/\s/, 2).first
-          if @context.symbol_alias?(command) || @context.transform_args?(command)
-            next true
-          end
+          next true if single_line_command?(code)
 
           code.gsub!(/\s*\z/, '').concat("\n")
           tokens = self.class.ripper_lex_without_warning(code, context: @context)
@@ -210,67 +209,50 @@ class RubyLex
     [ltype, indent, continue, code_block_open]
   end
 
-  def prompt
-    if @prompt
-      @prompt.call(@ltype, @indent, @continue, @line_no)
-    end
+  def save_prompt_to_context_io(ltype, indent, continue, line_num_offset)
+    # Implicitly saves prompt string to `@context.io.prompt`. This will be used in the next `@input.call`.
+    @prompt.call(ltype, indent, continue, @line_no + line_num_offset)
   end
 
-  def initialize_input
-    @ltype = nil
-    @indent = 0
-    @continue = false
-    @line = ""
-    @exp_line_no = @line_no
-    @code_block_open = false
+  def readmultiline
+    save_prompt_to_context_io(nil, 0, false, 0)
+
+    # multiline
+    return @input.call if @io.respond_to?(:check_termination)
+
+    # nomultiline
+    code = ''
+    line_offset = 0
+    loop do
+      line = @input.call
+      return code.empty? ? nil : code unless line
+
+      code << line
+      # Accept any single-line input for symbol aliases or commands that transform args
+      return code if single_line_command?(code)
+
+      check_target_code = code.gsub(/\s*\z/, '').concat("\n")
+      tokens = self.class.ripper_lex_without_warning(check_target_code, context: @context)
+      ltype, indent, continue, code_block_open = check_state(check_target_code, tokens)
+      return code unless ltype or indent > 0 or continue or code_block_open
+
+      line_offset += 1
+      save_prompt_to_context_io(ltype, indent, continue, line_offset)
+    end
   end
 
   def each_top_level_statement
-    initialize_input
-    catch(:TERM_INPUT) do
-      loop do
-        begin
-          prompt
-          unless l = lex
-            throw :TERM_INPUT if @line == ''
-          else
-            @line_no += l.count("\n")
-            if l == "\n"
-              @exp_line_no += 1
-              next
-            end
-            @line.concat l
-            if @code_block_open or @ltype or @continue or @indent > 0
-              next
-            end
-          end
-          if @line != "\n"
-            @line.force_encoding(@io.encoding)
-            yield @line, @exp_line_no
-          end
-          raise TerminateLineInput if @io.eof?
-          @line = ''
-          @exp_line_no = @line_no
+    loop do
+      code = readmultiline
+      break unless code
 
-          @indent = 0
-        rescue TerminateLineInput
-          initialize_input
-          prompt
-        end
+      if code != "\n"
+        code.force_encoding(@io.encoding)
+        yield code, @line_no
       end
+      @line_no += code.count("\n")
+    rescue RubyLex::TerminateLineInput
     end
-  end
-
-  def lex
-    line = @input.call
-    if @io.respond_to?(:check_termination)
-      return line # multiline
-    end
-    code = @line + (line.nil? ? '' : line)
-    code.gsub!(/\s*\z/, '').concat("\n")
-    @tokens = self.class.ripper_lex_without_warning(code, context: @context)
-    @ltype, @indent, @continue, @code_block_open = check_state(code, @tokens)
-    line
   end
 
   def process_continue(tokens)

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -253,7 +253,7 @@ class RubyLex
         yield code, @line_no
       end
       @line_no += code.count("\n")
-    rescue RubyLex::TerminateLineInput
+    rescue TerminateLineInput
     end
   end
 

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -69,9 +69,7 @@ class RubyLex
           # Accept any single-line input for symbol aliases or commands that transform args
           next true if single_line_command?(code)
 
-          code.gsub!(/\s*\z/, '').concat("\n")
-          tokens = self.class.ripper_lex_without_warning(code, context: @context)
-          ltype, indent, continue, code_block_open = check_state(code, tokens)
+          ltype, indent, continue, code_block_open = check_code_state(code)
           if ltype or indent > 0 or continue or code_block_open
             false
           else
@@ -209,6 +207,12 @@ class RubyLex
     [ltype, indent, continue, code_block_open]
   end
 
+  def check_code_state(code)
+    check_target_code = code.gsub(/\s*\z/, '').concat("\n")
+    tokens = self.class.ripper_lex_without_warning(check_target_code, context: @context)
+    check_state(check_target_code, tokens)
+  end
+
   def save_prompt_to_context_io(ltype, indent, continue, line_num_offset)
     # Implicitly saves prompt string to `@context.io.prompt`. This will be used in the next `@input.call`.
     @prompt.call(ltype, indent, continue, @line_no + line_num_offset)
@@ -233,9 +237,7 @@ class RubyLex
       # Accept any single-line input for symbol aliases or commands that transform args
       return code if single_line_command?(code)
 
-      check_target_code = code.gsub(/\s*\z/, '').concat("\n")
-      tokens = self.class.ripper_lex_without_warning(check_target_code, context: @context)
-      ltype, indent, continue, code_block_open = check_state(check_target_code, tokens)
+      ltype, indent, continue, code_block_open = check_code_state(code)
       return code unless ltype or indent > 0 or continue or code_block_open
 
       line_offset += 1

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -83,13 +83,13 @@ module TestIRB
     end
 
     def assert_nesting_level(lines, expected, local_variables: [])
-      _ltype, indent, _code_block_open = check_state(lines, local_variables: local_variables)
+      indent, _code_block_open = check_state(lines, local_variables: local_variables)
       error_message = "Calculated the wrong number of nesting level for:\n #{lines.join("\n")}"
       assert_equal(expected, indent, error_message)
     end
 
     def assert_code_block_open(lines, expected, local_variables: [])
-      _ltype, _indent, code_block_open = check_state(lines, local_variables: local_variables)
+      _indent, code_block_open = check_state(lines, local_variables: local_variables)
       error_message = "Wrong result of code_block_open for:\n #{lines.join("\n")}"
       assert_equal(expected, code_block_open, error_message)
     end
@@ -99,8 +99,8 @@ module TestIRB
       code = lines.join("\n")
       tokens = RubyLex.ripper_lex_without_warning(code, context: context)
       ruby_lex = RubyLex.new(context)
-      ltype, indent, _continue, code_block_open = ruby_lex.check_state(code, tokens)
-      [ltype, indent, code_block_open]
+      _ltype, indent, _continue, code_block_open = ruby_lex.check_state(code, tokens)
+      [indent, code_block_open]
     end
 
     def test_auto_indent

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -96,10 +96,8 @@ module TestIRB
 
     def check_state(lines, local_variables: [])
       context = build_context(local_variables)
-      code = lines.join("\n")
-      tokens = RubyLex.ripper_lex_without_warning(code, context: context)
       ruby_lex = RubyLex.new(context)
-      _ltype, indent, _continue, code_block_open = ruby_lex.check_state(code, tokens)
+      _ltype, indent, _continue, code_block_open = ruby_lex.check_code_state(lines.join("\n"))
       [indent, code_block_open]
     end
 


### PR DESCRIPTION
This pull request is an extract of refactor from #500 


Refactored each_top_level_statement
- Remove instance variables `@exp_line_no` `@indent` `@continue` `@line` from `ruby-lex.rb`
- Extract reading line part from `def each_top_level_statement` to `def readmultiline`
- Refactor complex flow using `catch(:TERM_INPUT)` and `throw :TERM_INPUT` into simple loop and break
- Delete `def lex` because it is only used from test code now


