### PR TITLE
Store integration tests' envs in an ivar

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -87,6 +87,8 @@ module TestIRB
       unless defined?(PTY)
         omit "Integration tests require PTY."
       end
+
+      @envs = {}
     end
 
     def run_ruby_file(&block)
@@ -98,7 +100,7 @@ module TestIRB
 
       yield
 
-      PTY.spawn(integration_envs.merge("TERM" => "dumb"), *cmd) do |read, write, pid|
+      PTY.spawn(@envs.merge("TERM" => "dumb"), *cmd) do |read, write, pid|
         Timeout.timeout(TIMEOUT_SEC) do
           while line = safe_gets(read)
             lines << line
@@ -177,10 +179,6 @@ module TestIRB
       @ruby_file = Tempfile.create(%w{irb- .rb})
       @ruby_file.write(program)
       @ruby_file.close
-    end
-
-    def integration_envs
-      {}
     end
   end
 end

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -8,6 +8,8 @@ require_relative "helper"
 module TestIRB
   class DebugCommandTest < IntegrationTestCase
     def setup
+      super
+
       if ruby_core?
         omit "This test works only under ruby/irb"
       end
@@ -15,6 +17,8 @@ module TestIRB
       if RUBY_ENGINE == 'truffleruby'
         omit "This test runs with ruby/debug, which doesn't work with truffleruby"
       end
+
+      @envs.merge!("NO_COLOR" => "true", "RUBY_DEBUG_HISTORY_FILE" => '')
     end
 
     def test_backtrace
@@ -188,12 +192,6 @@ module TestIRB
 
       assert_match(/\(rdbg:irb\) catch/, output)
       assert_match(/Stop by #0  BP - Catch  "ZeroDivisionError"/, output)
-    end
-
-    private
-
-    def integration_envs
-      { "NO_COLOR" => "true", "RUBY_DEBUG_HISTORY_FILE" => '' }
     end
   end
 end


### PR DESCRIPTION
So individual test cases can specify different envs too.