### PR TITLE
Require Reline 0.3.8+

### DIFF
--- a/irb.gemspec
+++ b/irb.gemspec
@@ -41,6 +41,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 2.7")
 
-  spec.add_dependency "reline", ">= 0.3.6"
+  spec.add_dependency "reline", ">= 0.3.8"
   spec.add_dependency "rdoc", "~> 6.5"
 end


### PR DESCRIPTION
Reline 0.3.8 reduces the chance of having a deadlock with the debugger while using the new `irb:rdbg` integration.