### PR TITLE
Fix test warnings

### DIFF
--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -93,7 +93,7 @@ module TestIRB
     def test_prompt_n_deprecation
       irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new))
 
-      out, err = capture_output do
+      _, err = capture_output do
         irb.context.prompt_n = "foo"
         irb.context.prompt_n
       end

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -94,8 +94,8 @@ module TestIRB
     end
 
     def setup
-      @irb = build_irb
       save_encodings
+      @irb = build_irb
     end
 
     def teardown


### PR DESCRIPTION
1. Encodings should be saved before creating `Irb` objects as the creation itself changes the encoding already.
2. Avoid assigning the `out` variable when it's not needed.