### PR TITLE
Fix deprecation test when ran multiple times

### DIFF
--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -203,11 +203,10 @@ module TestIRB
     end
 
     def test_initialising_the_old_top_level_ruby_lex
-      _, err = capture_output do
+      assert_in_out_err(["--disable-gems", "-W:deprecated"], <<~RUBY, [], /warning: constant ::RubyLex is deprecated/)
+        require "irb"
         ::RubyLex.new(nil)
-      end
-
-      assert_match(/warning: constant ::RubyLex is deprecated/, err)
+      RUBY
     end
 
     private


### PR DESCRIPTION
The deprecation warning is only printed on the first time the test is ran, so subsequent runs will fail because the error message will not be printed. This can be seen in the Ruby CI logs such as http://ci.rvm.jp/results/trunk-repeat50@ruby-sp2-docker/4696313:

    1) Failure:
    TestIRB::RubyLexTest#test_initialising_the_old_top_level_ruby_lex [/tmp/ruby/src/trunk-repeat50/test/irb/test_ruby_lex.rb:210]:
    Expected /warning: constant ::RubyLex is deprecated/ to match "".

It can also be reproduced in the Ruby repo with the following test command:

    make test/irb/test_ruby_lex.rb TESTOPTS=--repeat-count=2

This commit changes the test to use assert_in_out_err, which spawns a new Ruby process.