### PR TITLE
Improve help/show_cmds message during debugger integration

### DIFF
--- a/lib/irb/cmd/show_cmds.rb
+++ b/lib/irb/cmd/show_cmds.rb
@@ -15,6 +15,16 @@ module IRB
       def execute(*args)
         commands_info = IRB::ExtendCommandBundle.all_commands_info
         commands_grouped_by_categories = commands_info.group_by { |cmd| cmd[:category] }
+
+        if irb_context.with_debugger
+          # Remove the original "Debugging" category
+          commands_grouped_by_categories.delete("Debugging")
+          # Remove the `help` command as it's delegated to the debugger
+          commands_grouped_by_categories["Context"].delete_if { |cmd| cmd[:display_name] == :help }
+          # Add an empty "Debugging (from debug.gem)" category at the end
+          commands_grouped_by_categories["Debugging (from debug.gem)"] = []
+        end
+
         longest_cmd_name_length = commands_info.map { |c| c[:display_name].length }.max
 
         output = StringIO.new
@@ -27,6 +37,11 @@ module IRB
           end
 
           output.puts
+        end
+
+        # Append the debugger help at the end
+        if irb_context.with_debugger
+          output.puts DEBUGGER__.help
         end
 
         Pager.page_content(output.string)

--- a/lib/irb/statement.rb
+++ b/lib/irb/statement.rb
@@ -60,7 +60,9 @@ module IRB
       end
 
       def should_be_handled_by_debugger?
-        IRB::ExtendCommand::DebugCommand > @command_class
+        require_relative 'cmd/help'
+        require_relative 'cmd/debug'
+        IRB::ExtendCommand::DebugCommand > @command_class || IRB::ExtendCommand::Help == @command_class
       end
 
       def evaluable_code

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -331,6 +331,20 @@ module TestIRB
       assert_include(output, "InputMethod: RelineInputMethod")
     end
 
+    def test_help_command_is_delegated_to_the_debugger
+      write_ruby <<~'ruby'
+        binding.irb
+      ruby
+
+      output = run_ruby_file do
+        type "debug"
+        type "help"
+        type "continue"
+      end
+
+      assert_include(output, "### Frame control")
+    end
+
     def test_input_is_evaluated_in_the_context_of_the_current_thread
       write_ruby <<~'ruby'
         current_thread = Thread.current

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -345,6 +345,25 @@ module TestIRB
       assert_include(output, "### Frame control")
     end
 
+    def test_show_cmds_display_different_content_when_debugger_is_enabled
+      write_ruby <<~'ruby'
+        # disable pager
+        STDIN.singleton_class.define_method(:tty?) { false }
+        binding.irb
+      ruby
+
+      output = run_ruby_file do
+        type "debug"
+        type "show_cmds"
+        type "continue"
+      end
+
+      # IRB's commands should still be listed
+      assert_match(/show_cmds\s+List all available commands and their description\./, output)
+      # debug gem's commands should be appended at the end
+      assert_match(/Debugging \(from debug\.gem\)\s+### Control flow/, output)
+    end
+
     def test_input_is_evaluated_in_the_context_of_the_current_thread
       write_ruby <<~'ruby'
         current_thread = Thread.current


### PR DESCRIPTION
1. When in the `irb:rdbg` session, IRB should pass `help` command to the debugger, instead of invoking ri.
2. `show_cmds` should update its content when in the `irb:rdbg` session:
    - It should remove the old `Debugging` session as they're not useful in that context.
    - It should also remove `help` due to the change of 1)
    - Finally, I think it's better to append `debug`'s help message at the end of its output, so users don't need to learn when to use `show_cmds` and when to use `help`. 