### PR TITLE
Declare rdoc as dependency

### DIFF
--- a/irb.gemspec
+++ b/irb.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.7")
 
   spec.add_dependency "reline", ">= 0.3.6"
+  spec.add_dependency "rdoc", "~> 6.5"
 end


### PR DESCRIPTION
IRB already has several features that rely on rdoc, such as:

- Autocompletion's document dialog
- Autocompletion's `PerfectMatchedProc`
- The `show_doc` command
- Easter egg

And we could use its pager more in the future too. So it makes sense to declare rdoc as a dependency instead of relying on the one bundled with Ruby.

### How will this affect Rails?

TL;DR - `rdoc` will be installed as a gem in all environments, but won't be required outside of `rails console` usages. In production, `rdoc` will only be required when IRB's document look-up commands are used because autocompletion is diabled.

- After this PR, Rails 7.1 will install `rdoc` as a gem along with `irb`
- Rails only requires `irb` in [console_command.rb](https://github.com/rails/rails/blob/main/railties/lib/rails/commands/console/console_command.rb), which is not loaded unless `rails console` is run. So whatever IRB requires, including `rdoc`, won't be loaded outside of `rails console`.
- Even with this PR, IRB does NOT eagerly require `rdoc`. And consider Rails disables IRB's autocompletion in production, `rdoc` won't be loaded unless `show_doc`/`help` commands are run.