### PR TITLE
Support helper method registration

### DIFF
--- a/lib/irb/command/help.rb
+++ b/lib/irb/command/help.rb
@@ -24,7 +24,9 @@ module IRB
 
       def help_message
         commands_info = IRB::Command.all_commands_info
+        helper_methods_info = IRB::HelperMethod.all_helper_methods_info
         commands_grouped_by_categories = commands_info.group_by { |cmd| cmd[:category] }
+        commands_grouped_by_categories["Helper methods"] = helper_methods_info
 
         user_aliases = irb_context.instance_variable_get(:@user_aliases)
 

--- a/lib/irb/default_commands.rb
+++ b/lib/irb/default_commands.rb
@@ -98,10 +98,7 @@ module IRB
     end
 
     _register_with_aliases(:irb_context, Command::Context,
-      [
-        [:context, NO_OVERRIDE],
-        [:conf, NO_OVERRIDE],
-      ],
+      [:context, NO_OVERRIDE]
     )
 
     _register_with_aliases(:irb_exit, Command::Exit,

--- a/lib/irb/helper_method.rb
+++ b/lib/irb/helper_method.rb
@@ -1,0 +1,29 @@
+require_relative "helper_method/base"
+
+module IRB
+  module HelperMethod
+    @helper_methods = {}
+
+    class << self
+      attr_reader :helper_methods
+
+      def register(name, helper_class)
+        @helper_methods[name] = helper_class
+
+        if defined?(HelpersContainer)
+          HelpersContainer.install_helper_methods
+        end
+      end
+
+      def all_helper_methods_info
+        @helper_methods.map do |name, helper_class|
+          { display_name: name, description: helper_class.description }
+        end
+      end
+    end
+
+    # Default helper_methods
+    require_relative "helper_method/conf"
+    register(:conf, HelperMethod::Conf)
+  end
+end

--- a/lib/irb/helper_method/base.rb
+++ b/lib/irb/helper_method/base.rb
@@ -1,0 +1,12 @@
+module IRB
+  module HelperMethod
+    class Base
+      class << self
+        def description(description = nil)
+          @description = description if description
+          @description
+        end
+      end
+    end
+  end
+end

--- a/lib/irb/helper_method/conf.rb
+++ b/lib/irb/helper_method/conf.rb
@@ -1,0 +1,11 @@
+module IRB
+  module HelperMethod
+    class Conf < Base
+      description "Returns the current context."
+
+      def execute
+        IRB.CurrentContext
+      end
+    end
+  end
+end

--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -6,6 +6,8 @@
 
 require "delegate"
 
+require_relative "helper_method"
+
 IRB::TOPLEVEL_BINDING = binding
 module IRB # :nodoc:
   class WorkSpace
@@ -109,9 +111,9 @@ EOF
     attr_reader :main
 
     def load_helper_methods_to_main
-      if !(class<<main;ancestors;end).include?(ExtendCommandBundle)
-        main.extend ExtendCommandBundle
-      end
+      ancestors = class<<main;ancestors;end
+      main.extend ExtendCommandBundle if !ancestors.include?(ExtendCommandBundle)
+      main.extend HelpersContainer if !ancestors.include?(HelpersContainer)
     end
 
     # Evaluate the given +statements+ within the  context of this workspace.
@@ -171,5 +173,17 @@ EOF
 
       "\nFrom: #{file} @ line #{pos + 1} :\n\n#{body}#{Color.clear}\n"
     end
+  end
+
+  module HelpersContainer
+    def self.install_helper_methods
+      HelperMethod.helper_methods.each do |name, helper_method_class|
+        define_method name do |*args, **opts, &block|
+          helper_method_class.new.execute(*args, **opts, &block)
+        end unless method_defined?(name)
+      end
+    end
+
+    install_helper_methods
   end
 end

--- a/test/irb/command/test_help.rb
+++ b/test/irb/command/test_help.rb
@@ -62,5 +62,14 @@ module TestIRB
       assert_match(/\$\s+Alias for `show_source`/, out)
       assert_match(/@\s+Alias for `whereami`/, out)
     end
+
+    def test_help_lists_helper_methods
+      out = run_ruby_file do
+        type "help"
+        type "exit"
+      end
+
+      assert_match(/Helper methods\s+conf\s+Returns the current context/, out)
+    end
   end
 end

--- a/test/irb/test_helper_method.rb
+++ b/test/irb/test_helper_method.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+require "irb"
+
+require_relative "helper"
+
+module TestIRB
+  class HelperMethodTestCase < TestCase
+    def setup
+      $VERBOSE = nil
+      @verbosity = $VERBOSE
+      save_encodings
+      IRB.instance_variable_get(:@CONF).clear
+    end
+
+    def teardown
+      $VERBOSE = @verbosity
+      restore_encodings
+    end
+
+    def execute_lines(*lines, conf: {}, main: self, irb_path: nil)
+      IRB.init_config(nil)
+      IRB.conf[:VERBOSE] = false
+      IRB.conf[:PROMPT_MODE] = :SIMPLE
+      IRB.conf.merge!(conf)
+      input = TestInputMethod.new(lines)
+      irb = IRB::Irb.new(IRB::WorkSpace.new(main), input)
+      irb.context.return_format = "=> %s\n"
+      irb.context.irb_path = irb_path if irb_path
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+      IRB.conf[:USE_PAGER] = false
+      capture_output do
+        irb.eval_input
+      end
+    end
+  end
+
+  module TestHelperMethod
+    class ConfTest < HelperMethodTestCase
+      def test_conf_returns_the_context_object
+        out, err = execute_lines("conf.ap_name")
+
+        assert_empty err
+        assert_include out, "=> \"irb\""
+      end
+    end
+  end
+
+  class HelperMethodIntegrationTest < IntegrationTestCase
+    def test_arguments_propogation
+      write_ruby <<~RUBY
+        require "irb/helper_method"
+
+        class MyHelper < IRB::HelperMethod::Base
+          description "This is a test helper"
+
+          def execute(
+            required_arg, optional_arg = nil, *splat_arg, required_keyword_arg:,
+            optional_keyword_arg: nil, **double_splat_arg, &block_arg
+          )
+            puts [required_arg, optional_arg, splat_arg, required_keyword_arg, optional_keyword_arg, double_splat_arg, block_arg.call].to_s
+          end
+        end
+
+        IRB::HelperMethod.register(:my_helper, MyHelper)
+
+        binding.irb
+      RUBY
+
+      output = run_ruby_file do
+        type <<~INPUT
+          my_helper(
+            "required", "optional", "splat", required_keyword_arg: "required",
+            optional_keyword_arg: "optional", a: 1, b: 2
+          ) { "block" }
+        INPUT
+        type "exit"
+      end
+
+      assert_include(output, '["required", "optional", ["splat"], "required", "optional", {:a=>1, :b=>2}, "block"]')
+    end
+
+    def test_helper_method_injection_can_happen_after_irb_require
+      write_ruby <<~RUBY
+        require "irb"
+
+        class MyHelper < IRB::HelperMethod::Base
+          description "This is a test helper"
+
+          def execute
+            puts "Hello from MyHelper"
+          end
+        end
+
+        IRB::HelperMethod.register(:my_helper, MyHelper)
+
+        binding.irb
+      RUBY
+
+      output = run_ruby_file do
+        type <<~INPUT
+          my_helper
+        INPUT
+        type "exit"
+      end
+
+      assert_include(output, 'Hello from MyHelper')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This Pull Request introduces a helper extension API as discussed in issue #588. It aims to provide an API for helper methods in IRB, improving the method-extending approach currently in use. The new approach would make helper methods more discoverable and user-friendly.

## Background

There are two categories of operations in IRB: **Helper methods** and **Commands**.

**Helper methods**
- They are designed to be used as Ruby methods.
- Users primarily use them for their return values, such as calling `app` for a Rails application instance.
- At present, this is achieved by directly extending `ExtendCommandBundle`, like [`controller`](https://github.com/rails/rails/blob/ef04fbb3b256beececfa44c47c4ec93ac6945e59/railties/lib/rails/console/helpers.rb#L15) or [`app`](https://github.com/rails/rails/blob/ef04fbb3b256beececfa44c47c4ec93ac6945e59/railties/lib/rails/console/app.rb#L10-L13) in Rails console.

**Commands**
- They are intended to be used with their own syntax, for example, `show_source Foo#bar`.
- Users utilize them to complete certain tasks (like `edit`) or display information (like `help`). The return value is generally not important.
- They will also have an official registration API, as discussed in #513.

## Motivation

The current method-extending approach has several limitations:
- `ExtendCommandBundle` is an internal component that is currently exposed, which is not ideal.
- IRB cannot effectively detect and aid users in discovering the extended helpers.
- Due to the above reasons, we don't officially support or mention a method to extend IRB with helpers, which has likely limited IRB's potential for personal or library customization.

## Implementation

This PR introduces a new `IRB::HelperMethod::Base` class that provides `description` methods to helper classes. After requiring `irb/helper_method`, users can use `IRB::HelperMethod.register(:my_helper, MyHelper)` to add new helpers. Once registered, a `my_helper` method will be added to IRB sessions.

Here's an example:

```rb
# test.rb

# this doesn't require the entire IRB, just the helper registration API
require "irb/helper_method"

class MyHelperMethod < IRB::HelperMethod::Base
  description "Describe how to use this helper"

  # all kinds of arguments are supported
  def execute(*args, **opts, &block)
    "Hello from MyHelperMethod#execute"
  end
end

IRB::HelperMethod.register(:my_helper, MyHelperMethod)

binding.irb

# irb(main):001:0> puts my_helper
# Hello from MyHelperMethod#execute
# => nil
```

## Changes

- A new `IRB::HelperMethod::Base` class has been added.
- Users can now register new helpers using `IRB::HelperMethod.register(:my_helper, MyHelperMethod)`.
- `conf` is now declared as helpers.
- `help` now also displays registered helpers.

    <details>

    ```
    IRB
      exit           Exit the current irb session.
      irb_load       Load a Ruby file.
      irb_require    Require a Ruby file.
      source         Loads a given file in the current session.
      irb_info       Show information about IRB.
      show_cmds      List all available commands and their description.
      history        Shows the input history. `-g [query]` or `-G [query]` allows you to filter the output.
    
    Workspace
      cwws           Show the current workspace.
      chws           Change the current workspace to an object.
      workspaces     Show workspaces.
      pushws         Push an object to the workspace stack.
      popws          Pop a workspace from the workspace stack.
    
    Multi-irb (DEPRECATED)
      irb            Start a child IRB.
      jobs           List of current sessions.
      fg             Switches to the session of the given number.
      kill           Kills the session with the given number.
    
    Debugging
      debug          Start the debugger of debug.gem.
      break          Start the debugger of debug.gem and run its `break` command.
      catch          Start the debugger of debug.gem and run its `catch` command.
      next           Start the debugger of debug.gem and run its `next` command.
      delete         Start the debugger of debug.gem and run its `delete` command.
      step           Start the debugger of debug.gem and run its `step` command.
      continue       Start the debugger of debug.gem and run its `continue` command.
      finish         Start the debugger of debug.gem and run its `finish` command.
      backtrace      Start the debugger of debug.gem and run its `backtrace` command.
      info           Start the debugger of debug.gem and run its `info` command.
    
    Misc
      edit           Open a file with the editor command defined with `ENV["VISUAL"]` or `ENV["EDITOR"]`.
      measure        `measure` enables the mode to measure processing time. `measure :off` disables it.
    
    Context
      help           [DEPRECATED] Enter the mode to look up RI documents.
      show_doc       Enter the mode to look up RI documents.
      ls             Show methods, constants, and variables. `-g [query]` or `-G [query]` allows you to filter out the output.
      show_source    Show the source code of a given method or constant.
      whereami       Show the source code around binding.irb again.
    
    Helper methods
      conf           Returns the current context.
    
    Aliases
      $              Alias for `show_source`
      @              Alias for `whereami`
    ```
    </details>