### PR TITLE
Stanardise test class names with `Test` postfix instead of prefix

### DIFF
--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -6,7 +6,7 @@ require 'stringio'
 require_relative "helper"
 
 module TestIRB
-  class TestColor < TestCase
+  class ColorTest < TestCase
     CLEAR     = "\e[0m"
     BOLD      = "\e[1m"
     UNDERLINE = "\e[4m"

--- a/test/irb/test_color_printer.rb
+++ b/test/irb/test_color_printer.rb
@@ -6,7 +6,7 @@ require 'stringio'
 require_relative "helper"
 
 module TestIRB
-  class TestColorPrinter < TestCase
+  class ColorPrinterTest < TestCase
     CLEAR     = "\e[0m"
     BOLD      = "\e[1m"
     RED       = "\e[31m"
@@ -41,7 +41,7 @@ module TestIRB
       {
         1 => "#{BLUE}#{BOLD}1#{CLEAR}\n",
         "a\nb" => %[#{RED}#{BOLD}"#{CLEAR}#{RED}a\\nb#{CLEAR}#{RED}#{BOLD}"#{CLEAR}\n],
-        IRBTestColorPrinter.new('test') => "#{GREEN}#<struct TestIRB::TestColorPrinter::IRBTestColorPrinter#{CLEAR} a#{GREEN}=#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{RED}test#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{GREEN}>#{CLEAR}\n",
+        IRBTestColorPrinter.new('test') => "#{GREEN}#<struct TestIRB::ColorPrinterTest::IRBTestColorPrinter#{CLEAR} a#{GREEN}=#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{RED}test#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{GREEN}>#{CLEAR}\n",
         Ripper::Lexer.new('1').scan => "[#{GREEN}#<Ripper::Lexer::Elem:#{CLEAR} on_int@1:0 END token: #{RED}#{BOLD}\"#{CLEAR}#{RED}1#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{GREEN}>#{CLEAR}]\n",
         Class.new{define_method(:pretty_print){|q| q.text("[__FILE__, __LINE__, __ENCODING__]")}}.new => "[#{CYAN}#{BOLD}__FILE__#{CLEAR}, #{CYAN}#{BOLD}__LINE__#{CLEAR}, #{CYAN}#{BOLD}__ENCODING__#{CLEAR}]\n",
       }.each do |object, result|

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -5,13 +5,13 @@ require "irb"
 require_relative "helper"
 
 module TestIRB
-  class TestCompletion < TestCase
+  class CompletionTest < TestCase
     def setup
       # make sure require completion candidates are not cached
       IRB::InputCompletor.class_variable_set(:@@files_from_load_path, nil)
     end
 
-    class TestMethodCompletion < TestCompletion
+    class MethodCompletionTest < CompletionTest
       def test_complete_string
         assert_include(IRB::InputCompletor.retrieve_completion_data("'foo'.up", bind: binding), "'foo'.upcase")
         # completing 'foo bar'.up
@@ -65,7 +65,7 @@ module TestIRB
       end
     end
 
-    class TestRequireComepletion < TestCompletion
+    class RequireComepletionTest < CompletionTest
       def test_complete_require
         candidates = IRB::InputCompletor::CompletionProc.("'irb", "require ", "")
         %w['irb/init 'irb/ruby-lex].each do |word|
@@ -139,7 +139,7 @@ module TestIRB
       end
     end
 
-    class TestVariableCompletion < TestCompletion
+    class VariableCompletionTest < CompletionTest
       def test_complete_variable
         # Bug fix issues https://github.com/ruby/irb/issues/368
         # Variables other than `str_example` and `@str_example` are defined to ensure that irb completion does not cause unintended behavior
@@ -181,7 +181,7 @@ module TestIRB
       end
     end
 
-    class TestConstantCompletion < TestCompletion
+    class ConstantCompletionTest < CompletionTest
       class Foo
         B3 = 1
         B1 = 1
@@ -198,7 +198,7 @@ module TestIRB
       end
     end
 
-    class TestPerfectMatching < TestCompletion
+    class PerfectMatchingTest < CompletionTest
       def setup
         # trigger PerfectMatchedProc to set up RDocRIDriver constant
         IRB::InputCompletor::PerfectMatchedProc.("foo", bind: binding)

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -6,7 +6,7 @@ require 'rubygems' if defined?(Gem)
 require_relative "helper"
 
 module TestIRB
-  class TestContext < TestCase
+  class ContextTest < TestCase
     def setup
       IRB.init_config(nil)
       IRB.conf[:USE_SINGLELINE] = false

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -6,7 +6,7 @@ require 'readline'
 require_relative "helper"
 
 module TestIRB
-  class TestHistory < TestCase
+  class HistoryTest < TestCase
     def setup
       IRB.conf[:RC_NAME_GENERATOR] = nil
     end

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -5,7 +5,7 @@ require "fileutils"
 require_relative "helper"
 
 module TestIRB
-  class TestInit < TestCase
+  class InitTest < TestCase
     def setup
       # IRBRC is for RVM...
       @backup_env = %w[HOME XDG_CONFIG_HOME IRBRC].each_with_object({}) do |env, hash|

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -5,7 +5,7 @@ require "irb"
 require_relative "helper"
 
 module TestIRB
-  class TestRelineInputMethod < TestCase
+  class RelineInputMethodTest < TestCase
     def setup
       @conf_backup = IRB.conf.dup
       IRB.conf[:LC_MESSAGES] = IRB::Locale.new

--- a/test/irb/test_option.rb
+++ b/test/irb/test_option.rb
@@ -2,7 +2,7 @@
 require_relative "helper"
 
 module TestIRB
-  class TestOption < TestCase
+  class OptionTest < TestCase
     def test_end_of_option
       bug4117 = '[ruby-core:33574]'
       bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []

--- a/test/irb/test_raise_no_backtrace_exception.rb
+++ b/test/irb/test_raise_no_backtrace_exception.rb
@@ -4,7 +4,7 @@ require "tmpdir"
 require_relative "helper"
 
 module TestIRB
-  class TestRaiseNoBacktraceException < TestCase
+  class RaiseNoBacktraceExceptionTest < TestCase
     def test_raise_exception
       bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []
       assert_in_out_err(bundle_exec + %w[-rirb -W0 -e IRB.start(__FILE__) -- -f --], <<-IRB, /Exception: foo/, [])

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -6,7 +6,7 @@ require 'ostruct'
 require_relative "helper"
 
 module TestIRB
-  class TestRubyLex < TestCase
+  class RubyLexTest < TestCase
     Row = Struct.new(:content, :current_line_spaces, :new_line_spaces, :nesting_level)
 
     class MockIO_AutoIndent

--- a/test/irb/test_workspace.rb
+++ b/test/irb/test_workspace.rb
@@ -8,7 +8,7 @@ require 'irb/color'
 require_relative "helper"
 
 module TestIRB
-  class TestWorkSpace < TestCase
+  class WorkSpaceTest < TestCase
     def test_code_around_binding
       IRB.conf[:USE_COLORIZE] = false
       Tempfile.create('irb') do |f|


### PR DESCRIPTION
1. I think it's better to standardise test class names so things are more clear
2. I prefer `SomethingTest` instead of `TestSomething` because we sometimes also name some stub/mock class, like `TestInputMethod`. So the latter is more ambiguous.
    - Another reason is that `ruby-lsp` detects code-lens activation on `SomethingTest` only.

    ![Screenshot 2023-06-12 at 12 20 26](https://github.com/ruby/irb/assets/5079556/3b54380f-8d2f-4843-8f22-90c7e7155b34)
