### PR TITLE
Deprecate measure block usage

### DIFF
--- a/lib/irb/cmd/measure.rb
+++ b/lib/irb/cmd/measure.rb
@@ -12,7 +12,7 @@ module IRB
         super(*args)
       end
 
-      def execute(type = nil, arg = nil, &block)
+      def execute(type = nil, arg = nil)
         # Please check IRB.init_config in lib/irb/init.rb that sets
         # IRB.conf[:MEASURE_PROC] to register default "measure" methods,
         # "measure :time" (abbreviated as "measure") and "measure :stackprof".
@@ -29,15 +29,9 @@ module IRB
           added = IRB.set_measure_callback(type, arg)
           puts "#{added[0]} is added." if added
         else
-          if block_given?
-            IRB.conf[:MEASURE] = true
-            added = IRB.set_measure_callback(&block)
-            puts "#{added[0]} is added." if added
-          else
-            IRB.conf[:MEASURE] = true
-            added = IRB.set_measure_callback(type, arg)
-            puts "#{added[0]} is added." if added
-          end
+          IRB.conf[:MEASURE] = true
+          added = IRB.set_measure_callback(type, arg)
+          puts "#{added[0]} is added." if added
         end
         nil
       end

--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -30,9 +30,9 @@ module IRB
         end
       end
 
-      def self.execute(irb_context, *opts, **kwargs, &block)
+      def self.execute(irb_context, *opts, **kwargs)
         command = new(irb_context)
-        command.execute(*opts, **kwargs, &block)
+        command.execute(*opts, **kwargs)
       rescue CommandArgumentError => e
         puts e.message
       end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -251,6 +251,36 @@ module TestIRB
       assert_match(/\A=> 3\nTIME is added\.\n=> nil\nprocessing time: .+\n=> 3\n=> nil\n=> 3\n/, out)
       assert_empty(c.class_variables)
     end
+    def test_measure_doesnt_override
+      conf = {
+        PROMPT: {
+          DEFAULT: {
+            PROMPT_I: '> ',
+            PROMPT_S: '> ',
+            PROMPT_C: '> ',
+            PROMPT_N: '> '
+          }
+        },
+        PROMPT_MODE: :DEFAULT,
+        MEASURE: false
+      }
+
+      c = Class.new(Object) do
+        def measure(*)
+          puts "measure defined by user"
+        end
+      end
+
+      out, err = execute_lines(
+        "measure :on\n",
+        conf: conf,
+        main: c.new
+      )
+
+      assert_empty err
+      assert_match(/measure defined by user/, out)
+      assert_empty(c.class_variables)
+    end
 
     def test_measure_enabled_by_rc
       conf = {
@@ -375,7 +405,7 @@ module TestIRB
         main: c
       )
 
-      assert_empty err
+      assert_match(/Passing a block to measure is deprecated/, err)
       assert_match(/\A=> 3\nBLOCK is added\.\n=> nil\naaa\n=> 3\nBLOCK is added.\naaa\n=> nil\nbbb\n=> 3\n=> nil\n=> 3\n/, out)
       assert_empty(c.class_variables)
     end


### PR DESCRIPTION
1. Add custom command definition for `irb_measure`
2. Deprecate `measure` command's block usage

This will officially remove the need to pass block to command's `execute`
method, which will make future command refactoring a lot easier.