### PR TITLE
Use `Kernel.warn` to print command alias warning

### DIFF
--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -289,7 +289,7 @@ module IRB # :nodoc:
           alias_method to, from
         }
       else
-        Kernel.print "irb: warn: can't alias #{to} from #{from}.\n"
+        Kernel.warn "irb: warn: can't alias #{to} from #{from}.\n"
       end
     end
 


### PR DESCRIPTION
This aligns with other warnings in IRB and properly channels the message to stderr.