### PR TITLE
Remove unused `PROMPT_N`

### DIFF
--- a/doc/irb/irb.rd.ja
+++ b/doc/irb/irb.rd.ja
@@ -125,7 +125,6 @@ irb起動時に``~/.irbrc''を読み込みます. もし存在しない場合は
 
    IRB.conf[:PROMPT][:MY_PROMPT] = { # プロンプトモードの名前
      :PROMPT_I => nil,		  # 通常のプロンプト
-     :PROMPT_N => nil,		  # 継続行のプロンプト
      :PROMPT_S => nil,		  # 文字列などの継続行のプロンプト
      :PROMPT_C => nil,		  # 式が継続している時のプロンプト
      :RETURN => "    ==>%s\n"	  # リターン時のプロンプト
@@ -140,7 +139,7 @@ OKです.
 
   IRB.conf[:PROMPT_MODE] = :MY_PROMPT
 
-PROMPT_I, PROMPT_N, PROMPT_S, PROMPT_Cは, フォーマットを指定します.
+PROMPT_I, PROMPT_S, PROMPT_Cは, フォーマットを指定します.
 
   %N	起動しているコマンド名が出力される.
   %m	mainオブジェクト(self)がto_sで出力される.
@@ -155,7 +154,6 @@ PROMPT_I, PROMPT_N, PROMPT_S, PROMPT_Cは, フォーマットを指定します.
 
   IRB.conf[:PROMPT][:DEFAULT] = {
       :PROMPT_I => "%N(%m):%03n:%i> ",
-      :PROMPT_N => "%N(%m):%03n:%i> ",
       :PROMPT_S => "%N(%m):%03n:%i%l ",
       :PROMPT_C => "%N(%m):%03n:%i* ",
       :RETURN => "=> %s\n"

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -196,7 +196,6 @@ require_relative "irb/debug"
 #
 #     IRB.conf[:PROMPT_MODE][:DEFAULT] = {
 #       :PROMPT_I => "%N(%m):%03n> ",
-#       :PROMPT_N => "%N(%m):%03n> ",
 #       :PROMPT_S => "%N(%m):%03n%l ",
 #       :PROMPT_C => "%N(%m):%03n* ",
 #       :RETURN => "%s\n" # used to printf
@@ -206,35 +205,30 @@ require_relative "irb/debug"
 #
 #   # :NULL:
 #   #   :PROMPT_I:
-#   #   :PROMPT_N:
 #   #   :PROMPT_S:
 #   #   :PROMPT_C:
 #   #   :RETURN: |
 #   #     %s
 #   # :DEFAULT:
 #   #   :PROMPT_I: ! '%N(%m):%03n> '
-#   #   :PROMPT_N: ! '%N(%m):%03n> '
 #   #   :PROMPT_S: ! '%N(%m):%03n%l '
 #   #   :PROMPT_C: ! '%N(%m):%03n* '
 #   #   :RETURN: |
 #   #     => %s
 #   # :CLASSIC:
 #   #   :PROMPT_I: ! '%N(%m):%03n:%i> '
-#   #   :PROMPT_N: ! '%N(%m):%03n:%i> '
 #   #   :PROMPT_S: ! '%N(%m):%03n:%i%l '
 #   #   :PROMPT_C: ! '%N(%m):%03n:%i* '
 #   #   :RETURN: |
 #   #     %s
 #   # :SIMPLE:
 #   #   :PROMPT_I: ! '>> '
-#   #   :PROMPT_N: ! '>> '
 #   #   :PROMPT_S:
 #   #   :PROMPT_C: ! '?> '
 #   #   :RETURN: |
 #   #     => %s
 #   # :INF_RUBY:
 #   #   :PROMPT_I: ! '%N(%m):%03n> '
-#   #   :PROMPT_N:
 #   #   :PROMPT_S:
 #   #   :PROMPT_C:
 #   #   :RETURN: |
@@ -242,7 +236,6 @@ require_relative "irb/debug"
 #   #   :AUTO_INDENT: true
 #   # :XMP:
 #   #   :PROMPT_I:
-#   #   :PROMPT_N:
 #   #   :PROMPT_S:
 #   #   :PROMPT_C:
 #   #   :RETURN: |2
@@ -527,8 +520,6 @@ module IRB
           f = @context.prompt_s
         elsif continue
           f = @context.prompt_c
-        elsif indent > 0
-          f = @context.prompt_n
         else
           f = @context.prompt_i
         end

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -229,8 +229,6 @@ module IRB
     #
     # See IRB@Customizing+the+IRB+Prompt for more information.
     attr_accessor :prompt_c
-    # See IRB@Customizing+the+IRB+Prompt for more information.
-    attr_accessor :prompt_n
     # Can be either the default <code>IRB.conf[:AUTO_INDENT]</code>, or the
     # mode set by #prompt_mode=
     #
@@ -414,7 +412,6 @@ module IRB
       @prompt_i = pconf[:PROMPT_I]
       @prompt_s = pconf[:PROMPT_S]
       @prompt_c = pconf[:PROMPT_C]
-      @prompt_n = pconf[:PROMPT_N]
       @return_format = pconf[:RETURN]
       @return_format = "%s\n" if @return_format == nil
       if ai = pconf.include?(:AUTO_INDENT)

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -58,35 +58,30 @@ module IRB # :nodoc:
     @CONF[:PROMPT] = {
       :NULL => {
         :PROMPT_I => nil,
-        :PROMPT_N => nil,
         :PROMPT_S => nil,
         :PROMPT_C => nil,
         :RETURN => "%s\n"
       },
       :DEFAULT => {
         :PROMPT_I => "%N(%m):%03n> ",
-        :PROMPT_N => "%N(%m):%03n> ",
         :PROMPT_S => "%N(%m):%03n%l ",
         :PROMPT_C => "%N(%m):%03n* ",
         :RETURN => "=> %s\n"
       },
       :CLASSIC => {
         :PROMPT_I => "%N(%m):%03n:%i> ",
-        :PROMPT_N => "%N(%m):%03n:%i> ",
         :PROMPT_S => "%N(%m):%03n:%i%l ",
         :PROMPT_C => "%N(%m):%03n:%i* ",
         :RETURN => "%s\n"
       },
       :SIMPLE => {
         :PROMPT_I => ">> ",
-        :PROMPT_N => ">> ",
         :PROMPT_S => "%l> ",
         :PROMPT_C => "?> ",
         :RETURN => "=> %s\n"
       },
       :INF_RUBY => {
         :PROMPT_I => "%N(%m):%03n> ",
-        :PROMPT_N => nil,
         :PROMPT_S => nil,
         :PROMPT_C => nil,
         :RETURN => "%s\n",
@@ -94,7 +89,6 @@ module IRB # :nodoc:
       },
       :XMP => {
         :PROMPT_I => nil,
-        :PROMPT_N => nil,
         :PROMPT_S => nil,
         :PROMPT_C => nil,
         :RETURN => "    ==>%s\n"

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -228,8 +228,7 @@ module TestIRB
           DEFAULT: {
             PROMPT_I: '> ',
             PROMPT_S: '> ',
-            PROMPT_C: '> ',
-            PROMPT_N: '> '
+            PROMPT_C: '> '
           }
         },
         PROMPT_MODE: :DEFAULT,
@@ -258,8 +257,7 @@ module TestIRB
           DEFAULT: {
             PROMPT_I: '> ',
             PROMPT_S: '> ',
-            PROMPT_C: '> ',
-            PROMPT_N: '> '
+            PROMPT_C: '> '
           }
         },
         PROMPT_MODE: :DEFAULT,
@@ -286,8 +284,7 @@ module TestIRB
           DEFAULT: {
             PROMPT_I: '> ',
             PROMPT_S: '> ',
-            PROMPT_C: '> ',
-            PROMPT_N: '> '
+            PROMPT_C: '> '
           }
         },
         PROMPT_MODE: :DEFAULT,
@@ -317,8 +314,7 @@ module TestIRB
           DEFAULT: {
             PROMPT_I: '> ',
             PROMPT_S: '> ',
-            PROMPT_C: '> ',
-            PROMPT_N: '> '
+            PROMPT_C: '> '
           }
         },
         PROMPT_MODE: :DEFAULT,
@@ -348,8 +344,7 @@ module TestIRB
           DEFAULT: {
             PROMPT_I: '> ',
             PROMPT_S: '> ',
-            PROMPT_C: '> ',
-            PROMPT_N: '> '
+            PROMPT_C: '> '
           }
         },
         PROMPT_MODE: :DEFAULT,
@@ -375,8 +370,7 @@ module TestIRB
           DEFAULT: {
             PROMPT_I: '> ',
             PROMPT_S: '> ',
-            PROMPT_C: '> ',
-            PROMPT_N: '> '
+            PROMPT_C: '> '
           }
         },
         PROMPT_MODE: :DEFAULT,

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -454,7 +454,6 @@ module TestIRB
     def test_default_return_format
       IRB.conf[:PROMPT][:MY_PROMPT] = {
         :PROMPT_I => "%03n> ",
-        :PROMPT_N => "%03n> ",
         :PROMPT_S => "%03n> ",
         :PROMPT_C => "%03n> "
         # without :RETURN

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -179,7 +179,6 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     write_irbrc <<~'LINES'
       IRB.conf[:PROMPT][:MY_PROMPT] = {
         :PROMPT_I => "%03n> ",
-        :PROMPT_N => "%03n> ",
         :PROMPT_S => "%03n> ",
         :PROMPT_C => "%03n> "
       }
@@ -214,7 +213,6 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     write_irbrc <<~'LINES'
       IRB.conf[:PROMPT][:MY_PROMPT] = {
         :PROMPT_I => "%03n> ",
-        :PROMPT_N => "%03n> ",
         :PROMPT_S => "%03n> ",
         :PROMPT_C => "%03n> "
       }


### PR DESCRIPTION
Since #500 ([revision `364a6d56`](https://bugs.ruby-lang.org/projects/ruby-master/repository/git/revisions/364a6d56d776270da09604816d623047c66c5e32)), the `PROMPT_N` prompt format is no longer used (explanation follows). This change removes it.

---

The only usage of `PROMPT_N`'s value is in `IRB::Irb#eval_input`:

<https://github.com/ruby/irb/blob/65e8e6869075c47c95591f1d12175eb6377b8a9f/lib/irb.rb#L522-L534>

In order for `@context.prompt_n` to be used here, `continue` must be falsey and `indent` must be positive.

That block given to `set_prompt` is called only by`RubyLex#prompt`:

<https://github.com/ruby/irb/blob/65e8e6869075c47c95591f1d12175eb6377b8a9f/lib/irb/ruby-lex.rb#L157-L161>

In order to satisfy the conditions above, `opens` must be empty (technically [it could also be populated with only falsey values](https://thoughtbot.com/blog/any-empty), but that's not the case here) and `calc_indent_level(opens)` must be positive.

`RubyLex#calc_indent_level` is defined as:

<https://github.com/ruby/irb/blob/65e8e6869075c47c95591f1d12175eb6377b8a9f/lib/irb/ruby-lex.rb#L365-L388>

If `opens` is empty, then the block given to `opens.each_with_index` will never be evaluated, and `calc_indent_level` will return the initial value of `indent_level`: `0`. Therefore `calc_indent_level(opens)` cannot be positive while `opens` is empty.

Since these conditions cannot be satisfied, `PROMPT_N` will never be used.

---

However, maybe it's unintended that `PROMPT_N` is unused now, in which case I can close this PR.