### PR TITLE
Fixed string escaping omissions

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -233,7 +233,7 @@ module IRB
         if doc_namespace
           candidates.find { |i| i == receiver }
         else
-          candidates.grep(/^#{receiver}/).collect{|e| "::" + e}
+          candidates.grep(/^#{Regexp.quote(receiver)}/).collect{|e| "::" + e}
         end
 
       when /^([A-Z].*)::([^:.]*)$/

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -310,6 +310,7 @@ module TestIRB
       assert_empty(IRB::InputCompletor.retrieve_completion_data("::A.", bind: binding))
       assert_empty(IRB::InputCompletor.retrieve_completion_data("::A(", bind: binding))
       assert_empty(IRB::InputCompletor.retrieve_completion_data("::A)", bind: binding))
+      assert_empty(IRB::InputCompletor.retrieve_completion_data("::A[", bind: binding))
     end
 
     def test_complete_reserved_words


### PR DESCRIPTION
Original issue was reported by @koic. 

I received a `RegexpError` when I typed `::Array[`.
Added `Regexp.quote` because `receiver` was not escaped.

Stack trace:

```
irb(main):001:1* ::Array[/Users/mi/ghq/github.com/ruby/irb/lib/irb/completion.rb:236:in `retrieve_completion_data': premature end of char-class: /^Array[/ (RegexpError)
        from /Users/mi/ghq/github.com/ruby/irb/lib/irb/completion.rb:151:in `block in <module:InputCompletor>'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline/line_editor.rb:1631:in `call_completion_proc_with_checking_args'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline/line_editor.rb:529:in `call_completion_proc_with_checking_args'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline.rb:239:in `block in <class:Core>'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline/line_editor.rb:584:in `instance_exec'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline/line_editor.rb:584:in `call'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline/line_editor.rb:619:in `call'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline/line_editor.rb:772:in `update_each_dialog'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline/line_editor.rb:648:in `block in render_dialog'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline/line_editor.rb:646:in `map'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline/line_editor.rb:646:in `render_dialog'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline/line_editor.rb:496:in `rerender'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline.rb:354:in `block (3 levels) in inner_readline'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline.rb:352:in `each'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline.rb:352:in `block (2 levels) in inner_readline'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline.rb:427:in `block in read_io'
        from <internal:kernel>:187:in `loop'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline.rb:397:in `read_io'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline.rb:350:in `block in inner_readline'
        from <internal:kernel>:187:in `loop'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline.rb:348:in `inner_readline'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline.rb:277:in `block in readmultiline'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline/ansi.rb:149:in `block in with_raw_input'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline/ansi.rb:149:in `raw'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline/ansi.rb:149:in `with_raw_input'
        from /Users/mi/ghq/github.com/ruby/reline/lib/reline.rb:273:in `readmultiline'
        from /Users/mi/.asdf/installs/ruby/3.3.0-dev/lib/ruby/3.3.0+0/forwardable.rb:240:in `readmultiline'
        from /Users/mi/.asdf/installs/ruby/3.3.0-dev/lib/ruby/3.3.0+0/forwardable.rb:240:in `readmultiline'
        from /Users/mi/ghq/github.com/ruby/irb/lib/irb/input-method.rb:418:in `gets'
        from /Users/mi/ghq/github.com/ruby/irb/lib/irb.rb:542:in `block (2 levels) in eval_input'
        from /Users/mi/ghq/github.com/ruby/irb/lib/irb.rb:770:in `signal_status'
        from /Users/mi/ghq/github.com/ruby/irb/lib/irb.rb:541:in `block in eval_input'
        from /Users/mi/ghq/github.com/ruby/irb/lib/irb/ruby-lex.rb:225:in `readmultiline'
        from /Users/mi/ghq/github.com/ruby/irb/lib/irb/ruby-lex.rb:250:in `block in each_top_level_statement'
        from <internal:kernel>:187:in `loop'
        from /Users/mi/ghq/github.com/ruby/irb/lib/irb/ruby-lex.rb:249:in `each_top_level_statement'
        from /Users/mi/ghq/github.com/ruby/irb/lib/irb.rb:560:in `eval_input'
        from /Users/mi/ghq/github.com/ruby/irb/lib/irb.rb:494:in `block in run'
        from /Users/mi/ghq/github.com/ruby/irb/lib/irb.rb:493:in `catch'
        from /Users/mi/ghq/github.com/ruby/irb/lib/irb.rb:493:in `run'
        from /Users/mi/ghq/github.com/ruby/irb/lib/irb.rb:416:in `start'
        from /Users/mi/ghq/github.com/ruby/irb/exe/irb:9:in `<main>'
```