### PR TITLE
Fix invalid byte sequence in autoindent calculation

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -94,7 +94,10 @@ class RubyLex
     if @io.respond_to?(:auto_indent) and @context.auto_indent_mode
       @io.auto_indent do |lines, line_index, byte_pointer, is_newline|
         next nil if lines == [nil] # Workaround for exit IRB with CTRL+d
-        next nil if !is_newline && lines[line_index]&.byteslice(0, byte_pointer)&.match?(/\A\s*\z/)
+
+        text_before_cursor = lines[line_index]&.byteslice(0, byte_pointer)
+        # Need to validate encoding because Reline has a bug that passes wrong byte_pointer. See https://github.com/ruby/reline/issues/553
+        next nil if !is_newline && text_before_cursor&.valid_encoding? && text_before_cursor&.match?(/\A\s*\z/)
 
         code = lines[0..line_index].map { |l| "#{l}\n" }.join
         tokens = self.class.ripper_lex_without_warning(code, context: @context)

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -33,7 +33,7 @@ module TestIRB
     def calculate_indenting(lines, add_new_line)
       lines = lines + [""] if add_new_line
       last_line_index = lines.length - 1
-      byte_pointer = lines.last.length
+      byte_pointer = lines.last.bytesize
 
       context = build_context
       context.auto_indent_mode = true
@@ -934,6 +934,18 @@ module TestIRB
       assert_indent_level(reference_code.lines, expected)
       assert_indent_level(code_with_heredoc.lines, expected)
       assert_indent_level(code_with_embdoc.lines, expected)
+    end
+
+    def test_auto_indent_proc_incorrect_byte_pointer
+      # Reline sometimes passes wrong byte_pointer that might cause `invalid byte sequence in UTF-8`
+      context = build_context
+      context.auto_indent_mode = true
+
+      ruby_lex = RubyLex.new(context)
+      mock_io = MockIO_AutoIndent.new(['あ'], 0, 2, false)
+
+      ruby_lex.configure_io(mock_io)
+      assert_equal(mock_io.calculated_indent, 0)
     end
 
     private


### PR DESCRIPTION
Workaround for https://github.com/ruby/irb/issues/627

The root cause of this issue is several (more than two) bugs in Reline.
https://github.com/ruby/reline/issues/553

Reline sometimes passes wrong byte_pointer to auto_indent_proc.
If Reline's bug is not going to be fixed soon, IRB needs to validate encoding of `byteslice(0, byte_pointer)` before using it.
