### PR TITLE
Mention `irb_debug` alternative in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Context
 
 Starting from version 1.8.0, IRB boasts a powerful integration with `debug.gem`, providing a debugging experience akin to `pry-byebug`.
 
-After hitting a `binding.irb` breakpoint, you can activate the debugger with the `debug` command.
+After hitting a `binding.irb` breakpoint, you can activate the debugger with the `debug` command. Alternatively, if the `debug` method happens to already be defined in the current scope, you can call `irb_debug`.
 
 ```shell
 From: test.rb @ line 3 :


### PR DESCRIPTION
When starting an IRB session via `binding.irb` inside a Rails view template, the `debug` method cannot be used because it's already defined in Action View.

I only found out about `irb_debug` from the IRB warning `can't alias debug from irb_debug`, so I thought it would be useful to mention it in the documentation.
