### PR TITLE
Fix dynamic_prompt test not executed, remove unnecessary set_input

### DIFF
--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -41,7 +41,6 @@ module TestIRB
       ruby_lex = RubyLex.new(context)
       mock_io = MockIO_AutoIndent.new(lines, last_line_index, byte_pointer, add_new_line)
 
-      ruby_lex.set_input { @io.gets }
       ruby_lex.configure_io(mock_io)
       mock_io.calculated_indent
     end
@@ -653,7 +652,7 @@ module TestIRB
       ruby_lex.set_prompt do |ltype, indent, continue, line_no|
         '%03d:%01d:%1s:%s ' % [line_no, indent, ltype, continue ? '*' : '>']
       end
-      ruby_lex.set_input { @io.gets }
+      ruby_lex.configure_io(io)
     end
 
     def test_dyanmic_prompt


### PR DESCRIPTION
The assersion `assert_dynamic_prompt` was not working.
`MockIO_DynamicPrompt#dynamic_prompt` is triggered when configure_io is called. it was changed on refactor of `set_input`.


I also removed `set_input { @io.gets }`.
The block passed to set_input is not called and `@io` is always nil because it is an instance variable of `TestIRB::TestRubyLex`.