### PR TITLE
Drop showing indent level number in DEFAULT prompt and INF_RUBY prompt

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -194,10 +194,10 @@ require_relative "irb/easter-egg"
 # For instance, the default prompt mode is defined as follows:
 #
 #     IRB.conf[:PROMPT_MODE][:DEFAULT] = {
-#       :PROMPT_I => "%N(%m):%03n:%i> ",
-#       :PROMPT_N => "%N(%m):%03n:%i> ",
-#       :PROMPT_S => "%N(%m):%03n:%i%l ",
-#       :PROMPT_C => "%N(%m):%03n:%i* ",
+#       :PROMPT_I => "%N(%m):%03n> ",
+#       :PROMPT_N => "%N(%m):%03n> ",
+#       :PROMPT_S => "%N(%m):%03n%l ",
+#       :PROMPT_C => "%N(%m):%03n* ",
 #       :RETURN => "%s\n" # used to printf
 #     }
 #
@@ -211,10 +211,10 @@ require_relative "irb/easter-egg"
 #   #   :RETURN: |
 #   #     %s
 #   # :DEFAULT:
-#   #   :PROMPT_I: ! '%N(%m):%03n:%i> '
-#   #   :PROMPT_N: ! '%N(%m):%03n:%i> '
-#   #   :PROMPT_S: ! '%N(%m):%03n:%i%l '
-#   #   :PROMPT_C: ! '%N(%m):%03n:%i* '
+#   #   :PROMPT_I: ! '%N(%m):%03n> '
+#   #   :PROMPT_N: ! '%N(%m):%03n> '
+#   #   :PROMPT_S: ! '%N(%m):%03n%l '
+#   #   :PROMPT_C: ! '%N(%m):%03n* '
 #   #   :RETURN: |
 #   #     => %s
 #   # :CLASSIC:
@@ -232,7 +232,7 @@ require_relative "irb/easter-egg"
 #   #   :RETURN: |
 #   #     => %s
 #   # :INF_RUBY:
-#   #   :PROMPT_I: ! '%N(%m):%03n:%i> '
+#   #   :PROMPT_I: ! '%N(%m):%03n> '
 #   #   :PROMPT_N:
 #   #   :PROMPT_S:
 #   #   :PROMPT_C:

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -64,10 +64,10 @@ module IRB # :nodoc:
         :RETURN => "%s\n"
       },
       :DEFAULT => {
-        :PROMPT_I => "%N(%m):%03n:%i> ",
-        :PROMPT_N => "%N(%m):%03n:%i> ",
-        :PROMPT_S => "%N(%m):%03n:%i%l ",
-        :PROMPT_C => "%N(%m):%03n:%i* ",
+        :PROMPT_I => "%N(%m):%03n> ",
+        :PROMPT_N => "%N(%m):%03n> ",
+        :PROMPT_S => "%N(%m):%03n%l ",
+        :PROMPT_C => "%N(%m):%03n* ",
         :RETURN => "=> %s\n"
       },
       :CLASSIC => {
@@ -85,7 +85,7 @@ module IRB # :nodoc:
         :RETURN => "=> %s\n"
       },
       :INF_RUBY => {
-        :PROMPT_I => "%N(%m):%03n:%i> ",
+        :PROMPT_I => "%N(%m):%03n> ",
         :PROMPT_N => nil,
         :PROMPT_S => nil,
         :PROMPT_C => nil,

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -41,9 +41,9 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     close
     assert_screen(<<~EOC)
       start IRB
-      irb(main):001:0> 'Hello, World!'
+      irb(main):001> 'Hello, World!'
       => "Hello, World!"
-      irb(main):002:0>
+      irb(main):002>
     EOC
   end
 
@@ -68,21 +68,21 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     close
     assert_screen(<<~EOC)
       start IRB
-      irb(main):001:1* class A
-      irb(main):002:1*   def inspect; '#<A>'; end
-      irb(main):003:1*   def a; self; end
-      irb(main):004:1*   def b; true; end
-      irb(main):005:0> end
+      irb(main):001* class A
+      irb(main):002*   def inspect; '#<A>'; end
+      irb(main):003*   def a; self; end
+      irb(main):004*   def b; true; end
+      irb(main):005> end
       => :b
-      irb(main):006:0>
-      irb(main):007:0> a = A.new
+      irb(main):006>
+      irb(main):007> a = A.new
       => #<A>
-      irb(main):008:0>
-      irb(main):009:0> a
-      irb(main):010:0>  .a
-      irb(main):011:0> .b
+      irb(main):008>
+      irb(main):009> a
+      irb(main):010>  .a
+      irb(main):011> .b
       => true
-      irb(main):012:0>
+      irb(main):012>
     EOC
   end
 
@@ -121,39 +121,39 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     close
     assert_screen(<<~EOC)
       start IRB
-      irb(main):001:1* class A
-      irb(main):002:1*   def inspect; '#<A>'; end
-      irb(main):003:1*   def b; self; end
-      irb(main):004:1*   def c; true; end
-      irb(main):005:0> end
+      irb(main):001* class A
+      irb(main):002*   def inspect; '#<A>'; end
+      irb(main):003*   def b; self; end
+      irb(main):004*   def c; true; end
+      irb(main):005> end
       => :c
-      irb(main):006:0>
-      irb(main):007:0> a = A.new
+      irb(main):006>
+      irb(main):007> a = A.new
       => #<A>
-      irb(main):008:0>
-      irb(main):009:0> a
-      irb(main):010:0>   .b
-      irb(main):011:0>   # aaa
-      irb(main):012:0>   .c
+      irb(main):008>
+      irb(main):009> a
+      irb(main):010>   .b
+      irb(main):011>   # aaa
+      irb(main):012>   .c
       => true
-      irb(main):013:0>
-      irb(main):014:0> (a)
-      irb(main):015:0>   &.b()
+      irb(main):013>
+      irb(main):014> (a)
+      irb(main):015>   &.b()
       => #<A>
-      irb(main):016:0>
-      irb(main):017:0>
-      irb(main):018:0> class A def b; self; end; def c; true; end; end;
-      irb(main):019:0> a = A.new
+      irb(main):016>
+      irb(main):017>
+      irb(main):018> class A def b; self; end; def c; true; end; end;
+      irb(main):019> a = A.new
       => #<A>
-      irb(main):020:0> a
-      irb(main):021:0>   .b
-      irb(main):022:0>   # aaa
-      irb(main):023:0>   .c
+      irb(main):020> a
+      irb(main):021>   .b
+      irb(main):022>   # aaa
+      irb(main):023>   .c
       => true
-      irb(main):024:0> (a)
-      irb(main):025:0> &.b()
+      irb(main):024> (a)
+      irb(main):025> &.b()
       => #<A>
-      irb(main):026:0>
+      irb(main):026>
     EOC
   end
 
@@ -168,9 +168,9 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     close
     assert_screen(<<~EOC)
       start IRB
-      irb(main):001:0> :`
+      irb(main):001> :`
       => :`
-      irb(main):002:0>
+      irb(main):002>
     EOC
   end
 
@@ -243,11 +243,11 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     close
     assert_screen(<<~EOC)
       start IRB
-      irb(main):001:0> #{code}
+      irb(main):001> #{code}
       =>
       [0,
       ...
-      irb(main):002:0>
+      irb(main):002>
     EOC
   end
 


### PR DESCRIPTION
Removes indent level number in `:DEFAULT` and `:INF_RUBY` prompt mode.

```
irb(main):001:1> if true
irb(main):002:2>   puts(
irb(main):003:3>     1,
irb(main):004:3>     2,
↓
irb(main):001> if true
irb(main):002>   puts(
irb(main):003>     1,
irb(main):004>     2,
``````

Until irb 1.0.0, auto indent was not enabled by default and this indent level number was useful.
```
irb(main):001:0> IRB::VERSION
=> "1.0.0"
irb(main):002:0> def f
irb(main):003:1> if true
irb(main):004:2> puts(
irb(main):005:3* 1,
irb(main):006:3* 2,
irb(main):007:3* )
irb(main):008:2> end
irb(main):009:1> end
=> :f
```
But now, auto indent is enabled by default. Indent level is identical to next-line's indentation spaces. You can easily know how deep the code is nested without seeing this number. It is just making prompt long.

### Other prompt modes
For `:INF_RUBY` prompt mode, only `PROMPT_I` is present. In this case, indent level number (always zero) is completely useless.
Indent level number still remains in `:CLASSIC` prompt mode.