### PR TITLE
Use `max_by` for `longest_cmd_name_length`

### DIFF
--- a/lib/irb/cmd/show_cmds.rb
+++ b/lib/irb/cmd/show_cmds.rb
@@ -14,7 +14,7 @@ module IRB
       def execute(*args)
         commands_info = IRB::ExtendCommandBundle.all_commands_info
         commands_grouped_by_categories = commands_info.group_by { |cmd| cmd[:category] }
-        longest_cmd_name_length = commands_info.map { |c| c[:display_name] }.max { |a, b| a.length <=> b.length }.length
+        longest_cmd_name_length = commands_info.map { |c| c[:display_name].length }.max
 
         output = StringIO.new
 


### PR DESCRIPTION
A small refactoring for readability.

https://rubyapi.org/3.2/o/enumerable#method-i-max_by