### PR TITLE
Remove unused keyword `exception` from Context#evaluate

### DIFF
--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -473,15 +473,8 @@ module IRB
       @inspect_mode
     end
 
-    def evaluate(line, line_no, exception: nil) # :nodoc:
+    def evaluate(line, line_no) # :nodoc:
       @line_no = line_no
-
-      if exception
-        line_no -= 1
-        line = "begin ::Kernel.raise _; rescue _.class\n#{line}\n""end"
-        @workspace.local_variable_set(:_, exception)
-      end
-
       set_last_value(@workspace.evaluate(line, irb_path, line_no))
     end
 

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -37,20 +37,6 @@ module TestIRB
       assert_same(obj, @context.evaluate('_', 1))
     end
 
-    def test_evaluate_with_exception
-      assert_nil(@context.evaluate("$!", 1))
-      e = assert_raise_with_message(RuntimeError, 'foo') {
-        @context.evaluate("raise 'foo'", 1)
-      }
-      assert_equal('foo', e.message)
-      assert_same(e, @context.evaluate('$!', 1, exception: e))
-      e = assert_raise(SyntaxError) {
-        @context.evaluate("1,2,3", 1, exception: e)
-      }
-      assert_match(/\A\(irb\):1:/, e.message)
-      assert_not_match(/rescue _\.class/, e.message)
-    end
-
     def test_evaluate_with_encoding_error_without_lineno
       assert_raise_with_message(EncodingError, /invalid symbol/) {
         @context.evaluate(%q[:"\xAE"], 1)


### PR DESCRIPTION
I think `exception` is always nil. Non-nil value is only passed from test code.

## Background

I think the original code want to do something like this.
```
irb> raise 'a'
in `<main>': a (RuntimeError)
irb> 42
=> 42
irb> [_]
=> [42]
irb> $!
=> #<RuntimeError: a> ← want this
```

But it was breaking the value `_` (https://bugs.ruby-lang.org/issues/14749)
```
irb> raise 'a'
in `<main>': a (RuntimeError)
irb> 42
=> 42
irb> [_]
=> [#<RuntimeError: a>] ← wrong
irb> $!
=> #<RuntimeError: a>
```

And the feature (I think it's never implemented correctly) is dropped
```
irb> raise 'a'
in `<main>': a (RuntimeError)
irb> 42
=> 42
irb> [_]
=> [42]
irb> $!
=> nil ← it's nil now
```
