### PR TITLE
Deprecate multi-irb commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IRB
 
-[![Gem Version](https://badge.fury.io/rb/irb.svg)](https://badge.fury.io/rb/irb) 
+[![Gem Version](https://badge.fury.io/rb/irb.svg)](https://badge.fury.io/rb/irb)
 [![build](https://github.com/ruby/irb/actions/workflows/test.yml/badge.svg)](https://github.com/ruby/irb/actions/workflows/test.yml)
 
 IRB stands for "interactive Ruby" and is a tool to interactively execute Ruby expressions read from the standard input.
@@ -96,12 +96,14 @@ IRB
   irb_load       Load a Ruby file.
   irb_require    Require a Ruby file.
   source         Loads a given file in the current session.
+  irb_info       Show information about IRB.
+  show_cmds      List all available commands and their description.
+
+Multi-irb (DEPRECATED)
   irb            Start a child IRB.
   jobs           List of current sessions.
   fg             Switches to the session of the given number.
   kill           Kills the session with the given number.
-  irb_info       Show information about IRB.
-  show_cmds      List all available commands and their description.
 
 Debugging
   debug          Start the debugger of debug.gem.

--- a/lib/irb/cmd/subirb.rb
+++ b/lib/irb/cmd/subirb.rb
@@ -18,6 +18,13 @@ module IRB
 
       private
 
+      def print_deprecated_warning
+        warn <<~MSG
+          Multi-irb commands are deprecated and will be removed in IRB 2.0.0. Please use workspace commands instead.
+          If you have any use case for multi-irb, please leave a comment at https://github.com/ruby/irb/issues/653
+        MSG
+      end
+
       def extend_irb_context
         # this extension patches IRB context like IRB.CurrentContext
         require_relative "../ext/multi-irb"
@@ -25,38 +32,42 @@ module IRB
     end
 
     class IrbCommand < MultiIRBCommand
-      category "IRB"
+      category "Multi-irb (DEPRECATED)"
       description "Start a child IRB."
 
       def execute(*obj)
+        print_deprecated_warning
         IRB.irb(nil, *obj)
       end
     end
 
     class Jobs < MultiIRBCommand
-      category "IRB"
+      category "Multi-irb (DEPRECATED)"
       description "List of current sessions."
 
       def execute
+        print_deprecated_warning
         IRB.JobManager
       end
     end
 
     class Foreground < MultiIRBCommand
-      category "IRB"
+      category "Multi-irb (DEPRECATED)"
       description "Switches to the session of the given number."
 
       def execute(key = nil)
+        print_deprecated_warning
         raise CommandArgumentError.new("Please specify the id of target IRB job (listed in the `jobs` command).") unless key
         IRB.JobManager.switch(key)
       end
     end
 
     class Kill < MultiIRBCommand
-      category "IRB"
+      category "Multi-irb (DEPRECATED)"
       description "Kills the session with the given number."
 
       def execute(*keys)
+        print_deprecated_warning
         IRB.JobManager.kill(*keys)
       end
     end


### PR DESCRIPTION
This is part of #653 

- Print deprecated message when any of the commands are used

    ```
    irb(main):002:0> jobs
    Multi-irb commands are deprecated and will be removed in IRB 2.0.0.
    If you have any use case for multi-irb, please leave a comment at https://github.com/ruby/irb/issues/653
    => #0->irb on main (#<Thread:0x0000000104dab128 run>: running)
    ```

- Put related commands under `Multi-irb` category with a deprecated label
    
    ```
    Multi-irb (DEPRECATED)
      irb            Start a child IRB.
      jobs           List of current sessions.
      fg             Switches to the session of the given number.
      kill           Kills the session with the given number.
    ```