### PR TITLE
Forward-port from ruby/ruby

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -967,7 +967,7 @@ class Binding
   #     Cooked potato: true
   #
   #
-  # See IRB@IRB+Usage for more information.
+  # See IRB@Usage for more information.
   def irb(show_code: true)
     IRB.setup(source_location[0], argv: [])
     workspace = IRB::WorkSpace.new(self)


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/6528cf9fcf503706ec16d378b27469b0be51cbff is directly changed `lib/irb.rb`. I picked this commit for ruby/irb.