### PR TITLE
Fix IntegrationTestCase

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -79,7 +79,7 @@ module TestIRB
     end
   end
 
-  class IntegrationTestCase
+  class IntegrationTestCase < TestCase
     LIB = File.expand_path("../../lib", __dir__)
     TIMEOUT_SEC = 3
 


### PR DESCRIPTION
The tests aren't being run because I forgot to inherit `TestCase` on `IntegrationTestCase`.