### PR TITLE
Indent multiline percent literals

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -368,9 +368,9 @@ class RubyLex
           end
         end
       when :on_tstring_beg, :on_regexp_beg, :on_symbeg, :on_backtick
-        # can be indented if t.tok starts with `%`
-      when :on_words_beg, :on_qwords_beg, :on_symbols_beg, :on_qsymbols_beg, :on_embexpr_beg
-        # can be indented but not indented in current implementation
+        # No indent: "", //, :"", ``
+        # Indent: %(), %r(), %i(), %x()
+        indent_level += 1 if t.tok.start_with? '%'
       when :on_embdoc_beg
         indent_level = 0
       else

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -256,13 +256,13 @@ module TestIRB
         PromptRow.new('001:0:":* ', %q(<<A+%W[#{<<B)),
         PromptRow.new('002:0:":* ', %q(#{<<C+%W[)),
         PromptRow.new('003:0:":* ', %q(a)),
-        PromptRow.new('004:0:]:* ', %q(C)),
-        PromptRow.new('005:0:]:* ', %q(a)),
+        PromptRow.new('004:2:]:* ', %q(C)),
+        PromptRow.new('005:2:]:* ', %q(a)),
         PromptRow.new('006:0:":* ', %q(]})),
         PromptRow.new('007:0:":* ', %q(})),
         PromptRow.new('008:0:":* ', %q(A)),
-        PromptRow.new('009:0:]:* ', %q(B)),
-        PromptRow.new('010:0:]:* ', %q(})),
+        PromptRow.new('009:2:]:* ', %q(B)),
+        PromptRow.new('010:1:]:* ', %q(})),
         PromptRow.new('011:0: :> ', %q(])),
         PromptRow.new('012:0: :> ', %q()),
       ]
@@ -737,16 +737,16 @@ module TestIRB
         Row.new(%q(          [1), 10, 12, 3),
         Row.new(%q(          ]+[["a), 10, 14, 4),
         Row.new(%q(b" + <<~A + <<-B + <<C), 0, 16, 5),
-        Row.new(%q(                a#{), 16, 16, 5),
-        Row.new(%q(                1), 16, 16, 5),
+        Row.new(%q(                a#{), 16, 18, 6),
+        Row.new(%q(                  1), 18, 18, 6),
         Row.new(%q(                }), 16, 16, 5),
         Row.new(%q(              A), 14, 16, 5),
-        Row.new(%q(                b#{), 16, 16, 5),
-        Row.new(%q(                1), 16, 16, 5),
+        Row.new(%q(                b#{), 16, 18, 6),
+        Row.new(%q(                  1), 18, 18, 6),
         Row.new(%q(                }), 16, 16, 5),
         Row.new(%q(              B), 14, 0, 0),
-        Row.new(%q(c#{), 0, 0, 0),
-        Row.new(%q(1), 0, 0, 0),
+        Row.new(%q(c#{), 0, 2, 1),
+        Row.new(%q(  1), 2, 2, 1),
         Row.new(%q(}), 0, 0, 0),
         Row.new(%q(C), 0, 14, 4),
         Row.new(%q(            ]), 12, 12, 3),
@@ -799,7 +799,7 @@ module TestIRB
     def test_dynamic_prompt_with_double_newline_breaking_code
       input_with_prompt = [
         PromptRow.new('001:1: :* ', %q(if true)),
-        PromptRow.new('002:1: :* ', %q(%)),
+        PromptRow.new('002:2: :* ', %q(%)),
         PromptRow.new('003:1: :* ', %q(;end)),
         PromptRow.new('004:1: :* ', %q(;hello)),
         PromptRow.new('005:0: :> ', %q(end)),
@@ -813,12 +813,12 @@ module TestIRB
     def test_dynamic_prompt_with_multiline_literal
       input_with_prompt = [
         PromptRow.new('001:1: :* ', %q(if true)),
-        PromptRow.new('002:1:]:* ', %q(  %w[)),
-        PromptRow.new('003:1:]:* ', %q(  a)),
+        PromptRow.new('002:2:]:* ', %q(  %w[)),
+        PromptRow.new('003:2:]:* ', %q(  a)),
         PromptRow.new('004:1: :* ', %q(  ])),
         PromptRow.new('005:1: :* ', %q(  b)),
-        PromptRow.new('006:1:]:* ', %q(  %w[)),
-        PromptRow.new('007:1:]:* ', %q(  c)),
+        PromptRow.new('006:2:]:* ', %q(  %w[)),
+        PromptRow.new('007:2:]:* ', %q(  c)),
         PromptRow.new('008:1: :* ', %q(  ])),
         PromptRow.new('009:0: :> ', %q(end)),
       ]
@@ -830,8 +830,8 @@ module TestIRB
 
     def test_dynamic_prompt_with_blank_line
       input_with_prompt = [
-        PromptRow.new('001:0:]:* ', %q(%w[)),
-        PromptRow.new('002:0:]:* ', %q()),
+        PromptRow.new('001:1:]:* ', %q(%w[)),
+        PromptRow.new('002:1:]:* ', %q()),
         PromptRow.new('003:0: :> ', %q(])),
       ]
 


### PR DESCRIPTION
This pull request implements percent literal indenting, which I pend implementing in #500 to not change the behavior at that time.
![percent_literal_indent](https://github.com/ruby/irb/assets/1780201/0e442d9e-b8b4-48cf-bdb6-7dfb28c9c2ef)


Indented percent literal is used in IRB and also in ruby/ruby.
You can search with this regexp: `%[a-z]?[({\[]\n`
```ruby
# Words. Indent is fixed to `prev_indent + 1`.
ReservedWords = %w[
  __ENCODING__ __LINE__ __FILE__
  BEGIN END
  ...
]
# String. Indent is initially `prev_indent + 1` but can add or delete space because space is part of the content.
line = __LINE__; Context.module_eval %[
  def foo(*opts, &b)
    bar
  end
], __FILE__, line
```

