### PR TITLE
Add black and white color to IRB::Color

### DIFF
--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -9,12 +9,14 @@ module IRB # :nodoc:
     BOLD      = 1
     UNDERLINE = 4
     REVERSE   = 7
+    BLACK     = 30
     RED       = 31
     GREEN     = 32
     YELLOW    = 33
     BLUE      = 34
     MAGENTA   = 35
     CYAN      = 36
+    WHITE     = 37
 
     TOKEN_KEYWORDS = {
       on_kw: ['nil', 'self', 'true', 'false', '__FILE__', '__LINE__', '__ENCODING__'],


### PR DESCRIPTION
Although they're not used by syntax highlighting, they could be used to things like prompt.

(Since `ruby/debug` already depends on `IRB::Color`, I consider this part as public API)