### PR TITLE
Improve debug command tests

### DIFF
--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -8,8 +8,8 @@ end
 
 require "tempfile"
 require "tmpdir"
-require "envutil"
 
+require_relative "../lib/envutil"
 require_relative "helper"
 
 module TestIRB

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -210,19 +210,13 @@ module TestIRB
     def run_ruby_file(&block)
       cmd = [EnvUtil.rubybin, "-I", LIB, @ruby_file.to_path]
       tmp_dir = Dir.mktmpdir
-      rc_file = File.open(File.join(tmp_dir, ".irbrc"), "w+")
-      rc_file.write(<<~RUBY)
-        IRB.conf[:USE_SINGLELINE] = true
-        Reline.const_set(:IOGate, Reline::GeneralIO)
-      RUBY
-      rc_file.close
 
       @commands = []
       lines = []
 
       yield
 
-      PTY.spawn(IRB_AND_DEBUGGER_OPTIONS.merge("IRBRC" => rc_file.to_path), *cmd) do |read, write, pid|
+      PTY.spawn(IRB_AND_DEBUGGER_OPTIONS.merge("TERM" => "dumb"), *cmd) do |read, write, pid|
         Timeout.timeout(TIMEOUT_SEC) do
           while line = safe_gets(read)
             lines << line


### PR DESCRIPTION
1. By requiring `envutil` with `require_relative`, we match other testing helper requires. But more importantly, it allows running the tests with `ruby -Itest test/irb/test_debug_cmd.rb` without having to set up the load path.
2. If we specify `TERM=dumb`, reline will use a simpler IO gate that doesn't do  east-asian-amibuous character detection, which would cause hanging in a PTY environment.