### PR TITLE
Don't echo an expression's result when it ends with a semicolon

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -562,7 +562,8 @@ module IRB
             is_assignment = assignment_expression?(line)
             evaluate_line(line, line_no)
 
-            if @context.echo?
+            # Don't echo if the line ends with a semicolon
+            if @context.echo? && !line.match?(/;\s*\z/)
               if is_assignment
                 if @context.echo_on_assignment?
                   output_value(@context.echo_on_assignment? == :truncate)

--- a/test/irb/test_evaluation.rb
+++ b/test/irb/test_evaluation.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+require_relative "helper"
+
+module TestIRB
+  class EchoingTest < IntegrationTestCase
+    def test_irb_echos_by_default
+      write_ruby <<~'RUBY'
+        binding.irb
+      RUBY
+
+      output = run_ruby_file do
+        type "123123"
+        type "exit"
+      end
+
+      assert_include(output, "=> 123123")
+    end
+
+    def test_irb_doesnt_echo_line_with_semicolon
+      write_ruby <<~'RUBY'
+        binding.irb
+      RUBY
+
+      output = run_ruby_file do
+        type "123123;"
+        type "123123   ;"
+        type "123123;   "
+        type <<~RUBY
+          if true
+            123123
+          end;
+        RUBY
+        type "'evaluation ends'"
+        type "exit"
+      end
+
+      assert_include(output, "=> \"evaluation ends\"")
+      assert_not_include(output, "=> 123123")
+    end
+  end
+end

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -143,7 +143,6 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       irb(main):016:0>
       irb(main):017:0>
       irb(main):018:0> class A def b; self; end; def c; true; end; end;
-      => :c
       irb(main):019:0> a = A.new
       => #<A>
       irb(main):020:0> a


### PR DESCRIPTION
Closes #656 