### PR TITLE
Fix Test timedout in test_debug_cmd

### DIFF
--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -211,7 +211,15 @@ module TestIRB
       cmd = [EnvUtil.rubybin, "-I", LIB, @ruby_file.to_path]
       tmp_dir = Dir.mktmpdir
       rc_file = File.open(File.join(tmp_dir, ".irbrc"), "w+")
-      rc_file.write("IRB.conf[:USE_SINGLELINE] = true")
+      rc_file.write(<<~RUBY)
+        IRB.conf[:USE_SINGLELINE] = true
+        require 'readline'
+        if Readline.const_defined?(:IOGate)
+          def (Reline::IOGate).cursor_pos
+            Reline::GeneralIO.cursor_pos
+          end
+        end
+      RUBY
       rc_file.close
 
       @commands = []

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -17,7 +17,7 @@ module TestIRB
 
   class DebugCommandTestCase < TestCase
     IRB_AND_DEBUGGER_OPTIONS = {
-      "RUBY_DEBUG_NO_RELINE" => "true", "NO_COLOR" => "true", "RUBY_DEBUG_HISTORY_FILE" => ''
+      "NO_COLOR" => "true", "RUBY_DEBUG_HISTORY_FILE" => ''
     }
 
     def setup
@@ -213,12 +213,7 @@ module TestIRB
       rc_file = File.open(File.join(tmp_dir, ".irbrc"), "w+")
       rc_file.write(<<~RUBY)
         IRB.conf[:USE_SINGLELINE] = true
-        require 'readline'
-        if Readline.const_defined?(:IOGate)
-          def (Reline::IOGate).cursor_pos
-            Reline::GeneralIO.cursor_pos
-          end
-        end
+        Reline.const_set(:IOGate, Reline::GeneralIO)
       RUBY
       rc_file.close
 


### PR DESCRIPTION
### Description

In ruby head, `readline-ext` is removed. `Readline.readline` will be `Reline.readline` instead of `readline.so`.

The problem is that Reline prints `"▽\e[6n"`, east-asian-amibuous character and device status report escape sequence.
Reline will wait for cursor position report `\e[<row>;<col>R` forever and cause timeout error.
[Timeout result in #581](https://github.com/ruby/irb/actions/runs/4984571776/jobs/8929008593?pr=581)
To suppress this, I override `Reline::IOGate.cursor_pos` to use `Reline::GeneralIO.cursor_pos` in test_debug_cmd


### Failing test (help wanted)

Still one test is failing in ruby head.
#### Failed assertion
```ruby

assert_match(/\(rdbg\) next/, output)
```
#### Actual output
```
From: /tmp/irb-20230516-1760-qqd7e7.rb @ line 1 :

 => 1: binding.irb
    2: puts "hello"

debug
next
continue
(rdbg) [1, 2] in /tmp/irb-20230516-1760-qqd7e7.rb
     1| binding.irb
=>   2| puts "hello"
=>#0	<main> at /tmp/irb-20230516-1760-qqd7e7.rb:2
(rdbg) hello
```
This is because ruby/debug is directly requiring `readline.so` and fallbacks to `print prompt; gets`.
https://github.com/ruby/debug/blob/4ec9d7ab46df09aa87d64e600df8805a3ee0314c/lib/debug/console.rb#L164-L168
