### PR TITLE
Skip nested IRB tests in Ruby Core CI

### DIFF
--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -210,6 +210,14 @@ module TestIRB
   end
 
   class NestedIRBHistoryTest < IntegrationTestCase
+    def setup
+      super
+
+      if ruby_core?
+        omit "This test works only under ruby/irb"
+      end
+    end
+
     def test_history_saving_with_nested_sessions
       write_history ""
 


### PR DESCRIPTION
Sometimes (or under some environments) the subprocess gets stuck in the nested IRB session until timed out ([example](http://ci.rvm.jp/results/trunk-gc-asserts@ruby-sp2-docker/4679871)). We don't have enough information to debug it yet, so skip the tests to unblock CI.