### PR TITLE
Decouple `edit` and `show_source` commands

### DIFF
--- a/lib/irb/cmd/edit.rb
+++ b/lib/irb/cmd/edit.rb
@@ -37,7 +37,7 @@ module IRB
               # in this case, we should just ignore the error
             end
 
-          if source && File.exist?(source.file)
+          if source
             path = source.file
           else
             puts "Can not find file: #{path}"

--- a/lib/irb/cmd/edit.rb
+++ b/lib/irb/cmd/edit.rb
@@ -1,5 +1,6 @@
 require 'shellwords'
 require_relative "nop"
+require_relative "../source_finder"
 
 module IRB
   # :stopdoc:
@@ -28,11 +29,9 @@ module IRB
         end
 
         if !File.exist?(path)
-          require_relative "show_source"
-
           source =
             begin
-              ShowSource.find_source(path, @irb_context)
+              SourceFinder.new(@irb_context).find_source(path)
             rescue NameError
               # if user enters a path that doesn't exist, it'll cause NameError when passed here because find_source would try to evaluate it as well
               # in this case, we should just ignore the error

--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -29,7 +29,7 @@ module IRB
 
         source = SourceFinder.new(@irb_context).find_source(str)
 
-        if source && File.exist?(source.file)
+        if source
           show_source(source)
         else
           puts "Error: Couldn't locate a definition for #{str}"

--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 require_relative "nop"
+require_relative "../source_finder"
 require_relative "../color"
-require_relative "../ruby-lex"
 
 module IRB
-  # :stopdoc:
-
   module ExtendCommand
     class ShowSource < Nop
       category "Context"
@@ -21,51 +19,6 @@ module IRB
             args.strip.dump
           end
         end
-
-        def find_source(str, irb_context)
-          case str
-          when /\A[A-Z]\w*(::[A-Z]\w*)*\z/ # Const::Name
-            eval(str, irb_context.workspace.binding) # trigger autoload
-            base = irb_context.workspace.binding.receiver.yield_self { |r| r.is_a?(Module) ? r : Object }
-            file, line = base.const_source_location(str)
-          when /\A(?<owner>[A-Z]\w*(::[A-Z]\w*)*)#(?<method>[^ :.]+)\z/ # Class#method
-            owner = eval(Regexp.last_match[:owner], irb_context.workspace.binding)
-            method = Regexp.last_match[:method]
-            if owner.respond_to?(:instance_method)
-              methods = owner.instance_methods + owner.private_instance_methods
-              file, line = owner.instance_method(method).source_location if methods.include?(method.to_sym)
-            end
-          when /\A((?<receiver>.+)(\.|::))?(?<method>[^ :.]+)\z/ # method, receiver.method, receiver::method
-            receiver = eval(Regexp.last_match[:receiver] || 'self', irb_context.workspace.binding)
-            method = Regexp.last_match[:method]
-            file, line = receiver.method(method).source_location if receiver.respond_to?(method, true)
-          end
-          if file && line
-            Source.new(file: file, first_line: line, last_line: find_end(file, line, irb_context))
-          end
-        end
-
-        private
-
-        def find_end(file, first_line, irb_context)
-          return first_line unless File.exist?(file)
-          lex = RubyLex.new(irb_context)
-          lines = File.read(file).lines[(first_line - 1)..-1]
-          tokens = RubyLex.ripper_lex_without_warning(lines.join)
-          prev_tokens = []
-
-          # chunk with line number
-          tokens.chunk { |tok| tok.pos[0] }.each do |lnum, chunk|
-            code = lines[0..lnum].join
-            prev_tokens.concat chunk
-            continue = lex.should_continue?(prev_tokens)
-            syntax = lex.check_code_syntax(code)
-            if !continue && syntax == :valid
-              return first_line + lnum
-            end
-          end
-          first_line
-        end
       end
 
       def execute(str = nil)
@@ -74,7 +27,8 @@ module IRB
           return
         end
 
-        source = self.class.find_source(str, @irb_context)
+        source = SourceFinder.new(@irb_context).find_source(str)
+
         if source && File.exist?(source.file)
           show_source(source)
         else
@@ -85,7 +39,6 @@ module IRB
 
       private
 
-      # @param [IRB::ExtendCommand::ShowSource::Source] source
       def show_source(source)
         puts
         puts "#{bold("From")}: #{source.file}:#{source.first_line}"
@@ -98,16 +51,6 @@ module IRB
       def bold(str)
         Color.colorize(str, [:BOLD])
       end
-
-      Source = Struct.new(
-        :file,       # @param [String] - file name
-        :first_line, # @param [String] - first line
-        :last_line,  # @param [String] - last line
-        keyword_init: true,
-      )
-      private_constant :Source
     end
   end
-
-  # :startdoc:
 end

--- a/lib/irb/source_finder.rb
+++ b/lib/irb/source_finder.rb
@@ -34,16 +34,15 @@ module IRB
         method = Regexp.last_match[:method]
         file, line = receiver.method(method).source_location if receiver.respond_to?(method, true)
       end
-      if file && line
-        Source.new(file: file, first_line: line, last_line: find_end(file, line, @irb_context))
+      if file && line && File.exist?(file)
+        Source.new(file: file, first_line: line, last_line: find_end(file, line))
       end
     end
 
     private
 
-    def find_end(file, first_line, irb_context)
-      return first_line unless File.exist?(file)
-      lex = RubyLex.new(irb_context)
+    def find_end(file, first_line)
+      lex = RubyLex.new(@irb_context)
       lines = File.read(file).lines[(first_line - 1)..-1]
       tokens = RubyLex.ripper_lex_without_warning(lines.join)
       prev_tokens = []

--- a/lib/irb/source_finder.rb
+++ b/lib/irb/source_finder.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative "ruby-lex"
+
+module IRB
+  class SourceFinder
+    Source = Struct.new(
+      :file,       # @param [String] - file name
+      :first_line, # @param [String] - first line
+      :last_line,  # @param [String] - last line
+      keyword_init: true,
+    )
+    private_constant :Source
+
+    def initialize(irb_context)
+      @irb_context = irb_context
+    end
+
+    def find_source(signature)
+      case signature
+      when /\A[A-Z]\w*(::[A-Z]\w*)*\z/ # Const::Name
+        eval(signature, @irb_context.workspace.binding) # trigger autoload
+        base = @irb_context.workspace.binding.receiver.yield_self { |r| r.is_a?(Module) ? r : Object }
+        file, line = base.const_source_location(signature)
+      when /\A(?<owner>[A-Z]\w*(::[A-Z]\w*)*)#(?<method>[^ :.]+)\z/ # Class#method
+        owner = eval(Regexp.last_match[:owner], @irb_context.workspace.binding)
+        method = Regexp.last_match[:method]
+        if owner.respond_to?(:instance_method)
+          methods = owner.instance_methods + owner.private_instance_methods
+          file, line = owner.instance_method(method).source_location if methods.include?(method.to_sym)
+        end
+      when /\A((?<receiver>.+)(\.|::))?(?<method>[^ :.]+)\z/ # method, receiver.method, receiver::method
+        receiver = eval(Regexp.last_match[:receiver] || 'self', @irb_context.workspace.binding)
+        method = Regexp.last_match[:method]
+        file, line = receiver.method(method).source_location if receiver.respond_to?(method, true)
+      end
+      if file && line
+        Source.new(file: file, first_line: line, last_line: find_end(file, line, @irb_context))
+      end
+    end
+
+    private
+
+    def find_end(file, first_line, irb_context)
+      return first_line unless File.exist?(file)
+      lex = RubyLex.new(irb_context)
+      lines = File.read(file).lines[(first_line - 1)..-1]
+      tokens = RubyLex.ripper_lex_without_warning(lines.join)
+      prev_tokens = []
+
+      # chunk with line number
+      tokens.chunk { |tok| tok.pos[0] }.each do |lnum, chunk|
+        code = lines[0..lnum].join
+        prev_tokens.concat chunk
+        continue = lex.should_continue?(prev_tokens)
+        syntax = lex.check_code_syntax(code)
+        if !continue && syntax == :valid
+          return first_line + lnum
+        end
+      end
+      first_line
+    end
+  end
+end


### PR DESCRIPTION
Ideally all commands should be independent from each other. But currently `edit` is implemented based on the `show_source` command for its source-finding mechanism.

I think the better approach is to extract the source-finding part to a standalone utility class and use it in both commands instead.