### PR TITLE
Refactor RubyLex's input/io methods

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -537,7 +537,7 @@ module IRB
         @context.io.prompt
       end
 
-      @scanner.set_input(@context.io) do
+      @scanner.set_input do
         signal_status(:IN_INPUT) do
           if l = @context.io.gets
             print l if @context.verbose?
@@ -555,7 +555,7 @@ module IRB
         end
       end
 
-      @scanner.set_auto_indent
+      @scanner.configure_io(@context.io)
 
       @scanner.each_top_level_statement do |line, line_no|
         signal_status(:IN_EVAL) do

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -41,8 +41,8 @@ module TestIRB
       ruby_lex = RubyLex.new(context)
       mock_io = MockIO_AutoIndent.new(lines, last_line_index, byte_pointer, add_new_line)
 
-      ruby_lex.set_input(mock_io)
-      ruby_lex.set_auto_indent
+      ruby_lex.set_input { @io.gets }
+      ruby_lex.configure_io(mock_io)
       mock_io.calculated_indent
     end
 
@@ -99,7 +99,7 @@ module TestIRB
       ruby_lex = RubyLex.new(context)
 
       io = proc{ lines.join("\n") }
-      ruby_lex.set_input(io) do
+      ruby_lex.set_input do
         lines.join("\n")
       end
       ruby_lex.lex
@@ -658,7 +658,7 @@ module TestIRB
       ruby_lex.set_prompt do |ltype, indent, continue, line_no|
         '%03d:%01d:%1s:%s ' % [line_no, indent, ltype, continue ? '*' : '>']
       end
-      ruby_lex.set_input(io)
+      ruby_lex.set_input { @io.gets }
     end
 
     def test_dyanmic_prompt


### PR DESCRIPTION
1. Make `RubyLex#set_input` simply assign the input block. This matches the behavior of `RubyLex#set_prompt`.
2. Merge `RubyLex#set_input`'s IO configuration logic with `#set_auto_indent` into `#configure_io`.

I think `RubyLex#configure_io` could use further refactor. But I want to revisit it after #576 is merged.