### PR TITLE
Decouple RubyLex from prompt and line_no

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -437,6 +437,7 @@ module IRB
       @context.workspace.load_commands_to_main
       @signal_status = :IN_IRB
       @scanner = RubyLex.new
+      @line_no = 1
     end
 
     # A hook point for `debug` command's breakpoint after :IRB_EXIT as well as its clean-up
@@ -454,7 +455,7 @@ module IRB
       workspace = IRB::WorkSpace.new(binding)
       context.workspace = workspace
       context.workspace.load_commands_to_main
-      scanner.increase_line_no(1)
+      @line_no += 1
 
       # When users run:
       # 1. Debugging commands, like `step 2`
@@ -476,7 +477,7 @@ module IRB
       end
 
       if input&.include?("\n")
-        scanner.increase_line_no(input.count("\n") - 1)
+        @line_no += input.count("\n") - 1
       end
 
       input
@@ -513,34 +514,38 @@ module IRB
     # The lexer used by this irb session
     attr_accessor :scanner
 
+    def prompt(opens, continue, line_offset)
+      ltype = @scanner.ltype_from_open_tokens(opens)
+      indent = @scanner.calc_indent_level(opens)
+      continue = opens.any? || continue
+      line_no = @line_no + line_offset
+
+      if ltype
+        f = @context.prompt_s
+      elsif continue
+        f = @context.prompt_c
+      else
+        f = @context.prompt_i
+      end
+      f = "" unless f
+      if @context.prompting?
+        p = format_prompt(f, ltype, indent, line_no)
+      else
+        p = ""
+      end
+      if @context.auto_indent_mode and !@context.io.respond_to?(:auto_indent)
+        unless ltype
+          prompt_i = @context.prompt_i.nil? ? "" : @context.prompt_i
+          ind = format_prompt(prompt_i, ltype, indent, line_no)[/.*\z/].size +
+            indent * 2 - p.size
+          p += " " * ind if ind > 0
+        end
+      end
+      p
+    end
+
     # Evaluates input for this session.
     def eval_input
-      @scanner.set_prompt do
-        |ltype, indent, continue, line_no|
-        if ltype
-          f = @context.prompt_s
-        elsif continue
-          f = @context.prompt_c
-        else
-          f = @context.prompt_i
-        end
-        f = "" unless f
-        if @context.prompting?
-          @context.io.prompt = p = prompt(f, ltype, indent, line_no)
-        else
-          @context.io.prompt = p = ""
-        end
-        if @context.auto_indent_mode and !@context.io.respond_to?(:auto_indent)
-          unless ltype
-            prompt_i = @context.prompt_i.nil? ? "" : @context.prompt_i
-            ind = prompt(prompt_i, ltype, indent, line_no)[/.*\z/].size +
-              indent * 2 - p.size
-            @context.io.prompt = p + " " * ind if ind > 0
-          end
-        end
-        @context.io.prompt
-      end
-
       configure_io
 
       each_top_level_statement do |statement, line_no|
@@ -572,8 +577,9 @@ module IRB
       end
     end
 
-    def read_input
+    def read_input(prompt_string)
       signal_status(:IN_INPUT) do
+        @context.io.prompt = prompt_string
         if l = @context.io.gets
           print l if @context.verbose?
         else
@@ -591,16 +597,16 @@ module IRB
     end
 
     def readmultiline
-      @scanner.save_prompt_to_context_io([], false, 0)
+      prompt_string = prompt([], false, 0)
 
       # multiline
-      return read_input if @context.io.respond_to?(:check_termination)
+      return read_input(prompt_string) if @context.io.respond_to?(:check_termination)
 
       # nomultiline
       code = ''
       line_offset = 0
       loop do
-        line = read_input
+        line = read_input(prompt_string)
         unless line
           return code.empty? ? nil : code
         end
@@ -615,7 +621,7 @@ module IRB
 
         line_offset += 1
         continue = @scanner.should_continue?(tokens)
-        @scanner.save_prompt_to_context_io(opens, continue, line_offset)
+        prompt_string = prompt(opens, continue, line_offset)
       end
     end
 
@@ -625,9 +631,9 @@ module IRB
         break unless code
 
         if code != "\n"
-          yield build_statement(code), @scanner.line_no
+          yield build_statement(code), @line_no
         end
-        @scanner.increase_line_no(code.count("\n"))
+        @line_no += code.count("\n")
       rescue RubyLex::TerminateLineInput
       end
     end
@@ -688,7 +694,7 @@ module IRB
               tokens_until_line << token if token != tokens_until_line.last
             end
             continue = @scanner.should_continue?(tokens_until_line)
-            @scanner.prompt(next_opens, continue, line_num_offset)
+            prompt(next_opens, continue, line_num_offset)
           end
         end
       end
@@ -883,9 +889,8 @@ module IRB
       end
     end
 
-    def prompt(prompt, ltype, indent, line_no) # :nodoc:
-      p = prompt.dup
-      p.gsub!(/%([0-9]+)?([a-zA-Z])/) do
+    def format_prompt(format, ltype, indent, line_no) # :nodoc:
+      format.gsub(/%([0-9]+)?([a-zA-Z])/) do
         case $2
         when "N"
           @context.irb_name
@@ -919,7 +924,6 @@ module IRB
           "%"
         end
       end
-      p
     end
 
     def output_value(omit = false) # :nodoc:

--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -42,13 +42,6 @@ module IRB
       end
     end
 
-    attr_reader :line_no
-
-    def initialize
-      @line_no = 1
-      @prompt = nil
-    end
-
     def self.compile_with_errors_suppressed(code, line_no: 1)
       begin
         result = yield code, line_no
@@ -64,10 +57,6 @@ module IRB
         result = yield code, line_no
       end
       result
-    end
-
-    def set_prompt(&block)
-      @prompt = block
     end
 
     ERROR_TOKENS = [
@@ -145,12 +134,6 @@ module IRB
       $VERBOSE = verbose
     end
 
-    def prompt(opens, continue, line_num_offset)
-      ltype = ltype_from_open_tokens(opens)
-      indent_level = calc_indent_level(opens)
-      @prompt&.call(ltype, indent_level, opens.any? || continue, @line_no + line_num_offset)
-    end
-
     def check_code_state(code, local_variables:)
       tokens = self.class.ripper_lex_without_warning(code, local_variables: local_variables)
       opens = NestingParser.open_tokens(tokens)
@@ -168,15 +151,6 @@ module IRB
       when :valid
         !should_continue?(tokens)
       end
-    end
-
-    def save_prompt_to_context_io(opens, continue, line_num_offset)
-      # Implicitly saves prompt string to `@context.io.prompt`. This will be used in the next `@input.call`.
-      prompt(opens, continue, line_num_offset)
-    end
-
-    def increase_line_no(addition)
-      @line_no += addition
     end
 
     def assignment_expression?(code, local_variables:)

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -614,21 +614,21 @@ module TestIRB
     def test_prompt_main_escape
       main = Struct.new(:to_s).new("main\a\t\r\n")
       irb = IRB::Irb.new(IRB::WorkSpace.new(main), TestInputMethod.new)
-      assert_equal("irb(main    )>", irb.format_prompt('irb(%m)>', nil, 1, 1))
+      assert_equal("irb(main    )>", irb.send(:format_prompt, 'irb(%m)>', nil, 1, 1))
     end
 
     def test_prompt_main_inspect_escape
       main = Struct.new(:inspect).new("main\\n\nmain")
       irb = IRB::Irb.new(IRB::WorkSpace.new(main), TestInputMethod.new)
-      assert_equal("irb(main\\n main)>", irb.format_prompt('irb(%M)>', nil, 1, 1))
+      assert_equal("irb(main\\n main)>", irb.send(:format_prompt, 'irb(%M)>', nil, 1, 1))
     end
 
     def test_prompt_main_truncate
       main = Struct.new(:to_s).new("a" * 100)
       def main.inspect; to_s.inspect; end
       irb = IRB::Irb.new(IRB::WorkSpace.new(main), TestInputMethod.new)
-      assert_equal('irb(aaaaaaaaaaaaaaaaaaaaaaaaaaaaa...)>', irb.format_prompt('irb(%m)>', nil, 1, 1))
-      assert_equal('irb("aaaaaaaaaaaaaaaaaaaaaaaaaaaa...)>', irb.format_prompt('irb(%M)>', nil, 1, 1))
+      assert_equal('irb(aaaaaaaaaaaaaaaaaaaaaaaaaaaaa...)>', irb.send(:format_prompt, 'irb(%m)>', nil, 1, 1))
+      assert_equal('irb("aaaaaaaaaaaaaaaaaaaaaaaaaaaa...)>', irb.send(:format_prompt, 'irb(%M)>', nil, 1, 1))
     end
 
     def test_lineno

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -614,21 +614,21 @@ module TestIRB
     def test_prompt_main_escape
       main = Struct.new(:to_s).new("main\a\t\r\n")
       irb = IRB::Irb.new(IRB::WorkSpace.new(main), TestInputMethod.new)
-      assert_equal("irb(main    )>", irb.prompt('irb(%m)>', nil, 1, 1))
+      assert_equal("irb(main    )>", irb.format_prompt('irb(%m)>', nil, 1, 1))
     end
 
     def test_prompt_main_inspect_escape
       main = Struct.new(:inspect).new("main\\n\nmain")
       irb = IRB::Irb.new(IRB::WorkSpace.new(main), TestInputMethod.new)
-      assert_equal("irb(main\\n main)>", irb.prompt('irb(%M)>', nil, 1, 1))
+      assert_equal("irb(main\\n main)>", irb.format_prompt('irb(%M)>', nil, 1, 1))
     end
 
     def test_prompt_main_truncate
       main = Struct.new(:to_s).new("a" * 100)
       def main.inspect; to_s.inspect; end
       irb = IRB::Irb.new(IRB::WorkSpace.new(main), TestInputMethod.new)
-      assert_equal('irb(aaaaaaaaaaaaaaaaaaaaaaaaaaaaa...)>', irb.prompt('irb(%m)>', nil, 1, 1))
-      assert_equal('irb("aaaaaaaaaaaaaaaaaaaaaaaaaaaa...)>', irb.prompt('irb(%M)>', nil, 1, 1))
+      assert_equal('irb(aaaaaaaaaaaaaaaaaaaaaaaaaaaaa...)>', irb.format_prompt('irb(%m)>', nil, 1, 1))
+      assert_equal('irb("aaaaaaaaaaaaaaaaaaaaaaaaaaaa...)>', irb.format_prompt('irb(%M)>', nil, 1, 1))
     end
 
     def test_lineno

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -709,7 +709,7 @@ module TestIRB
 
       def assert_dynamic_prompt(input_with_prompt)
         expected_prompt_list, lines = input_with_prompt.transpose
-        def @irb.prompt(opens, continue, line_offset)
+        def @irb.generate_prompt(opens, continue, line_offset)
           ltype = @scanner.ltype_from_open_tokens(opens)
           indent = @scanner.calc_indent_level(opens)
           continue = opens.any? || continue

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -75,7 +75,6 @@ module TestIRB
 
       def initialize(*params)
         @params = params
-        @calculated_indent
       end
 
       def auto_indent(&block)
@@ -84,14 +83,14 @@ module TestIRB
     end
 
     class MockIO_DynamicPrompt
+      attr_reader :prompt_list
+
       def initialize(params, &assertion)
         @params = params
-        @assertion = assertion
       end
 
       def dynamic_prompt(&block)
-        result = block.call(@params)
-        @assertion.call(result)
+        @prompt_list = block.call(@params)
       end
     end
 
@@ -710,24 +709,25 @@ module TestIRB
 
       def assert_dynamic_prompt(input_with_prompt)
         expected_prompt_list, lines = input_with_prompt.transpose
-        dynamic_prompt_executed = false
-        io = MockIO_DynamicPrompt.new(lines) do |prompt_list|
-          error_message = <<~EOM
-            Expected dynamic prompt:
-            #{expected_prompt_list.join("\n")}
-
-            Actual dynamic prompt:
-            #{prompt_list.join("\n")}
-          EOM
-          dynamic_prompt_executed = true
-          assert_equal(expected_prompt_list, prompt_list, error_message)
-        end
-        @irb.context.io = io
-        @irb.scanner.set_prompt do |ltype, indent, continue, line_no|
+        def @irb.prompt(opens, continue, line_offset)
+          ltype = @scanner.ltype_from_open_tokens(opens)
+          indent = @scanner.calc_indent_level(opens)
+          continue = opens.any? || continue
+          line_no = @line_no + line_offset
           '%03d:%01d:%1s:%s ' % [line_no, indent, ltype, continue ? '*' : '>']
         end
+        io = MockIO_DynamicPrompt.new(lines)
+        @irb.context.io = io
         @irb.configure_io
-        assert dynamic_prompt_executed, "dynamic_prompt's assertions were not executed."
+
+        error_message = <<~EOM
+          Expected dynamic prompt:
+          #{expected_prompt_list.join("\n")}
+
+          Actual dynamic prompt:
+          #{io.prompt_list.join("\n")}
+        EOM
+        assert_equal(expected_prompt_list, io.prompt_list, error_message)
       end
     end
 


### PR DESCRIPTION
Removes the last RubyLex's instance variable `@prompt` and `@line_no`.

Reason:
`@line_no` is completely controlled by IRB::Irb with `@scanner.increase_line_no`. It should be IRB::Irb's instance variable.
`@scanner.set_prompt do end` and `@scanner.prompt(args)` seems roundabout.
I wanted to remove `save_prompt_to_context_io` because the flow is complex and hard to understand.

After deleting `@prompt` and `@line_no` from RubyLex, RubyLex will have no state at all. RubyLex does not have to be a class anymore.
