### PR TITLE
Remove needless removal of trailing whitespace in check_code_state

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -189,8 +189,7 @@ class RubyLex
   end
 
   def check_code_state(code)
-    check_target_code = code.gsub(/\s*\z/, '').concat("\n")
-    tokens = self.class.ripper_lex_without_warning(check_target_code, context: @context)
+    tokens = self.class.ripper_lex_without_warning(code, context: @context)
     opens = IRB::NestingParser.open_tokens(tokens)
     [tokens, opens, code_terminated?(code, tokens, opens)]
   end


### PR DESCRIPTION
IRB unnecessarily removes trailing white space before checking `should_continue?`. It results in failure of executing tricky syntax.
```ruby
irb(main):001:0" <<"a "
irb(main):002:0" heredoc
irb(main):003:0> a (←whitespace here)
irb(main):004:0> 
irb(main):005:0> 
```

```ruby
irb(main):001:0> % ruby (←whitespace here)
irb(main):002:0> 
irb(main):003:0> 
irb(main):004:0> 
```

```ruby
irb(main):001:0* %
irb(main):002:0> 
irb(main):003:0> 
```

## Reason why there was gsub and why it's not needed now
The old implementation of `should_continue?` (`process_continue`) was assuming `tokens[-1]` is newline and `tokens[-2]` is the last non-whitespace token. `code.gsub(/\s*\z/, '').concat("\n")` was ensuring that assumption.
https://github.com/ruby/irb/pull/611/files#diff-612b926e42ed78aed1a889ac1944f7d22229b3a489cc08f837a7f75eca3d3399L250-L262
The implementation is changed to skip continuous trailing newline, space, and comment-like tokens so we don't need that gsub anymore.




