### PR TITLE
Reduce internal operations' exposure to benchmarking

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -558,24 +558,10 @@ module IRB
       @scanner.each_top_level_statement do |line, line_no|
         signal_status(:IN_EVAL) do
           begin
-            if IRB.conf[:MEASURE] && IRB.conf[:MEASURE_CALLBACKS].empty?
-              IRB.set_measure_callback
-            end
             # Assignment expression check should be done before evaluate_line to handle code like `a /2#/ if false; a = 1`
             is_assignment = assignment_expression?(line)
-            if IRB.conf[:MEASURE] && !IRB.conf[:MEASURE_CALLBACKS].empty?
-              last_proc = proc{ evaluate_line(line, line_no) }
-              IRB.conf[:MEASURE_CALLBACKS].inject(last_proc) { |chain, item|
-                _name, callback, arg = item
-                proc {
-                  callback.(@context, line, line_no, arg) do
-                    chain.call
-                  end
-                }
-              }.call
-            else
-              evaluate_line(line, line_no)
-            end
+            evaluate_line(line, line_no)
+
             if @context.echo?
               if is_assignment
                 if @context.echo_on_assignment?

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -564,8 +564,7 @@ module IRB
             # Assignment expression check should be done before evaluate_line to handle code like `a /2#/ if false; a = 1`
             is_assignment = assignment_expression?(line)
             if IRB.conf[:MEASURE] && !IRB.conf[:MEASURE_CALLBACKS].empty?
-              result = nil
-              last_proc = proc{ result = evaluate_line(line, line_no) }
+              last_proc = proc{ evaluate_line(line, line_no) }
               IRB.conf[:MEASURE_CALLBACKS].inject(last_proc) { |chain, item|
                 _name, callback, arg = item
                 proc {
@@ -574,7 +573,6 @@ module IRB
                   end
                 }
               }.call
-              @context.set_last_value(result)
             else
               evaluate_line(line, line_no)
             end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -252,6 +252,34 @@ module TestIRB
       assert_empty(c.class_variables)
     end
 
+    def test_measure_keeps_previous_value
+      conf = {
+        PROMPT: {
+          DEFAULT: {
+            PROMPT_I: '> ',
+            PROMPT_S: '> ',
+            PROMPT_C: '> ',
+            PROMPT_N: '> '
+          }
+        },
+        PROMPT_MODE: :DEFAULT,
+        MEASURE: false
+      }
+
+      c = Class.new(Object)
+      out, err = execute_lines(
+        "measure\n",
+        "3\n",
+        "_\n",
+        conf: conf,
+        main: c
+      )
+
+      assert_empty err
+      assert_match(/\ATIME is added\.\n=> nil\nprocessing time: .+\n=> 3\nprocessing time: .+\n=> 3/, out)
+      assert_empty(c.class_variables)
+    end
+
     def test_measure_enabled_by_rc
       conf = {
         PROMPT: {


### PR DESCRIPTION
Current location of the benchmarking logic is too high up (in terms of abstraction layer) and includes operations like command loading and argument transformation, which should be excluded. So this commit moves it into `Context#evaluate` to reduce the noise.

Keeping benchmarking logic out of `Irb#eval_input` and `#evaluate_line` also makes future work on command processing easier.

We don't move it further down to `Workspace#evaluate` because `Context` is an argument of the measure block, which is not available in `Workspace`.