### PR TITLE
Reduce boilerplate code in RubyLexTest

### DIFF
--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -235,65 +235,57 @@ module TestIRB
 
     def test_endless_range_at_end_of_line
       input_with_prompt = [
-        PromptRow.new('001:0: :> ', %q(a = 3..)),
-        PromptRow.new('002:0: :> ', %q()),
+        ['001:0: :> ', %q(a = 3..)],
+        ['002:0: :> ', %q()],
       ]
 
-      lines = input_with_prompt.map(&:content)
-      expected_prompt_list = input_with_prompt.map(&:prompt)
-      assert_dynamic_prompt(lines, expected_prompt_list)
+      assert_dynamic_prompt(input_with_prompt)
     end
 
     def test_heredoc_with_embexpr
       input_with_prompt = [
-        PromptRow.new('001:0:":* ', %q(<<A+%W[#{<<B)),
-        PromptRow.new('002:0:":* ', %q(#{<<C+%W[)),
-        PromptRow.new('003:0:":* ', %q(a)),
-        PromptRow.new('004:2:]:* ', %q(C)),
-        PromptRow.new('005:2:]:* ', %q(a)),
-        PromptRow.new('006:0:":* ', %q(]})),
-        PromptRow.new('007:0:":* ', %q(})),
-        PromptRow.new('008:0:":* ', %q(A)),
-        PromptRow.new('009:2:]:* ', %q(B)),
-        PromptRow.new('010:1:]:* ', %q(})),
-        PromptRow.new('011:0: :> ', %q(])),
-        PromptRow.new('012:0: :> ', %q()),
+        ['001:0:":* ', %q(<<A+%W[#{<<B)],
+        ['002:0:":* ', %q(#{<<C+%W[)],
+        ['003:0:":* ', %q(a)],
+        ['004:2:]:* ', %q(C)],
+        ['005:2:]:* ', %q(a)],
+        ['006:0:":* ', %q(]})],
+        ['007:0:":* ', %q(})],
+        ['008:0:":* ', %q(A)],
+        ['009:2:]:* ', %q(B)],
+        ['010:1:]:* ', %q(})],
+        ['011:0: :> ', %q(])],
+        ['012:0: :> ', %q()],
       ]
 
-      lines = input_with_prompt.map(&:content)
-      expected_prompt_list = input_with_prompt.map(&:prompt)
-      assert_dynamic_prompt(lines, expected_prompt_list)
+      assert_dynamic_prompt(input_with_prompt)
     end
 
     def test_heredoc_prompt_with_quotes
       input_with_prompt = [
-        PromptRow.new("001:1:':* ", %q(<<~'A')),
-        PromptRow.new("002:1:':* ", %q(#{foobar})),
-        PromptRow.new("003:0: :> ", %q(A)),
-        PromptRow.new("004:1:`:* ", %q(<<~`A`)),
-        PromptRow.new("005:1:`:* ", %q(whoami)),
-        PromptRow.new("006:0: :> ", %q(A)),
-        PromptRow.new('007:1:":* ', %q(<<~"A")),
-        PromptRow.new('008:1:":* ', %q(foobar)),
-        PromptRow.new('009:0: :> ', %q(A)),
+        ["001:1:':* ", %q(<<~'A')],
+        ["002:1:':* ", %q(#{foobar})],
+        ["003:0: :> ", %q(A)],
+        ["004:1:`:* ", %q(<<~`A`)],
+        ["005:1:`:* ", %q(whoami)],
+        ["006:0: :> ", %q(A)],
+        ['007:1:":* ', %q(<<~"A")],
+        ['008:1:":* ', %q(foobar)],
+        ['009:0: :> ', %q(A)],
       ]
 
-      lines = input_with_prompt.map(&:content)
-      expected_prompt_list = input_with_prompt.map(&:prompt)
-      assert_dynamic_prompt(lines, expected_prompt_list)
+      assert_dynamic_prompt(input_with_prompt)
     end
 
     def test_backtick_method
       input_with_prompt = [
-        PromptRow.new('001:0: :> ', %q(self.`(arg))),
-        PromptRow.new('002:0: :> ', %q()),
-        PromptRow.new('003:0: :> ', %q(def `(); end)),
-        PromptRow.new('004:0: :> ', %q()),
+        ['001:0: :> ', %q(self.`(arg))],
+        ['002:0: :> ', %q()],
+        ['003:0: :> ', %q(def `(); end)],
+        ['004:0: :> ', %q()],
       ]
 
-      lines = input_with_prompt.map(&:content)
-      expected_prompt_list = input_with_prompt.map(&:prompt)
-      assert_dynamic_prompt(lines, expected_prompt_list)
+      assert_dynamic_prompt(input_with_prompt)
     end
 
     def test_incomplete_coding_magic_comment
@@ -593,8 +585,6 @@ module TestIRB
       end
     end
 
-    PromptRow = Struct.new(:prompt, :content)
-
     class MockIO_DynamicPrompt
       def initialize(params, &assertion)
         @params = params
@@ -656,7 +646,8 @@ module TestIRB
       assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
-    def assert_dynamic_prompt(lines, expected_prompt_list)
+    def assert_dynamic_prompt(input_with_prompt)
+      expected_prompt_list, lines = input_with_prompt.transpose
       context = build_context
       ruby_lex = RubyLex.new(context)
       dynamic_prompt_executed = false
@@ -680,58 +671,50 @@ module TestIRB
 
     def test_dynamic_prompt
       input_with_prompt = [
-        PromptRow.new('001:1: :* ', %q(def hoge)),
-        PromptRow.new('002:1: :* ', %q(  3)),
-        PromptRow.new('003:0: :> ', %q(end)),
+        ['001:1: :* ', %q(def hoge)],
+        ['002:1: :* ', %q(  3)],
+        ['003:0: :> ', %q(end)],
       ]
 
-      lines = input_with_prompt.map(&:content)
-      expected_prompt_list = input_with_prompt.map(&:prompt)
-      assert_dynamic_prompt(lines, expected_prompt_list)
+      assert_dynamic_prompt(input_with_prompt)
     end
 
     def test_dynamic_prompt_with_double_newline_breaking_code
       input_with_prompt = [
-        PromptRow.new('001:1: :* ', %q(if true)),
-        PromptRow.new('002:2: :* ', %q(%)),
-        PromptRow.new('003:1: :* ', %q(;end)),
-        PromptRow.new('004:1: :* ', %q(;hello)),
-        PromptRow.new('005:0: :> ', %q(end)),
+        ['001:1: :* ', %q(if true)],
+        ['002:2: :* ', %q(%)],
+        ['003:1: :* ', %q(;end)],
+        ['004:1: :* ', %q(;hello)],
+        ['005:0: :> ', %q(end)],
       ]
 
-      lines = input_with_prompt.map(&:content)
-      expected_prompt_list = input_with_prompt.map(&:prompt)
-      assert_dynamic_prompt(lines, expected_prompt_list)
+      assert_dynamic_prompt(input_with_prompt)
     end
 
     def test_dynamic_prompt_with_multiline_literal
       input_with_prompt = [
-        PromptRow.new('001:1: :* ', %q(if true)),
-        PromptRow.new('002:2:]:* ', %q(  %w[)),
-        PromptRow.new('003:2:]:* ', %q(  a)),
-        PromptRow.new('004:1: :* ', %q(  ])),
-        PromptRow.new('005:1: :* ', %q(  b)),
-        PromptRow.new('006:2:]:* ', %q(  %w[)),
-        PromptRow.new('007:2:]:* ', %q(  c)),
-        PromptRow.new('008:1: :* ', %q(  ])),
-        PromptRow.new('009:0: :> ', %q(end)),
+        ['001:1: :* ', %q(if true)],
+        ['002:2:]:* ', %q(  %w[)],
+        ['003:2:]:* ', %q(  a)],
+        ['004:1: :* ', %q(  ])],
+        ['005:1: :* ', %q(  b)],
+        ['006:2:]:* ', %q(  %w[)],
+        ['007:2:]:* ', %q(  c)],
+        ['008:1: :* ', %q(  ])],
+        ['009:0: :> ', %q(end)],
       ]
 
-      lines = input_with_prompt.map(&:content)
-      expected_prompt_list = input_with_prompt.map(&:prompt)
-      assert_dynamic_prompt(lines, expected_prompt_list)
+      assert_dynamic_prompt(input_with_prompt)
     end
 
     def test_dynamic_prompt_with_blank_line
       input_with_prompt = [
-        PromptRow.new('001:1:]:* ', %q(%w[)),
-        PromptRow.new('002:1:]:* ', %q()),
-        PromptRow.new('003:0: :> ', %q(])),
+        ['001:1:]:* ', %q(%w[)],
+        ['002:1:]:* ', %q()],
+        ['003:0: :> ', %q(])],
       ]
 
-      lines = input_with_prompt.map(&:content)
-      expected_prompt_list = input_with_prompt.map(&:prompt)
-      assert_dynamic_prompt(lines, expected_prompt_list)
+      assert_dynamic_prompt(input_with_prompt)
     end
 
     def test_should_continue

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -134,42 +134,43 @@ module TestIRB
 
     def test_auto_indent
       input_with_correct_indents = [
-        Row.new(%q(def each_top_level_statement), 0, 2),
-        Row.new(%q(  initialize_input), 2, 2),
-        Row.new(%q(  catch(:TERM_INPUT) do), 2, 4),
-        Row.new(%q(    loop do), 4, 6),
-        Row.new(%q(      begin), 6, 8),
-        Row.new(%q(        prompt), 8, 8),
-        Row.new(%q(        unless l = lex), 8, 10),
-        Row.new(%q(          throw :TERM_INPUT if @line == ''), 10, 10),
-        Row.new(%q(        else), 8, 10),
-        Row.new(%q(          @line_no += l.count("\n")), 10, 10),
-        Row.new(%q(          next if l == "\n"), 10, 10),
-        Row.new(%q(          @line.concat l), 10, 10),
-        Row.new(%q(          if @code_block_open or @ltype or @continue or @indent > 0), 10, 12),
-        Row.new(%q(            next), 12, 12),
-        Row.new(%q(          end), 10, 10),
-        Row.new(%q(        end), 8, 8),
-        Row.new(%q(        if @line != "\n"), 8, 10),
-        Row.new(%q(          @line.force_encoding(@io.encoding)), 10, 10),
-        Row.new(%q(          yield @line, @exp_line_no), 10, 10),
-        Row.new(%q(        end), 8, 8),
-        Row.new(%q(        break if @io.eof?), 8, 8),
-        Row.new(%q(        @line = ''), 8, 8),
-        Row.new(%q(        @exp_line_no = @line_no), 8, 8),
-        Row.new(%q(        ), nil, 8),
-        Row.new(%q(        @indent = 0), 8, 8),
-        Row.new(%q(      rescue TerminateLineInput), 6, 8),
-        Row.new(%q(        initialize_input), 8, 8),
-        Row.new(%q(        prompt), 8, 8),
-        Row.new(%q(      end), 6, 6),
-        Row.new(%q(    end), 4, 4),
-        Row.new(%q(  end), 2, 2),
-        Row.new(%q(end), 0, 0),
+        [%q(def each_top_level_statement), 0, 2],
+        [%q(  initialize_input), 2, 2],
+        [%q(  catch(:TERM_INPUT) do), 2, 4],
+        [%q(    loop do), 4, 6],
+        [%q(      begin), 6, 8],
+        [%q(        prompt), 8, 8],
+        [%q(        unless l = lex), 8, 10],
+        [%q(          throw :TERM_INPUT if @line == ''), 10, 10],
+        [%q(        else), 8, 10],
+        [%q(          @line_no += l.count("\n")), 10, 10],
+        [%q(          next if l == "\n"), 10, 10],
+        [%q(          @line.concat l), 10, 10],
+        [%q(          if @code_block_open or @ltype or @continue or @indent > 0), 10, 12],
+        [%q(            next), 12, 12],
+        [%q(          end), 10, 10],
+        [%q(        end), 8, 8],
+        [%q(        if @line != "\n"), 8, 10],
+        [%q(          @line.force_encoding(@io.encoding)), 10, 10],
+        [%q(          yield @line, @exp_line_no), 10, 10],
+        [%q(        end), 8, 8],
+        [%q(        break if @io.eof?), 8, 8],
+        [%q(        @line = ''), 8, 8],
+        [%q(        @exp_line_no = @line_no), 8, 8],
+        [%q(        ), nil, 8],
+        [%q(        @indent = 0), 8, 8],
+        [%q(      rescue TerminateLineInput), 6, 8],
+        [%q(        initialize_input), 8, 8],
+        [%q(        prompt), 8, 8],
+        [%q(      end), 6, 6],
+        [%q(    end), 4, 4],
+        [%q(  end), 2, 2],
+        [%q(end), 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
       end
@@ -177,14 +178,15 @@ module TestIRB
 
     def test_braces_on_their_own_line
       input_with_correct_indents = [
-        Row.new(%q(if true), 0, 2),
-        Row.new(%q(  [), 2, 4),
-        Row.new(%q(  ]), 2, 2),
-        Row.new(%q(end), 0, 0),
+        [%q(if true), 0, 2],
+        [%q(  [), 2, 4],
+        [%q(  ]), 2, 2],
+        [%q(end), 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
       end
@@ -192,17 +194,18 @@ module TestIRB
 
     def test_multiple_braces_in_a_line
       input_with_correct_indents = [
-        Row.new(%q([[[), 0, 6),
-        Row.new(%q(    ]), 4, 4),
-        Row.new(%q(  ]), 2, 2),
-        Row.new(%q(]), 0, 0),
-        Row.new(%q([<<FOO]), 0, 0),
-        Row.new(%q(hello), 0, 0),
-        Row.new(%q(FOO), 0, 0),
+        [%q([[[), 0, 6],
+        [%q(    ]), 4, 4],
+        [%q(  ]), 2, 2],
+        [%q(]), 0, 0],
+        [%q([<<FOO]), 0, 0],
+        [%q(hello), 0, 0],
+        [%q(FOO), 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
       end
@@ -210,12 +213,13 @@ module TestIRB
 
     def test_a_closed_brace_and_not_closed_brace_in_a_line
       input_with_correct_indents = [
-        Row.new(%q(p() {), 0, 2),
-        Row.new(%q(}), 0, 0),
+        [%q(p() {), 0, 2],
+        [%q(}), 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
       end
@@ -223,18 +227,19 @@ module TestIRB
 
     def test_symbols
       input_with_correct_indents = [
-        Row.new(%q(:a), 0, 0),
-        Row.new(%q(:A), 0, 0),
-        Row.new(%q(:+), 0, 0),
-        Row.new(%q(:@@a), 0, 0),
-        Row.new(%q(:@a), 0, 0),
-        Row.new(%q(:$a), 0, 0),
-        Row.new(%q(:def), 0, 0),
-        Row.new(%q(:`), 0, 0),
+        [%q(:a), 0, 0],
+        [%q(:A), 0, 0],
+        [%q(:+), 0, 0],
+        [%q(:@@a), 0, 0],
+        [%q(:@a), 0, 0],
+        [%q(:$a), 0, 0],
+        [%q(:def), 0, 0],
+        [%q(:`), 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
       end
@@ -305,11 +310,12 @@ module TestIRB
 
     def test_incomplete_coding_magic_comment
       input_with_correct_indents = [
-        Row.new(%q(#coding:u), 0, 0),
+        [%q(#coding:u), 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
       end
@@ -317,11 +323,12 @@ module TestIRB
 
     def test_incomplete_encoding_magic_comment
       input_with_correct_indents = [
-        Row.new(%q(#encoding:u), 0, 0),
+        [%q(#encoding:u), 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
       end
@@ -329,11 +336,12 @@ module TestIRB
 
     def test_incomplete_emacs_coding_magic_comment
       input_with_correct_indents = [
-        Row.new(%q(# -*- coding: u), 0, 0),
+        [%q(# -*- coding: u), 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
       end
@@ -341,11 +349,12 @@ module TestIRB
 
     def test_incomplete_vim_coding_magic_comment
       input_with_correct_indents = [
-        Row.new(%q(# vim:set fileencoding=u), 0, 0),
+        [%q(# vim:set fileencoding=u), 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
       end
@@ -353,25 +362,26 @@ module TestIRB
 
     def test_mixed_rescue
       input_with_correct_indents = [
-        Row.new(%q(def m), 0, 2),
-        Row.new(%q(  begin), 2, 4),
-        Row.new(%q(    begin), 4, 6),
-        Row.new(%q(      x = a rescue 4), 6, 6),
-        Row.new(%q(      y = [(a rescue 5)]), 6, 6),
-        Row.new(%q(      [x, y]), 6, 6),
-        Row.new(%q(    rescue => e), 4, 6),
-        Row.new(%q(      raise e rescue 8), 6, 6),
-        Row.new(%q(    end), 4, 4),
-        Row.new(%q(  rescue), 2, 4),
-        Row.new(%q(    raise rescue 11), 4, 4),
-        Row.new(%q(  end), 2, 2),
-        Row.new(%q(rescue => e), 0, 2),
-        Row.new(%q(  raise e rescue 14), 2, 2),
-        Row.new(%q(end), 0, 0),
+        [%q(def m), 0, 2],
+        [%q(  begin), 2, 4],
+        [%q(    begin), 4, 6],
+        [%q(      x = a rescue 4), 6, 6],
+        [%q(      y = [(a rescue 5)]), 6, 6],
+        [%q(      [x, y]), 6, 6],
+        [%q(    rescue => e), 4, 6],
+        [%q(      raise e rescue 8), 6, 6],
+        [%q(    end), 4, 4],
+        [%q(  rescue), 2, 4],
+        [%q(    raise rescue 11), 4, 4],
+        [%q(  end), 2, 2],
+        [%q(rescue => e), 0, 2],
+        [%q(  raise e rescue 14), 2, 2],
+        [%q(end), 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
       end
@@ -379,29 +389,30 @@ module TestIRB
 
     def test_oneliner_method_definition
       input_with_correct_indents = [
-        Row.new(%q(class A), 0, 2),
-        Row.new(%q(  def foo0), 2, 4),
-        Row.new(%q(    3), 4, 4),
-        Row.new(%q(  end), 2, 2),
-        Row.new(%q(  def foo1()), 2, 4),
-        Row.new(%q(    3), 4, 4),
-        Row.new(%q(  end), 2, 2),
-        Row.new(%q(  def foo2(a, b)), 2, 4),
-        Row.new(%q(    a + b), 4, 4),
-        Row.new(%q(  end), 2, 2),
-        Row.new(%q(  def foo3 a, b), 2, 4),
-        Row.new(%q(    a + b), 4, 4),
-        Row.new(%q(  end), 2, 2),
-        Row.new(%q(  def bar0() = 3), 2, 2),
-        Row.new(%q(  def bar1(a) = a), 2, 2),
-        Row.new(%q(  def bar2(a, b) = a + b), 2, 2),
-        Row.new(%q(  def bar3() = :s), 2, 2),
-        Row.new(%q(  def bar4() = Time.now), 2, 2),
-        Row.new(%q(end), 0, 0),
+        [%q(class A), 0, 2],
+        [%q(  def foo0), 2, 4],
+        [%q(    3), 4, 4],
+        [%q(  end), 2, 2],
+        [%q(  def foo1()), 2, 4],
+        [%q(    3), 4, 4],
+        [%q(  end), 2, 2],
+        [%q(  def foo2(a, b)), 2, 4],
+        [%q(    a + b), 4, 4],
+        [%q(  end), 2, 2],
+        [%q(  def foo3 a, b), 2, 4],
+        [%q(    a + b), 4, 4],
+        [%q(  end), 2, 2],
+        [%q(  def bar0() = 3), 2, 2],
+        [%q(  def bar1(a) = a), 2, 2],
+        [%q(  def bar2(a, b) = a + b), 2, 2],
+        [%q(  def bar3() = :s), 2, 2],
+        [%q(  def bar4() = Time.now), 2, 2],
+        [%q(end), 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
       end
@@ -409,14 +420,15 @@ module TestIRB
 
     def test_tlambda
       input_with_correct_indents = [
-        Row.new(%q(if true), 0, 2, 1),
-        Row.new(%q(  -> {), 2, 4, 2),
-        Row.new(%q(  }), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
+        [%q(if true), 0, 2, 1],
+        [%q(  -> {), 2, 4, 2],
+        [%q(  }), 2, 2, 1],
+        [%q(end), 0, 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -425,18 +437,19 @@ module TestIRB
 
     def test_corresponding_syntax_to_keyword_do_in_class
       input_with_correct_indents = [
-        Row.new(%q(class C), 0, 2, 1),
-        Row.new(%q(  while method_name do), 2, 4, 2),
-        Row.new(%q(    3), 4, 4, 2),
-        Row.new(%q(  end), 2, 2, 1),
-        Row.new(%q(  foo do), 2, 4, 2),
-        Row.new(%q(    3), 4, 4, 2),
-        Row.new(%q(  end), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
+        [%q(class C), 0, 2, 1],
+        [%q(  while method_name do), 2, 4, 2],
+        [%q(    3), 4, 4, 2],
+        [%q(  end), 2, 2, 1],
+        [%q(  foo do), 2, 4, 2],
+        [%q(    3), 4, 4, 2],
+        [%q(  end), 2, 2, 1],
+        [%q(end), 0, 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -445,46 +458,47 @@ module TestIRB
 
     def test_corresponding_syntax_to_keyword_do
       input_with_correct_indents = [
-        Row.new(%q(while i > 0), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
-        Row.new(%q(while true), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
-        Row.new(%q(while ->{i > 0}.call), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
-        Row.new(%q(while ->{true}.call), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
-        Row.new(%q(while i > 0 do), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
-        Row.new(%q(while true do), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
-        Row.new(%q(while ->{i > 0}.call do), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
-        Row.new(%q(while ->{true}.call do), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
-        Row.new(%q(foo do), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
-        Row.new(%q(foo true do), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
-        Row.new(%q(foo ->{true} do), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
-        Row.new(%q(foo ->{i > 0} do), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
+        [%q(while i > 0), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
+        [%q(while true), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
+        [%q(while ->{i > 0}.call), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
+        [%q(while ->{true}.call), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
+        [%q(while i > 0 do), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
+        [%q(while true do), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
+        [%q(while ->{i > 0}.call do), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
+        [%q(while ->{true}.call do), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
+        [%q(foo do), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
+        [%q(foo true do), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
+        [%q(foo ->{true} do), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
+        [%q(foo ->{i > 0} do), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -493,13 +507,14 @@ module TestIRB
 
     def test_corresponding_syntax_to_keyword_for
       input_with_correct_indents = [
-        Row.new(%q(for i in [1]), 0, 2, 1),
-        Row.new(%q(  puts i), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
+        [%q(for i in [1]), 0, 2, 1],
+        [%q(  puts i), 2, 2, 1],
+        [%q(end), 0, 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -508,13 +523,14 @@ module TestIRB
 
     def test_corresponding_syntax_to_keyword_for_with_do
       input_with_correct_indents = [
-        Row.new(%q(for i in [1] do), 0, 2, 1),
-        Row.new(%q(  puts i), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
+        [%q(for i in [1] do), 0, 2, 1],
+        [%q(  puts i), 2, 2, 1],
+        [%q(end), 0, 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -523,14 +539,15 @@ module TestIRB
 
     def test_typing_incomplete_include_interpreted_as_keyword_in
       input_with_correct_indents = [
-        Row.new(%q(module E), 0, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
-        Row.new(%q(class A), 0, 2, 1),
-        Row.new(%q(  in), 2, 2, 1) # scenario typing `include E`
+        [%q(module E), 0, 2, 1],
+        [%q(end), 0, 0, 0],
+        [%q(class A), 0, 2, 1],
+        [%q(  in), 2, 2, 1] # scenario typing `include E`
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -539,13 +556,14 @@ module TestIRB
 
     def test_bracket_corresponding_to_times
       input_with_correct_indents = [
-        Row.new(%q(3.times { |i|), 0, 2, 1),
-        Row.new(%q(  puts i), 2, 2, 1),
-        Row.new(%q(}), 0, 0, 0),
+        [%q(3.times { |i|), 0, 2, 1],
+        [%q(  puts i), 2, 2, 1],
+        [%q(}), 0, 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -554,13 +572,14 @@ module TestIRB
 
     def test_do_corresponding_to_times
       input_with_correct_indents = [
-        Row.new(%q(3.times do |i|), 0, 2, 1),
-        #Row.new(%q(  puts i), 2, 2, 1),
-        #Row.new(%q(end), 0, 0, 0),
+        [%q(3.times do |i|), 0, 2, 1],
+        [%q(  puts i), 2, 2, 1],
+        [%q(end), 0, 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -569,13 +588,14 @@ module TestIRB
 
     def test_bracket_corresponding_to_loop
       input_with_correct_indents = [
-        Row.new(%q(loop {), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(}), 0, 0, 0),
+        ['loop {', 0, 2, 1],
+        ['  3', 2, 2, 1],
+        ['}', 0, 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -584,13 +604,14 @@ module TestIRB
 
     def test_do_corresponding_to_loop
       input_with_correct_indents = [
-        Row.new(%q(loop do), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
+        [%q(loop do), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
       ]
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -607,21 +628,22 @@ module TestIRB
 
     def test_embdoc_indent
       input_with_correct_indents = [
-        Row.new(%q(=begin), 0, 0, 0),
-        Row.new(%q(a), 0, 0, 0),
-        Row.new(%q( b), 1, 1, 0),
-        Row.new(%q(=end), 0, 0, 0),
-        Row.new(%q(if 1), 0, 2, 1),
-        Row.new(%q(  2), 2, 2, 1),
-        Row.new(%q(=begin), 0, 0, 0),
-        Row.new(%q(a), 0, 0, 0),
-        Row.new(%q( b), 1, 1, 0),
-        Row.new(%q(=end), 0, 2, 1),
-        Row.new(%q(  3), 2, 2, 1),
-        Row.new(%q(end), 0, 0, 0),
+        [%q(=begin), 0, 0, 0],
+        [%q(a), 0, 0, 0],
+        [%q( b), 1, 1, 0],
+        [%q(=end), 0, 0, 0],
+        [%q(if 1), 0, 2, 1],
+        [%q(  2), 2, 2, 1],
+        [%q(=begin), 0, 0, 0],
+        [%q(a), 0, 0, 0],
+        [%q( b), 1, 1, 0],
+        [%q(=end), 0, 2, 1],
+        [%q(  3), 2, 2, 1],
+        [%q(end), 0, 0, 0],
       ]
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -646,6 +668,7 @@ module TestIRB
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -662,6 +685,7 @@ module TestIRB
 
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -676,6 +700,7 @@ module TestIRB
       ]
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -724,6 +749,7 @@ module TestIRB
       ]
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)
@@ -756,6 +782,7 @@ module TestIRB
       ]
       lines = []
       input_with_correct_indents.each do |row|
+        row = Row.new(*row)
         lines << row.content
         assert_row_indenting(lines, row)
         assert_indent_level(lines, row.indent_level)

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -81,6 +81,19 @@ module TestIRB
       assert_equal(row.new_line_spaces, actual_next_line_spaces, error_message)
     end
 
+    def assert_rows_with_correct_indents(rows_with_spaces, assert_indent_level: false)
+      lines = []
+      rows_with_spaces.map do |row|
+        row = Row.new(*row)
+        lines << row.content
+        assert_row_indenting(lines, row)
+
+        if assert_indent_level
+          assert_indent_level(lines, row.indent_level)
+        end
+      end
+    end
+
     def assert_indent_level(lines, expected, local_variables: [])
       indent_level, _continue, _code_block_open = check_state(lines, local_variables: local_variables)
       error_message = "Calculated the wrong number of indent level for:\n #{lines.join("\n")}"
@@ -168,12 +181,7 @@ module TestIRB
         [%q(end), 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents)
     end
 
     def test_braces_on_their_own_line
@@ -184,12 +192,7 @@ module TestIRB
         [%q(end), 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents)
     end
 
     def test_multiple_braces_in_a_line
@@ -203,12 +206,7 @@ module TestIRB
         [%q(FOO), 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents)
     end
 
     def test_a_closed_brace_and_not_closed_brace_in_a_line
@@ -217,12 +215,7 @@ module TestIRB
         [%q(}), 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents)
     end
 
     def test_symbols
@@ -237,12 +230,7 @@ module TestIRB
         [%q(:`), 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents)
     end
 
     def test_endless_range_at_end_of_line
@@ -313,12 +301,7 @@ module TestIRB
         [%q(#coding:u), 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents)
     end
 
     def test_incomplete_encoding_magic_comment
@@ -326,12 +309,7 @@ module TestIRB
         [%q(#encoding:u), 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents)
     end
 
     def test_incomplete_emacs_coding_magic_comment
@@ -339,12 +317,7 @@ module TestIRB
         [%q(# -*- coding: u), 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents)
     end
 
     def test_incomplete_vim_coding_magic_comment
@@ -352,12 +325,7 @@ module TestIRB
         [%q(# vim:set fileencoding=u), 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents)
     end
 
     def test_mixed_rescue
@@ -379,12 +347,7 @@ module TestIRB
         [%q(end), 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents)
     end
 
     def test_oneliner_method_definition
@@ -410,12 +373,7 @@ module TestIRB
         [%q(end), 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents)
     end
 
     def test_tlambda
@@ -426,13 +384,7 @@ module TestIRB
         [%q(end), 0, 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_corresponding_syntax_to_keyword_do_in_class
@@ -447,13 +399,7 @@ module TestIRB
         [%q(end), 0, 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_corresponding_syntax_to_keyword_do
@@ -496,13 +442,7 @@ module TestIRB
         [%q(end), 0, 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_corresponding_syntax_to_keyword_for
@@ -512,13 +452,7 @@ module TestIRB
         [%q(end), 0, 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_corresponding_syntax_to_keyword_for_with_do
@@ -528,13 +462,7 @@ module TestIRB
         [%q(end), 0, 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_typing_incomplete_include_interpreted_as_keyword_in
@@ -545,13 +473,8 @@ module TestIRB
         [%q(  in), 2, 2, 1] # scenario typing `include E`
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
+
     end
 
     def test_bracket_corresponding_to_times
@@ -561,13 +484,7 @@ module TestIRB
         [%q(}), 0, 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_do_corresponding_to_times
@@ -577,13 +494,7 @@ module TestIRB
         [%q(end), 0, 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_bracket_corresponding_to_loop
@@ -593,13 +504,7 @@ module TestIRB
         ['}', 0, 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_do_corresponding_to_loop
@@ -609,13 +514,7 @@ module TestIRB
         [%q(end), 0, 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_local_variables_dependent_code
@@ -641,13 +540,8 @@ module TestIRB
         [%q(  3), 2, 2, 1],
         [%q(end), 0, 0, 0],
       ]
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_heredoc_with_indent
@@ -655,56 +549,39 @@ module TestIRB
         pend 'This test needs Ripper::Lexer#scan to take broken tokens'
       end
       input_with_correct_indents = [
-        Row.new(%q(<<~Q+<<~R), 0, 2, 1),
-        Row.new(%q(a), 2, 2, 1),
-        Row.new(%q(a), 2, 2, 1),
-        Row.new(%q(  b), 2, 2, 1),
-        Row.new(%q(  b), 2, 2, 1),
-        Row.new(%q(  Q), 0, 2, 1),
-        Row.new(%q(    c), 4, 4, 1),
-        Row.new(%q(    c), 4, 4, 1),
-        Row.new(%q(    R), 0, 0, 0),
+        [%q(<<~Q+<<~R), 0, 2, 1],
+        [%q(a), 2, 2, 1],
+        [%q(a), 2, 2, 1],
+        [%q(  b), 2, 2, 1],
+        [%q(  b), 2, 2, 1],
+        [%q(  Q), 0, 2, 1],
+        [%q(    c), 4, 4, 1],
+        [%q(    c), 4, 4, 1],
+        [%q(    R), 0, 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_oneliner_def_in_multiple_lines
       input_with_correct_indents = [
-        Row.new(%q(def a()=[), 0, 2, 1),
-        Row.new(%q(  1,), 2, 2, 1),
-        Row.new(%q(].), 0, 0, 0),
-        Row.new(%q(to_s), 0, 0, 0),
+        [%q(def a()=[), 0, 2, 1],
+        [%q(  1,), 2, 2, 1],
+        [%q(].), 0, 0, 0],
+        [%q(to_s), 0, 0, 0],
       ]
 
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_broken_heredoc
       input_with_correct_indents = [
-        Row.new(%q(def foo), 0, 2, 1),
-        Row.new(%q(  <<~Q), 2, 4, 2),
-        Row.new(%q(  Qend), 4, 4, 2),
+        [%q(def foo), 0, 2, 1],
+        [%q(  <<~Q), 2, 4, 2],
+        [%q(  Qend), 4, 4, 2],
       ]
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_heredoc_keep_indent_spaces
@@ -732,61 +609,51 @@ module TestIRB
 
     def test_pasted_code_keep_base_indent_spaces
       input_with_correct_indents = [
-        Row.new(%q(    def foo), 0, 6, 1),
-        Row.new(%q(        if bar), 6, 10, 2),
-        Row.new(%q(          [1), 10, 12, 3),
-        Row.new(%q(          ]+[["a), 10, 14, 4),
-        Row.new(%q(b" + `c), 0, 14, 4),
-        Row.new(%q(d` + /e), 0, 14, 4),
-        Row.new(%q(f/ + :"g), 0, 14, 4),
-        Row.new(%q(h".tap do), 0, 16, 5),
-        Row.new(%q(                1), 16, 16, 5),
-        Row.new(%q(              end), 14, 14, 4),
-        Row.new(%q(            ]), 12, 12, 3),
-        Row.new(%q(          ]), 10, 10, 2),
-        Row.new(%q(        end), 8, 6, 1),
-        Row.new(%q(    end), 4, 0, 0),
+        [%q(    def foo), 0, 6, 1],
+        [%q(        if bar), 6, 10, 2],
+        [%q(          [1), 10, 12, 3],
+        [%q(          ]+[["a), 10, 14, 4],
+        [%q(b" + `c), 0, 14, 4],
+        [%q(d` + /e), 0, 14, 4],
+        [%q(f/ + :"g), 0, 14, 4],
+        [%q(h".tap do), 0, 16, 5],
+        [%q(                1), 16, 16, 5],
+        [%q(              end), 14, 14, 4],
+        [%q(            ]), 12, 12, 3],
+        [%q(          ]), 10, 10, 2],
+        [%q(        end), 8, 6, 1],
+        [%q(    end), 4, 0, 0],
       ]
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def test_pasted_code_keep_base_indent_spaces_with_heredoc
       input_with_correct_indents = [
-        Row.new(%q(    def foo), 0, 6, 1),
-        Row.new(%q(        if bar), 6, 10, 2),
-        Row.new(%q(          [1), 10, 12, 3),
-        Row.new(%q(          ]+[["a), 10, 14, 4),
-        Row.new(%q(b" + <<~A + <<-B + <<C), 0, 16, 5),
-        Row.new(%q(                a#{), 16, 18, 6),
-        Row.new(%q(                  1), 18, 18, 6),
-        Row.new(%q(                }), 16, 16, 5),
-        Row.new(%q(              A), 14, 16, 5),
-        Row.new(%q(                b#{), 16, 18, 6),
-        Row.new(%q(                  1), 18, 18, 6),
-        Row.new(%q(                }), 16, 16, 5),
-        Row.new(%q(              B), 14, 0, 0),
-        Row.new(%q(c#{), 0, 2, 1),
-        Row.new(%q(  1), 2, 2, 1),
-        Row.new(%q(}), 0, 0, 0),
-        Row.new(%q(C), 0, 14, 4),
-        Row.new(%q(            ]), 12, 12, 3),
-        Row.new(%q(          ]), 10, 10, 2),
-        Row.new(%q(        end), 8, 6, 1),
-        Row.new(%q(    end), 4, 0, 0),
+        [%q(    def foo), 0, 6, 1],
+        [%q(        if bar), 6, 10, 2],
+        [%q(          [1), 10, 12, 3],
+        [%q(          ]+[["a), 10, 14, 4],
+        [%q(b" + <<~A + <<-B + <<C), 0, 16, 5],
+        [%q(                a#{), 16, 18, 6],
+        [%q(                1), 18, 18, 6],
+        [%q(                }), 16, 16, 5],
+        [%q(              A), 14, 16, 5],
+        [%q(                b#{), 16, 18, 6],
+        [%q(                1), 18, 18, 6],
+        [%q(                }), 16, 16, 5],
+        [%q(              B), 14, 0, 0],
+        [%q(c#{), 0, 2, 1],
+        [%q(1), 2, 2, 1],
+        [%q(}), 0, 0, 0],
+        [%q(C), 0, 14, 4],
+        [%q(            ]), 12, 12, 3],
+        [%q(          ]), 10, 10, 2],
+        [%q(        end), 8, 6, 1],
+        [%q(    end), 4, 0, 0],
       ]
-      lines = []
-      input_with_correct_indents.each do |row|
-        row = Row.new(*row)
-        lines << row.content
-        assert_row_indenting(lines, row)
-        assert_indent_level(lines, row.indent_level)
-      end
+
+      assert_rows_with_correct_indents(input_with_correct_indents, assert_indent_level: true)
     end
 
     def assert_dynamic_prompt(lines, expected_prompt_list)


### PR DESCRIPTION
The parentheses of `(Prompt)Row.new` are very distracting when trying to read through RubyLex tests. And there are also many boilerplate in this file that can be extracted away.

It'd be easier to review by commits.