### PR TITLE
Use Ripper.sexp instead of Regexp for completion

### DIFF
--- a/lib/irb/nesting_parser.rb
+++ b/lib/irb/nesting_parser.rb
@@ -223,5 +223,34 @@ module IRB
       output << [line_tokens, prev_opens, last_opens, min_depth] if line_tokens.any?
       output
     end
+
+    def self.closing_code(opens)
+      closing_tokens = opens.map do |t|
+        case t.tok
+        when /\A%.[<>]\z/
+          '>'
+        when '{', '#{', /\A%.?[{}]\z/
+          '}'
+        when '(', /\A%.?[()]\z/
+          # do not insert \n before closing paren. workaround to avoid syntax error of "a in ^(b\n)"
+          ')'
+        when '[', /\A%.?[\[\]]\z/
+          ']'
+        when /\A%.?(.)\z/
+          $1
+        when '"', "'", '/', '`'
+          t.tok
+        when /\A<<[~-]?(?:"(?<s>.+)"|'(?<s>.+)'|(?<s>.+))/
+          "\n#{s}\n"
+        when ':"', ":'", ':'
+          t.tok[1]
+        when 'case'
+          "\nwhen true\nend"
+        else
+          "\nend"
+        end
+      end
+      closing_tokens.reverse.join
+    end
   end
 end


### PR DESCRIPTION
## Description

Replaces completion method from Regex based to Ripper.sexp base

## Pros

Can complete these codes that Regexp based implementation provides wrong completion.
```ruby
# Code  | Ripper | Regexp
{}.█   #| Hash   | Hash or Proc
->{}.█ #| Proc   | Hash or Proc
%w{}.█ #| Array  | Hash or Proc
%{}.█  #| String | Hash or Proc
[].█   #| Array  | Array
a[].█  #| ------ | Array
/a/i.█ #| Regexp | ------
%/a/.█ #| String | Regexp
```

## Cons
Cannot complete if there are syntax error before cursor. Regexp based can complete these.
```ruby
@;1.█

1=1;1.█

if a*(b+c)) < d
  1.█
```

## Limitation

Cannot complete these code now. I can support this later (about +40 lines).
```ruby
# Inside ternary operator
a = condition ? true.a█ : false

# Inside block parameter
array.each_with_index do |value, index, other = 1.a█
```

## Why not RubyVM::AbstractSyntaxTree or YARP

Using RubyVM::AbstractSyntaxTree (and I beleave YARP too) is easier than Ripper.sexp but:

- RubyVM::AbstractSynatxTree: TruffleRuby does not have it
- YARP: Not a gem now, ruby >= 3.1 is specified in Gemfile
- Combination of both: Hard to maintain

## Future plan

Use RBS to provide powerful completion