### PR TITLE
Set maximum document dialog height

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -401,6 +401,7 @@ module IRB
       mod_key = RUBY_PLATFORM.match?(/darwin/) ? "Option" : "Alt"
       message = "Press #{mod_key}+d to read the full document"
       contents = [message] + doc.accept(formatter).split("\n")
+      contents = contents.take(preferred_dialog_height) if respond_to?(:preferred_dialog_height)
 
       y = cursor_pos_to_render.y
       DialogRenderInfo.new(pos: Reline::CursorPos.new(x, y), contents: contents, width: width, bg_color: '49')


### PR DESCRIPTION
In https://github.com/ruby/reline/pull/542, Reline uses small completion dialog in small screen, but IRB's document dialog is still large.
This pull request sets IRB's document dialog maximum height to `preferred_dialog_height` introduced in Reline.

Left: reline:master and irb:master
Right: reline:master and irb:this-pull-request
![doc_dialog](https://github.com/ruby/irb/assets/1780201/4ea47211-b6c5-43f1-9ac4-07018c398853)
