### PR TITLE
Skip integration tests in core CI

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -87,6 +87,10 @@ module TestIRB
         omit "Integration tests require PTY."
       end
 
+      if ruby_core?
+        omit "This test works only under ruby/irb"
+      end
+
       @envs = {}
     end
 

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -10,10 +10,6 @@ module TestIRB
     def setup
       super
 
-      if ruby_core?
-        omit "This test works only under ruby/irb"
-      end
-
       if RUBY_ENGINE == 'truffleruby'
         omit "This test runs with ruby/debug, which doesn't work with truffleruby"
       end

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -210,14 +210,6 @@ module TestIRB
   end
 
   class NestedIRBHistoryTest < IntegrationTestCase
-    def setup
-      super
-
-      if ruby_core?
-        omit "This test works only under ruby/irb"
-      end
-    end
-
     def test_history_saving_with_nested_sessions
       write_history ""
 


### PR DESCRIPTION
We already skipped history integration tests in core CI in #675 due to suspicion on nested IRB sessions don't work on certain operating systems.

But after #669, the evaluation integration test also started to fail on some Core CI suites ([example](http://rubyci.s3.amazonaws.com/solaris10-gcc/ruby-master/log/20230811T170006Z.fail.html.gz)). So, it looks like the integration test setup may not work in Core CI, at least in some suites.

Consider `ruby/irb` already has rather sophisticated test suite, I think it's better to skip the integration tests in core CI for now.