### PR TITLE
Remove unused `InputMethod#initialize`

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -10,16 +10,7 @@ require 'io/console'
 require 'reline'
 
 module IRB
-  STDIN_FILE_NAME = "(line)" # :nodoc:
   class InputMethod
-
-    # Creates a new input method object
-    def initialize(file = STDIN_FILE_NAME)
-      @file_name = file
-    end
-    # The file name of this input method, usually given during initialization.
-    attr_reader :file_name
-
     # The irb prompt associated with this input method
     attr_accessor :prompt
 
@@ -56,7 +47,6 @@ module IRB
   class StdioInputMethod < InputMethod
     # Creates a new input method object
     def initialize
-      super
       @line_no = 0
       @line = []
       @stdin = IO.open(STDIN.to_i, :external_encoding => IRB.conf[:LC_MESSAGES].encoding, :internal_encoding => "-")
@@ -130,7 +120,6 @@ module IRB
 
     # Creates a new input method object
     def initialize(file)
-      super
       @io = file.is_a?(IO) ? file : File.open(file)
       @external_encoding = @io.external_encoding
     end
@@ -183,7 +172,6 @@ module IRB
         if Readline.respond_to?(:encoding_system_needs)
           IRB.__send__(:set_encoding, Readline.encoding_system_needs.name, override: false)
         end
-        super
 
         @line_no = 0
         @line = []
@@ -261,7 +249,6 @@ module IRB
     # Creates a new input method object using Reline
     def initialize
       IRB.__send__(:set_encoding, Reline.encoding_system_needs.name, override: false)
-      super
 
       @line_no = 0
       @line = []

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -123,8 +123,6 @@ module IRB
       @io = file.is_a?(IO) ? file : File.open(file)
       @external_encoding = @io.external_encoding
     end
-    # The file name of this input method, usually given during initialization.
-    attr_reader :file_name
 
     # Whether the end of this input method has been reached, returns +true+ if
     # there is no more data to read.

--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -17,7 +17,6 @@ module TestIRB
       attr_reader :list, :line_no
 
       def initialize(list = [])
-        super("test")
         @line_no = 0
         @list = list
       end


### PR DESCRIPTION
The constructor takes a `file_name` argument, but it is never used. The only input method that needs a file is `FileInputMethod`, which has its own constructor to take a file object directly.

So the constructor in `InputMethod` is not needed and its child classes don't need to call `super` in their constructors.

I also dropped the attribute accessors for `file_name` as they're not used either.