### PR TITLE
Omit nesting_level, use indent_level to build prompt string

### DIFF
--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -7,7 +7,7 @@ require_relative "helper"
 
 module TestIRB
   class RubyLexTest < TestCase
-    Row = Struct.new(:content, :current_line_spaces, :new_line_spaces, :nesting_level)
+    Row = Struct.new(:content, :current_line_spaces, :new_line_spaces, :indent_level)
 
     class MockIO_AutoIndent
       attr_reader :calculated_indent
@@ -81,14 +81,14 @@ module TestIRB
       assert_equal(row.new_line_spaces, actual_next_line_spaces, error_message)
     end
 
-    def assert_nesting_level(lines, expected, local_variables: [])
-      nesting_level, _code_block_open = check_state(lines, local_variables: local_variables)
-      error_message = "Calculated the wrong number of nesting level for:\n #{lines.join("\n")}"
-      assert_equal(expected, nesting_level, error_message)
+    def assert_indent_level(lines, expected, local_variables: [])
+      indent_level, _code_block_open = check_state(lines, local_variables: local_variables)
+      error_message = "Calculated the wrong number of indent level for:\n #{lines.join("\n")}"
+      assert_equal(expected, indent_level, error_message)
     end
 
     def assert_code_block_open(lines, expected, local_variables: [])
-      _nesting_level, code_block_open = check_state(lines, local_variables: local_variables)
+      _indent_level, code_block_open = check_state(lines, local_variables: local_variables)
       error_message = "Wrong result of code_block_open for:\n #{lines.join("\n")}"
       assert_equal(expected, code_block_open, error_message)
     end
@@ -98,9 +98,9 @@ module TestIRB
       tokens = RubyLex.ripper_lex_without_warning(lines.join("\n"), context: context)
       opens = IRB::NestingParser.open_tokens(tokens)
       ruby_lex = RubyLex.new(context)
-      _indent, nesting_level = ruby_lex.calc_nesting_depth(opens)
+      indent_level = ruby_lex.calc_indent_level(opens)
       code_block_open = !opens.empty? || ruby_lex.process_continue(tokens)
-      [nesting_level, code_block_open]
+      [indent_level, code_block_open]
     end
 
     def test_interpolate_token_with_heredoc_and_unclosed_embexpr
@@ -266,14 +266,14 @@ module TestIRB
 
     def test_heredoc_prompt_with_quotes
       input_with_prompt = [
-        PromptRow.new("001:0:':* ", %q(<<~'A')),
-        PromptRow.new("002:0:':* ", %q(#{foobar})),
+        PromptRow.new("001:1:':* ", %q(<<~'A')),
+        PromptRow.new("002:1:':* ", %q(#{foobar})),
         PromptRow.new("003:0: :> ", %q(A)),
-        PromptRow.new("004:0:`:* ", %q(<<~`A`)),
-        PromptRow.new("005:0:`:* ", %q(whoami)),
+        PromptRow.new("004:1:`:* ", %q(<<~`A`)),
+        PromptRow.new("005:1:`:* ", %q(whoami)),
         PromptRow.new("006:0: :> ", %q(A)),
-        PromptRow.new('007:0:":* ', %q(<<~"A")),
-        PromptRow.new('008:0:":* ', %q(foobar)),
+        PromptRow.new('007:1:":* ', %q(<<~"A")),
+        PromptRow.new('008:1:":* ', %q(foobar)),
         PromptRow.new('009:0: :> ', %q(A)),
       ]
 
@@ -411,7 +411,7 @@ module TestIRB
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
@@ -431,7 +431,7 @@ module TestIRB
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
@@ -479,7 +479,7 @@ module TestIRB
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
@@ -494,7 +494,7 @@ module TestIRB
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
@@ -509,7 +509,7 @@ module TestIRB
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
@@ -525,7 +525,7 @@ module TestIRB
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
@@ -540,7 +540,7 @@ module TestIRB
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
@@ -555,7 +555,7 @@ module TestIRB
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
@@ -570,7 +570,7 @@ module TestIRB
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
@@ -585,16 +585,16 @@ module TestIRB
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
     def test_local_variables_dependent_code
       pend if RUBY_ENGINE == 'truffleruby'
       lines = ["a /1#/ do", "2"]
-      assert_nesting_level(lines, 1)
+      assert_indent_level(lines, 1)
       assert_code_block_open(lines, true)
-      assert_nesting_level(lines, 0, local_variables: ['a'])
+      assert_indent_level(lines, 0, local_variables: ['a'])
       assert_code_block_open(lines, false, local_variables: ['a'])
     end
 
@@ -606,9 +606,9 @@ module TestIRB
         Row.new(%q(=end), 0, 0, 0),
         Row.new(%q(if 1), 0, 2, 1),
         Row.new(%q(  2), 2, 2, 1),
-        Row.new(%q(=begin), 0, 0, 1),
-        Row.new(%q(a), 0, 0, 1),
-        Row.new(%q( b), 1, 1, 1),
+        Row.new(%q(=begin), 0, 0, 0),
+        Row.new(%q(a), 0, 0, 0),
+        Row.new(%q( b), 1, 1, 0),
         Row.new(%q(=end), 0, 2, 1),
         Row.new(%q(  3), 2, 2, 1),
         Row.new(%q(end), 0, 0, 0),
@@ -617,7 +617,7 @@ module TestIRB
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
@@ -626,14 +626,14 @@ module TestIRB
         pend 'This test needs Ripper::Lexer#scan to take broken tokens'
       end
       input_with_correct_indents = [
-        Row.new(%q(<<~Q+<<~R), 0, 2, 0),
-        Row.new(%q(a), 2, 2, 0),
-        Row.new(%q(a), 2, 2, 0),
-        Row.new(%q(  b), 2, 2, 0),
-        Row.new(%q(  b), 2, 2, 0),
-        Row.new(%q(  Q), 0, 2, 0),
-        Row.new(%q(    c), 4, 4, 0),
-        Row.new(%q(    c), 4, 4, 0),
+        Row.new(%q(<<~Q+<<~R), 0, 2, 1),
+        Row.new(%q(a), 2, 2, 1),
+        Row.new(%q(a), 2, 2, 1),
+        Row.new(%q(  b), 2, 2, 1),
+        Row.new(%q(  b), 2, 2, 1),
+        Row.new(%q(  Q), 0, 2, 1),
+        Row.new(%q(    c), 4, 4, 1),
+        Row.new(%q(    c), 4, 4, 1),
         Row.new(%q(    R), 0, 0, 0),
       ]
 
@@ -641,7 +641,7 @@ module TestIRB
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
@@ -657,30 +657,30 @@ module TestIRB
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
     def test_broken_heredoc
       input_with_correct_indents = [
         Row.new(%q(def foo), 0, 2, 1),
-        Row.new(%q(  <<~Q), 2, 4, 1),
-        Row.new(%q(  Qend), 4, 4, 1),
+        Row.new(%q(  <<~Q), 2, 4, 2),
+        Row.new(%q(  Qend), 4, 4, 2),
       ]
       lines = []
       input_with_correct_indents.each do |row|
         lines << row.content
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
     def test_heredoc_keep_indent_spaces
       (1..4).each do |indent|
-        row = Row.new(' ' * indent, nil, [4, indent].max, 1)
+        row = Row.new(' ' * indent, nil, [4, indent].max, 2)
         lines = ['def foo', '  <<~Q', row.content]
         assert_row_indenting(lines, row)
-        assert_nesting_level(lines, row.nesting_level)
+        assert_indent_level(lines, row.indent_level)
       end
     end
 
@@ -816,7 +816,7 @@ module TestIRB
       end
     end
 
-    def test_nesting_level_with_heredoc_and_embdoc
+    def test_indent_level_with_heredoc_and_embdoc
       reference_code = <<~EOC.chomp
         if true
           hello
@@ -838,9 +838,9 @@ module TestIRB
           )
       EOC
       expected = 1
-      assert_nesting_level(reference_code.lines, expected)
-      assert_nesting_level(code_with_heredoc.lines, expected)
-      assert_nesting_level(code_with_embdoc.lines, expected)
+      assert_indent_level(reference_code.lines, expected)
+      assert_indent_level(code_with_heredoc.lines, expected)
+      assert_indent_level(code_with_embdoc.lines, expected)
     end
 
     private


### PR DESCRIPTION
## Description

The document comment says that the part `%i` of the prompt is indent_level.
https://github.com/ruby/irb/blob/1159c13d90c5d2ee708545b6bbfcc18ab826930b/lib/irb.rb#L182-L192

This pull request removes calculation of nesting_level introduced in #500 and #515 and use indent_level for building prompt string.

## Concerns
In `test_ruby_lex.rb`, the word `nesting_level` is used instead of `indent_level`.

But if we want `nesting_level` in prompt string again, we can easily re-implement it like this
```ruby
NESTING_LEVEL_COUNTING_TOKENS = %i[on_kw on_tlambda on_tlambeg on_lparen on_lbracket on_lbrace]
def calc_nesting_level(opens)
  opens.count do |t|
    NESTING_LEVEL_COUNTING_TOKENS.include?(t.event)
  end
end
```

