### PR TITLE
Print deprecation message for prompt_n methods

### DIFF
--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -229,6 +229,19 @@ module IRB
     #
     # See IRB@Customizing+the+IRB+Prompt for more information.
     attr_accessor :prompt_c
+
+    # TODO: Remove this when developing v2.0
+    def prompt_n
+      warn "IRB::Context#prompt_n is deprecated and will be removed in the next major release."
+      ""
+    end
+
+    # TODO: Remove this when developing v2.0
+    def prompt_n=(_)
+      warn "IRB::Context#prompt_n= is deprecated and will be removed in the next major release."
+      ""
+    end
+
     # Can be either the default <code>IRB.conf[:AUTO_INDENT]</code>, or the
     # mode set by #prompt_mode=
     #

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -90,6 +90,18 @@ module TestIRB
         ], out)
     end
 
+    def test_prompt_n_deprecation
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new))
+
+      out, err = capture_output do
+        irb.context.prompt_n = "foo"
+        irb.context.prompt_n
+      end
+
+      assert_include err, "IRB::Context#prompt_n is deprecated"
+      assert_include err, "IRB::Context#prompt_n= is deprecated"
+    end
+
     def test_output_to_pipe
       require 'stringio'
       input = TestInputMethod.new(["n=1"])


### PR DESCRIPTION
They were removed in #685, but we should still keep them to avoid breaking changes to tools like Chef.

https://github.com/chef/chef/blob/533ff089479763f29045e4e6ddf388b73fc99338/lib/chef/shell.rb#L138