### PR TITLE
Make Reline/ReadlineInputMethod inherit StdioInputMethod

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -160,7 +160,7 @@ module IRB
   end
 
   begin
-    class ReadlineInputMethod < InputMethod
+    class ReadlineInputMethod < StdioInputMethod
       def self.initialize_readline
         require "readline"
       rescue LoadError
@@ -177,12 +177,9 @@ module IRB
           IRB.__send__(:set_encoding, Readline.encoding_system_needs.name, override: false)
         end
 
-        @line_no = 0
-        @line = []
-        @eof = false
+        super
 
-        @stdin = IO.open(STDIN.to_i, :external_encoding => IRB.conf[:LC_MESSAGES].encoding, :internal_encoding => "-")
-        @stdout = IO.open(STDOUT.to_i, 'w', :external_encoding => IRB.conf[:LC_MESSAGES].encoding, :internal_encoding => "-")
+        @eof = false
 
         if Readline.respond_to?("basic_word_break_characters=")
           Readline.basic_word_break_characters = IRB::InputCompletor::BASIC_WORD_BREAK_CHARACTERS
@@ -214,28 +211,6 @@ module IRB
         @eof
       end
 
-      # Whether this input method is still readable when there is no more data to
-      # read.
-      #
-      # See IO#eof for more information.
-      def readable_after_eof?
-        true
-      end
-
-      # Returns the current line number for #io.
-      #
-      # #line counts the number of times #gets is called.
-      #
-      # See IO#lineno for more information.
-      def line(line_no)
-        @line[line_no]
-      end
-
-      # The external encoding for standard input.
-      def encoding
-        @stdin.external_encoding
-      end
-
       # For debug message
       def inspect
         readline_impl = (defined?(Reline) && Readline == Reline) ? 'Reline' : 'ext/readline'
@@ -247,19 +222,16 @@ module IRB
     end
   end
 
-  class RelineInputMethod < InputMethod
+  class RelineInputMethod < StdioInputMethod
     HISTORY = Reline::HISTORY
     include HistorySavingAbility
     # Creates a new input method object using Reline
     def initialize
       IRB.__send__(:set_encoding, Reline.encoding_system_needs.name, override: false)
 
-      @line_no = 0
-      @line = []
-      @eof = false
+      super
 
-      @stdin = ::IO.open(STDIN.to_i, :external_encoding => IRB.conf[:LC_MESSAGES].encoding, :internal_encoding => "-")
-      @stdout = ::IO.open(STDOUT.to_i, 'w', :external_encoding => IRB.conf[:LC_MESSAGES].encoding, :internal_encoding => "-")
+      @eof = false
 
       Reline.basic_word_break_characters = IRB::InputCompletor::BASIC_WORD_BREAK_CHARACTERS
       Reline.completion_append_character = nil
@@ -419,28 +391,6 @@ module IRB
     # See IO#eof? for more information.
     def eof?
       @eof
-    end
-
-    # Whether this input method is still readable when there is no more data to
-    # read.
-    #
-    # See IO#eof for more information.
-    def readable_after_eof?
-      true
-    end
-
-    # Returns the current line number for #io.
-    #
-    # #line counts the number of times #gets is called.
-    #
-    # See IO#lineno for more information.
-    def line(line_no)
-      @line[line_no]
-    end
-
-    # The external encoding for standard input.
-    def encoding
-      @stdin.external_encoding
     end
 
     # For debug message


### PR DESCRIPTION
They are both built on top of stdio and are basically extended version of `StdioInputMethod`. They also share several attributes and methods with `StdioInputMethod`.

