### PR TITLE
Fix nested sessions' history saving

### DIFF
--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -8,7 +8,6 @@ require_relative "workspace"
 require_relative "inspector"
 require_relative "input-method"
 require_relative "output-method"
-require_relative "history"
 
 module IRB
   # A class that wraps the current state of the irb session, including the
@@ -130,8 +129,6 @@ module IRB
       else
         @io = input_method
       end
-      self.save_history = IRB.conf[:SAVE_HISTORY] if IRB.conf[:SAVE_HISTORY]
-
       @extra_doc_dirs = IRB.conf[:EXTRA_DOC_DIRS]
 
       @echo = IRB.conf[:ECHO]
@@ -154,13 +151,6 @@ module IRB
 
     def save_history=(val)
       IRB.conf[:SAVE_HISTORY] = val
-
-      if val
-        context = (IRB.conf[:MAIN_CONTEXT] || self)
-        if context.io.support_history_saving? && !context.io.singleton_class.include?(HistorySavingAbility)
-          context.io.extend(HistorySavingAbility)
-        end
-      end
     end
 
     def save_history

--- a/lib/irb/history.rb
+++ b/lib/irb/history.rb
@@ -1,9 +1,7 @@
 module IRB
   module HistorySavingAbility # :nodoc:
-    def HistorySavingAbility.extended(obj)
-      IRB.conf[:AT_EXIT].push proc{obj.save_history}
-      obj.load_history
-      obj
+    def support_history_saving?
+      true
     end
 
     def load_history

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -5,6 +5,7 @@
 #
 
 require_relative 'completion'
+require_relative "history"
 require 'io/console'
 require 'reline'
 
@@ -180,6 +181,8 @@ module IRB
         include ::Readline
       end
 
+      include HistorySavingAbility
+
       # Creates a new input method object using Readline
       def initialize
         self.class.initialize_readline
@@ -233,10 +236,6 @@ module IRB
         true
       end
 
-      def support_history_saving?
-        true
-      end
-
       # Returns the current line number for #io.
       #
       # #line counts the number of times #gets is called.
@@ -264,6 +263,7 @@ module IRB
 
   class RelineInputMethod < InputMethod
     HISTORY = Reline::HISTORY
+    include HistorySavingAbility
     # Creates a new input method object using Reline
     def initialize
       IRB.__send__(:set_encoding, Reline.encoding_system_needs.name, override: false)
@@ -465,10 +465,6 @@ module IRB
       inputrc_path = File.expand_path(config.inputrc_path)
       str += " and #{inputrc_path}" if File.exist?(inputrc_path)
       str
-    end
-
-    def support_history_saving?
-      true
     end
   end
 


### PR DESCRIPTION
Fix nested IRB sessions' history saving:
    
1. Dynamically including `HistorySavingAbility` makes things unnecessarily complicated and should be avoided.
2. Because both `Reline` and `Readline` use a single `HISTORY` constant to store history data. When nesting IRB sessions, only the first IRB session should handle history loading and saving so we can avoid duplicating history.
3. History saving callback should NOT be stored in `IRB.conf` as it's recreated every time `IRB.setup` is called, which would happen when nesting IRB sessions.

Fixes #666 #659 