### PR TITLE
Avoid overriding user's `irb_name` setting in debugger integration

### DIFF
--- a/lib/irb/debug.rb
+++ b/lib/irb/debug.rb
@@ -73,7 +73,7 @@ module IRB
         require 'irb/debug/ui'
         IRB.instance_variable_set(:@debugger_irb, irb)
         irb.context.with_debugger = true
-        irb.context.irb_name = "irb:rdbg"
+        irb.context.irb_name += ":rdbg"
       end
 
       def binding_irb?

--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -83,6 +83,9 @@ module TestIRB
     TIMEOUT_SEC = 3
 
     def setup
+      @envs = {}
+      @tmpfiles = []
+
       unless defined?(PTY)
         omit "Integration tests require PTY."
       end
@@ -90,8 +93,12 @@ module TestIRB
       if ruby_core?
         omit "This test works only under ruby/irb"
       end
+    end
 
-      @envs = {}
+    def teardown
+      @tmpfiles.each do |tmpfile|
+        File.unlink(tmpfile)
+      end
     end
 
     def run_ruby_file(&block)
@@ -133,7 +140,6 @@ module TestIRB
       MSG
       assert_block(message) { false }
     ensure
-      File.unlink(@ruby_file) if @ruby_file
       FileUtils.remove_entry tmp_dir
     end
 
@@ -180,8 +186,17 @@ module TestIRB
 
     def write_ruby(program)
       @ruby_file = Tempfile.create(%w{irb- .rb})
+      @tmpfiles << @ruby_file
       @ruby_file.write(program)
       @ruby_file.close
+    end
+
+    def write_rc(content)
+      @irbrc = Tempfile.new('irbrc')
+      @tmpfiles << @irbrc
+      @irbrc.write(content)
+      @irbrc.close
+      @envs['IRBRC'] = @irbrc.path
     end
   end
 end

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -289,6 +289,30 @@ module TestIRB
       assert_match(/irb:rdbg\(main\):005> next/, output)
     end
 
+    def test_prompt_irb_name_is_kept
+      @irbrc = Tempfile.new('irbrc')
+      @irbrc.write <<~RUBY
+        IRB.conf[:IRB_NAME] = "foo"
+      RUBY
+      @irbrc.close
+      @envs['IRBRC'] = @irbrc.path
+
+      write_ruby <<~'ruby'
+        binding.irb
+        puts "Hello"
+      ruby
+
+      output = run_ruby_file do
+        type "next"
+        type "continue"
+      end
+
+      assert_match(/foo\(main\):001> next/, output)
+      assert_match(/foo:rdbg\(main\):002> continue/, output)
+    ensure
+      @irbrc&.unlink
+    end
+
     def test_irb_commands_are_available_after_moving_around_with_the_debugger
       write_ruby <<~'ruby'
         class Foo

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -290,12 +290,9 @@ module TestIRB
     end
 
     def test_prompt_irb_name_is_kept
-      @irbrc = Tempfile.new('irbrc')
-      @irbrc.write <<~RUBY
+      write_rc <<~RUBY
         IRB.conf[:IRB_NAME] = "foo"
       RUBY
-      @irbrc.close
-      @envs['IRBRC'] = @irbrc.path
 
       write_ruby <<~'ruby'
         binding.irb
@@ -309,8 +306,6 @@ module TestIRB
 
       assert_match(/foo\(main\):001> next/, output)
       assert_match(/foo:rdbg\(main\):002> continue/, output)
-    ensure
-      @irbrc&.unlink
     end
 
     def test_irb_commands_are_available_after_moving_around_with_the_debugger

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -326,12 +326,9 @@ module TestIRB
       @history_file = Tempfile.new('irb_history')
       @history_file.write(history)
       @history_file.close
-      @irbrc = Tempfile.new('irbrc')
-      @irbrc.write <<~RUBY
+      write_rc <<~RUBY
         IRB.conf[:HISTORY_FILE] = "#{@history_file.path}"
       RUBY
-      @irbrc.close
-      @envs['IRBRC'] = @irbrc.path
     end
   end
 end


### PR DESCRIPTION
Instead of always setting `irb_name` to `irb:rdbg`, it should respect the user's setting and only append `:rdbg` to it.