### PR TITLE
Drop src_encoding.rb

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -4,7 +4,6 @@
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 
-require_relative 'src_encoding'
 require_relative 'completion'
 require 'io/console'
 require 'reline'

--- a/lib/irb/src_encoding.rb
+++ b/lib/irb/src_encoding.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: false
-# DO NOT WRITE ANY MAGIC COMMENT HERE.
-module IRB
-  def self.default_src_encoding
-    return __ENCODING__
-  end
-end


### PR DESCRIPTION
Its method `IRB.default_src_encoding` was only used in `magic-file.rb`, which has been removed.