### PR TITLE
Support `VISUAL` env var, and prefer it over `EDITOR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Debugging
   info           Start the debugger of debug.gem and run its `info` command.
 
 Misc
-  edit           Open a file with the editor command defined with `ENV["EDITOR"]`.
+  edit           Open a file with the editor command defined with `ENV["VISUAL"]` or `ENV["EDITOR"]`.
   measure        `measure` enables the mode to measure processing time. `measure :off` disables it.
 
 Context
@@ -135,7 +135,8 @@ Context
 
 - `NO_COLOR`: Assigning a value to it disables IRB's colorization.
 - `IRB_USE_AUTOCOMPLETE`: Setting it to `false` disables IRB's autocompletion.
-- `EDITOR`: Its value would be used to open files by the `edit` command.
+- `VISUAL`: Its value would be used to open files by the `edit` command.
+- `EDITOR`: Its value would be used to open files by the `edit` command if `VISUAL` is unset.
 - `IRBRC`: The file specified would be evaluated as IRB's rc-file.
 
 ## Documentation

--- a/lib/irb/cmd/edit.rb
+++ b/lib/irb/cmd/edit.rb
@@ -8,7 +8,7 @@ module IRB
   module ExtendCommand
     class Edit < Nop
       category "Misc"
-      description 'Open a file with the editor command defined with `ENV["EDITOR"]`.'
+      description 'Open a file with the editor command defined with `ENV["VISUAL"]` or `ENV["EDITOR"]`.'
 
       class << self
         def transform_args(args)
@@ -45,12 +45,12 @@ module IRB
           end
         end
 
-        if editor = ENV['EDITOR']
+        if editor = (ENV['VISUAL'] || ENV['EDITOR'])
           puts "command: '#{editor}'"
           puts "   path: #{path}"
           system(*Shellwords.split(editor), path)
         else
-          puts "Can not find editor setting: ENV['EDITOR']"
+          puts "Can not find editor setting: ENV['VISUAL'] or ENV['EDITOR']"
         end
       end
     end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -914,12 +914,15 @@ module TestIRB
 
   class EditTest < CommandTestCase
     def setup
+      @original_visual = ENV["VISUAL"]
       @original_editor = ENV["EDITOR"]
       # noop the command so nothing gets executed
-      ENV["EDITOR"] = ": code"
+      ENV["VISUAL"] = ": code"
+      ENV["EDITOR"] = ": code2"
     end
 
     def teardown
+      ENV["VISUAL"] = @original_visual
       ENV["EDITOR"] = @original_editor
     end
 
@@ -981,6 +984,21 @@ module TestIRB
       assert_empty err
       assert_match(/path: .*\/lib\/irb\.rb/, out)
       assert_match("command: ': code'", out)
+    end
+
+    def test_edit_with_editor_env_var
+      original_visual = ENV.delete("VISUAL")
+
+      out, err = execute_lines(
+        "edit",
+        irb_path: __FILE__
+      )
+
+      assert_empty err
+      assert_match("path: #{__FILE__}", out)
+      assert_match("command: ': code2'", out)
+
+      ENV["VISUAL"] = original_visual
     end
   end
 end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -987,7 +987,7 @@ module TestIRB
     end
 
     def test_edit_with_editor_env_var
-      original_visual = ENV.delete("VISUAL")
+      ENV.delete("VISUAL")
 
       out, err = execute_lines(
         "edit",
@@ -997,8 +997,6 @@ module TestIRB
       assert_empty err
       assert_match("path: #{__FILE__}", out)
       assert_match("command: ': code2'", out)
-
-      ENV["VISUAL"] = original_visual
     end
   end
 end


### PR DESCRIPTION
The [`edit` command](https://github.com/ruby/irb/blob/66e69fa0dc91b38aedf17f897c70f4da6cca3052/lib/irb/cmd/edit.rb) currently only uses the `EDITOR` environment variable to know which command to run to open that editor. It should also use the `VISUAL` environment variable, and it should prefer it over `EDITOR`.

See [this StackExchange answer](https://unix.stackexchange.com/a/4861) for some context:

> The `EDITOR` editor should be able to work without use of "advanced" terminal functionality (like old `ed` or `ex` mode of `vi`). It was used on teletype terminals.
> 
> A `VISUAL` editor could be a full screen editor as `vi` or `emacs`.
> 
> E.g. if you invoke an editor through bash (using `C-x C-e`), bash will try first `VISUAL` editor and then, if `VISUAL` fails (because terminal does not support a full-screen editor), it tries `EDITOR`.
> 
> Nowadays, you can leave `EDITOR` unset or set it to `vi -e`.

This pull request changes the `edit` command to first look for a value for `VISUAL`, then if `VISUAL` is unset, look for a value for `EDITOR`.

---

I've previously made [this same change in Rails](https://github.com/rails/rails/pull/48374).

[Pry also uses `VISUAL`](https://github.com/pry/pry/blob/52799c4902cca764f052ae7ded5361bc50feaf57/lib/pry/editor.rb#L8-L14) (<https://github.com/pry/pry/pull/211>).