### PR TITLE
Page `ls`'s output

### DIFF
--- a/lib/irb/cmd/show_cmds.rb
+++ b/lib/irb/cmd/show_cmds.rb
@@ -29,9 +29,7 @@ module IRB
           output.puts
         end
 
-        Pager.page do |io|
-          io.puts output.string
-        end
+        Pager.page_content(output.string)
       end
     end
   end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -710,6 +710,16 @@ module TestIRB
   end
 
   class LsTest < CommandTestCase
+    def setup
+      STDIN.singleton_class.define_method :tty? do
+        false
+      end
+    end
+
+    def teardown
+      STDIN.singleton_class.remove_method :tty?
+    end
+
     def test_ls
       out, err = execute_lines(
         "class P\n",

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -270,6 +270,54 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     assert_match(/foobar/, screen)
   end
 
+  def test_pager_page_content_pages_output_when_it_does_not_fit_in_the_screen_because_of_total_length
+    write_irbrc <<~'LINES'
+      puts 'start IRB'
+      require "irb/pager"
+    LINES
+    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    write("IRB::Pager.page_content('a' * (80 * 8))\n")
+    write("'foo' + 'bar'\n") # eval something to make sure IRB resumes
+    close
+
+    screen = result.join("\n").sub(/\n*\z/, "\n")
+    assert_match(/a{80}/, screen)
+    # because pager is invoked, foobar will not be evaluated
+    assert_not_match(/foobar/, screen)
+  end
+
+  def test_pager_page_content_pages_output_when_it_does_not_fit_in_the_screen_because_of_screen_height
+    write_irbrc <<~'LINES'
+      puts 'start IRB'
+      require "irb/pager"
+    LINES
+    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    write("IRB::Pager.page_content('a\n' * 8)\n")
+    write("'foo' + 'bar'\n") # eval something to make sure IRB resumes
+    close
+
+    screen = result.join("\n").sub(/\n*\z/, "\n")
+    assert_match(/(a\n){8}/, screen)
+    # because pager is invoked, foobar will not be evaluated
+    assert_not_match(/foobar/, screen)
+  end
+
+  def test_pager_page_content_doesnt_page_output_when_it_fits_in_the_screen
+    write_irbrc <<~'LINES'
+      puts 'start IRB'
+      require "irb/pager"
+    LINES
+    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    write("IRB::Pager.page_content('a' * (80 * 7))\n")
+    write("'foo' + 'bar'\n") # eval something to make sure IRB resumes
+    close
+
+    screen = result.join("\n").sub(/\n*\z/, "\n")
+    assert_match(/a{80}/, screen)
+    # because pager is not invoked, foobar will be evaluated
+    assert_match(/foobar/, screen)
+  end
+
   private
 
   def write_irbrc(content)


### PR DESCRIPTION
This PR:

- Introduces `Pager#page_content` that decides whether to page the content based on if it'd take too much of user's screen space.
    - For example, `"a"` will not be paged. But `"a" * 1000000` probably will be.
    - This matches Pry's paging behaviour.
- Use `Pager#page_content` in `ls` and `show_cmds` commands.


## Demo

https://github.com/ruby/irb/assets/5079556/074c152a-b0e6-40e2-ae00-1ca1699fd807

