### PR TITLE
Unpend RDoc dialog related tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '30 14 * * *'
+    - cron: "30 14 * * *"
 
 jobs:
   ruby-versions:
@@ -72,6 +72,7 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler --no-document
+          gem rdoc --all --ri --no-rdoc
           WITH_VTERM=1 bundle install
       - name: rake test_yamatanooroti
         run: WITH_VTERM=1 bundle exec rake test_yamatanooroti

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -8,7 +8,7 @@ rescue LoadError, NameError
   return
 end
 
-class IRB::TestRendering < Yamatanooroti::TestCase
+class IRB::RenderingTest < Yamatanooroti::TestCase
   def setup
     @pwd = Dir.pwd
     suffix = '%010d' % Random.rand(0..65535)
@@ -176,7 +176,6 @@ class IRB::TestRendering < Yamatanooroti::TestCase
   end
 
   def test_autocomplete_with_showdoc_in_gaps_on_narrow_screen_right
-    pend "Needs a dummy document to show doc"
     write_irbrc <<~'LINES'
       IRB.conf[:PROMPT][:MY_PROMPT] = {
         :PROMPT_I => "%03n> ",
@@ -191,15 +190,14 @@ class IRB::TestRendering < Yamatanooroti::TestCase
     write("Str\C-i")
     close
     assert_screen(<<~EOC)
+      start IRB
       001> String
-            StringPress A
-            StructString
-                  of byte
+           StringPress O
+           StructString
     EOC
   end
 
   def test_autocomplete_with_showdoc_in_gaps_on_narrow_screen_left
-    pend "Needs a dummy document to show doc"
     write_irbrc <<~'LINES'
       IRB.conf[:PROMPT][:MY_PROMPT] = {
         :PROMPT_I => "%03n> ",
@@ -214,10 +212,10 @@ class IRB::TestRendering < Yamatanooroti::TestCase
     write("Str\C-i")
     close
     assert_screen(<<~EOC)
+      start IRB
       001> String
       PressString
       StrinStruct
-      of by
     EOC
   end
 

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -176,6 +176,7 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
   end
 
   def test_autocomplete_with_showdoc_in_gaps_on_narrow_screen_right
+    omit if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.1')
     write_irbrc <<~'LINES'
       IRB.conf[:PROMPT][:MY_PROMPT] = {
         :PROMPT_I => "%03n> ",
@@ -189,15 +190,28 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     start_terminal(4, 19, %W{ruby -I/home/aycabta/ruby/reline/lib -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
     write("Str\C-i")
     close
-    assert_screen(<<~EOC)
-      start IRB
-      001> String
-           StringPress O
-           StructString
-    EOC
+
+    # This is because on macOS we display different shortcut for displaying the full doc
+    # 'O' is for 'Option' and 'A' is for 'Alt'
+    if RUBY_PLATFORM =~ /darwin/
+      assert_screen(<<~EOC)
+        start IRB
+        001> String
+             StringPress O
+             StructString
+      EOC
+    else
+      assert_screen(<<~EOC)
+        start IRB
+        001> String
+             StringPress A
+             StructString
+      EOC
+    end
   end
 
   def test_autocomplete_with_showdoc_in_gaps_on_narrow_screen_left
+    omit if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.1')
     write_irbrc <<~'LINES'
       IRB.conf[:PROMPT][:MY_PROMPT] = {
         :PROMPT_I => "%03n> ",


### PR DESCRIPTION
They are our only coverage on the doc dialog of autocompletion. Without them, issues like #638 would slip in unnoticed.

A few notes about these tests:

- To make them work properly, RI data is needed but RDoc HTML is not. Hence `gem rdoc --all --ri --no-rdoc`
- There's an output difference caused by different keyboard shortcut hint on mac and non-mac OS
- For some reason installing RI data still doesn't make it work under Ruby 3.1. But I think coverage on 3.1+ is enough so I just skip them on Ruby 2.7 and 3.0