### PR TITLE
Refactor ExtendCommand::Nop

### DIFF
--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -30,15 +30,15 @@ module IRB
         end
       end
 
-      def self.execute(conf, *opts, **kwargs, &block)
-        command = new(conf)
+      def self.execute(irb_context, *opts, **kwargs, &block)
+        command = new(irb_context)
         command.execute(*opts, **kwargs, &block)
       rescue CommandArgumentError => e
         puts e.message
       end
 
-      def initialize(conf)
-        @irb_context = conf
+      def initialize(irb_context)
+        @irb_context = irb_context
       end
 
       attr_reader :irb_context

--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -43,10 +43,6 @@ module IRB
 
       attr_reader :irb_context
 
-      def irb
-        @irb_context.irb
-      end
-
       def execute(*opts)
         #nop
       end

--- a/lib/irb/ext/loader.rb
+++ b/lib/irb/ext/loader.rb
@@ -42,6 +42,7 @@ module IRB # :nodoc:
     #
     # See Irb#suspend_input_method for more information.
     def source_file(path)
+      irb = irb_context.irb
       irb.suspend_name(path, File.basename(path)) do
         FileInputMethod.open(path) do |io|
           irb.suspend_input_method(io) do
@@ -66,6 +67,7 @@ module IRB # :nodoc:
     #
     # See Irb#suspend_input_method for more information.
     def load_file(path, priv = nil)
+      irb = irb_context.irb
       irb.suspend_name(path, File.basename(path)) do
 
         if priv


### PR DESCRIPTION
1. The `conf` name is very confusing because it doesn't mean `IRB.conf` but the current `irb_context` object. So I think it should be renamed.
2. We don't need to expose this method to all command classes, especially
when it's just an alias of `irb_context.irb`.