### PR TITLE
Require test helpers from central helper 

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -3,6 +3,7 @@ require "pathname"
 
 begin
   require_relative "../lib/helper"
+  require_relative "../lib/envutil"
 rescue LoadError # ruby/ruby defines helpers differently
 end
 
@@ -66,10 +67,6 @@ module TestIRB
 
       yield
     ensure
-      begin
-        require_relative "../lib/envutil"
-      rescue LoadError # ruby/ruby defines EnvUtil differently
-      end
       EnvUtil.suppress_warning {
         ::Kernel.send(:alias_method, :require, :irb_original_require)
         ::Kernel.undef_method :irb_original_require

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -9,7 +9,6 @@ end
 require "tempfile"
 require "tmpdir"
 
-require_relative "../lib/envutil"
 require_relative "helper"
 
 module TestIRB


### PR DESCRIPTION
Because they are handled differently in `ruby/irb` and `ruby/ruby`.