### PR TITLE
Encapsulate input details in Statement objects

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -582,7 +582,7 @@ module IRB
 
             # Don't echo if the line ends with a semicolon
             if @context.echo? && !statement.suppresses_echo?
-              if statement.is_assignment
+              if statement.is_assignment?
                 if @context.echo_on_assignment?
                   output_value(@context.echo_on_assignment? == :truncate)
                 end

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -236,13 +236,12 @@ class RubyLex
     command_name = @context.command_aliases[command_or_alias.to_sym]
     command = command_name || command_or_alias
     command_class = IRB::ExtendCommandBundle.load_command(command)
-    IRB::Statement.new(
-      code,
-      assignment_expression?(code),
-      command,
-      arg,
-      command_class
-    )
+
+    if command_class
+      IRB::Statement::Command.new(code, command, arg, command_class)
+    else
+      IRB::Statement::Expression.new(code, assignment_expression?(code))
+    end
   end
 
   def assignment_expression?(code)

--- a/lib/irb/statement.rb
+++ b/lib/irb/statement.rb
@@ -2,41 +2,77 @@
 
 module IRB
   class Statement
-    attr_reader :code, :is_assignment
+    attr_reader :code
 
-    def initialize(code, is_assignment, command, arg, command_class)
-      @code = code
-      @is_assignment = is_assignment
-      @command = command
-      @arg = arg
-      @command_class = command_class
+    def is_assignment?
+      raise NotImplementedError
     end
 
     def suppresses_echo?
-      @code.match?(/;\s*\z/)
+      raise NotImplementedError
     end
 
-    # First, let's pass debugging command's input to debugger
-    # Secondly, we need to let debugger evaluate non-command input
-    # Otherwise, the expression will be evaluated in the debugger's main session thread
-    # This is the only way to run the user's program in the expected thread
     def should_be_handled_by_debugger?
-      !@command_class || IRB::ExtendCommand::DebugCommand > @command_class
+      raise NotImplementedError
     end
 
-    # Because IRB accepts symbol aliases, the code user inputs may not be evaluable Ruby code
-    # This method returns code that's evaluable by Ruby
     def evaluable_code
-      return @code unless @command_class
+      raise NotImplementedError
+    end
 
-      # Hook command-specific transformation
-      if @command_class.respond_to?(:transform_args)
-        arg = @command_class.transform_args(@arg)
-      else
-        arg = @arg
+    class Expression < Statement
+      def initialize(code, is_assignment)
+        @code = code
+        @is_assignment = is_assignment
       end
 
-      [@command, arg].compact.join(' ')
+      def suppresses_echo?
+        @code.match?(/;\s*\z/)
+      end
+
+      def should_be_handled_by_debugger?
+        true
+      end
+
+      def is_assignment?
+        @is_assignment
+      end
+
+      def evaluable_code
+        @code
+      end
+    end
+
+    class Command < Statement
+      def initialize(code, command, arg, command_class)
+        @code = code
+        @command = command
+        @arg = arg
+        @command_class = command_class
+      end
+
+      def is_assignment?
+        false
+      end
+
+      def suppresses_echo?
+        false
+      end
+
+      def should_be_handled_by_debugger?
+        IRB::ExtendCommand::DebugCommand > @command_class
+      end
+
+      def evaluable_code
+        # Hook command-specific transformation to return valid Ruby code
+        if @command_class.respond_to?(:transform_args)
+          arg = @command_class.transform_args(@arg)
+        else
+          arg = @arg
+        end
+
+        [@command, arg].compact.join(' ')
+      end
     end
   end
 end


### PR DESCRIPTION
After #575 is merged, a single input can be handled differently under different context. And if we still pass them around as plain text, we always need to parse them whenever we need to perform a check (e.g. if it's a command). It also means the input processing flow is filled with regexp that could be hard to interpret over time.