### PR TITLE
Drop rdoc's version requirement

### DIFF
--- a/irb.gemspec
+++ b/irb.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.7")
 
   spec.add_dependency "reline", ">= 0.3.8"
-  spec.add_dependency "rdoc", "~> 6.5"
+  spec.add_dependency "rdoc"
 end


### PR DESCRIPTION
1. The newer versions of rdoc requires pysch 4.0+, which could break apps using Ruby 3.0 or 2.7. #703 has more detailed explanation on this.
2. We actually don't use any version-specific rdoc APIs. So having a version requirement is not necessary atm.

Closes #703 