### PR TITLE
Replace completion procs with class methods

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -56,8 +56,6 @@ module IRB
       yield
     ]
 
-    BASIC_WORD_BREAK_CHARACTERS = " \t\n`><=;|&{("
-
     GEM_PATHS =
       if defined?(Gem::Specification)
         Gem::Specification.latest_specs(true).map { |s|

--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -443,11 +443,4 @@ module IRB
       }
     end
   end
-
-  begin
-    require 'rdoc/ri/driver'
-    InputCompletor = RegexpCompletor.new(RDoc::RI::Driver.new)
-  rescue LoadError
-    InputCompletor = RegexpCompletor.new(nil)
-  end
 end

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -11,6 +11,8 @@ require 'reline'
 
 module IRB
   class InputMethod
+    BASIC_WORD_BREAK_CHARACTERS = " \t\n`><=;|&{("
+
     # The irb prompt associated with this input method
     attr_accessor :prompt
 
@@ -181,7 +183,7 @@ module IRB
       @eof = false
 
       if Readline.respond_to?("basic_word_break_characters=")
-        Readline.basic_word_break_characters = IRB::InputCompletor::BASIC_WORD_BREAK_CHARACTERS
+        Readline.basic_word_break_characters = BASIC_WORD_BREAK_CHARACTERS
       end
       Readline.completion_append_character = nil
       Readline.completion_proc = IRB::InputCompletor.method(:complete)
@@ -231,7 +233,7 @@ module IRB
 
       @eof = false
 
-      Reline.basic_word_break_characters = IRB::InputCompletor::BASIC_WORD_BREAK_CHARACTERS
+      Reline.basic_word_break_characters = BASIC_WORD_BREAK_CHARACTERS
       Reline.completion_append_character = nil
       Reline.completer_quote_characters = ''
       Reline.completion_proc = IRB::InputCompletor.method(:complete)

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -184,7 +184,7 @@ module IRB
         Readline.basic_word_break_characters = IRB::InputCompletor::BASIC_WORD_BREAK_CHARACTERS
       end
       Readline.completion_append_character = nil
-      Readline.completion_proc = IRB::InputCompletor::CompletionProc
+      Readline.completion_proc = IRB::InputCompletor.method(:complete)
     end
 
     # Reads the next line from this input method.
@@ -234,7 +234,7 @@ module IRB
       Reline.basic_word_break_characters = IRB::InputCompletor::BASIC_WORD_BREAK_CHARACTERS
       Reline.completion_append_character = nil
       Reline.completer_quote_characters = ''
-      Reline.completion_proc = IRB::InputCompletor::CompletionProc
+      Reline.completion_proc = IRB::InputCompletor.method(:complete)
       Reline.output_modifier_proc =
         if IRB.conf[:USE_COLORIZE]
           proc do |output, complete: |
@@ -247,7 +247,7 @@ module IRB
             Reline::Unicode.escape_for_print(output)
           end
         end
-      Reline.dig_perfect_match_proc = IRB::InputCompletor::PerfectMatchedProc
+      Reline.dig_perfect_match_proc = IRB::InputCompletor.method(:display_doc)
       Reline.autocompletion = IRB.conf[:USE_AUTOCOMPLETE]
 
       if IRB.conf[:USE_AUTOCOMPLETE]

--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -61,20 +61,27 @@ module TestIRB
       end
     end
 
+    # It prevents new rdoc require as well as unset any cached rdoc components
     def without_rdoc(&block)
       ::Kernel.send(:alias_method, :irb_original_require, :require)
-
       ::Kernel.define_method(:require) do |name|
         raise LoadError, "cannot load such file -- rdoc (test)" if name.match?("rdoc") || name.match?(/^rdoc\/.*/)
         ::Kernel.send(:irb_original_require, name)
       end
 
+      IRB::InputCompletor.singleton_class.send(:alias_method, :original_rdoc_driver, :rdoc_driver)
+      IRB::InputCompletor.define_singleton_method :rdoc_driver do
+        nil
+      end
+
       yield
     ensure
-      EnvUtil.suppress_warning {
+      EnvUtil.suppress_warning do
         ::Kernel.send(:alias_method, :require, :irb_original_require)
         ::Kernel.undef_method :irb_original_require
-      }
+        IRB::InputCompletor.singleton_class.send(:alias_method, :rdoc_driver, :original_rdoc_driver)
+        IRB::InputCompletor.singleton_class.undef_method :original_rdoc_driver
+      end
     end
   end
 

--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -69,18 +69,11 @@ module TestIRB
         ::Kernel.send(:irb_original_require, name)
       end
 
-      IRB::InputCompletor.singleton_class.send(:alias_method, :original_rdoc_driver, :rdoc_driver)
-      IRB::InputCompletor.define_singleton_method :rdoc_driver do
-        nil
-      end
-
       yield
     ensure
       EnvUtil.suppress_warning do
         ::Kernel.send(:alias_method, :require, :irb_original_require)
         ::Kernel.undef_method :irb_original_require
-        IRB::InputCompletor.singleton_class.send(:alias_method, :rdoc_driver, :original_rdoc_driver)
-        IRB::InputCompletor.singleton_class.undef_method :original_rdoc_driver
       end
     end
   end

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -8,6 +8,7 @@ module TestIRB
   class RelineInputMethodTest < TestCase
     def setup
       @conf_backup = IRB.conf.dup
+      @completor = IRB::RegexpCompletor.new(nil)
       IRB.conf[:LC_MESSAGES] = IRB::Locale.new
       save_encodings
     end
@@ -18,13 +19,13 @@ module TestIRB
     end
 
     def test_initialization
-      IRB::RelineInputMethod.new
+      IRB::RelineInputMethod.new(completor: @completor)
 
       assert_nil Reline.completion_append_character
       assert_equal '', Reline.completer_quote_characters
       assert_equal IRB::InputMethod::BASIC_WORD_BREAK_CHARACTERS, Reline.basic_word_break_characters
-      assert_equal IRB::InputCompletor.method(:complete), Reline.completion_proc
-      assert_equal IRB::InputCompletor.method(:display_doc), Reline.dig_perfect_match_proc
+      assert_equal @completor.method(:complete), Reline.completion_proc
+      assert_equal @completor.method(:display_doc), Reline.dig_perfect_match_proc
     end
 
     def test_initialization_without_use_autocomplete
@@ -34,7 +35,7 @@ module TestIRB
 
       IRB.conf[:USE_AUTOCOMPLETE] = false
 
-      IRB::RelineInputMethod.new
+      IRB::RelineInputMethod.new(completor: @completor)
 
       refute Reline.autocompletion
       assert_equal empty_proc, Reline.dialog_proc(:show_doc).dialog_proc
@@ -49,10 +50,11 @@ module TestIRB
 
       IRB.conf[:USE_AUTOCOMPLETE] = true
 
-      IRB::RelineInputMethod.new
+      IRB::RelineInputMethod.new(completor: @completor)
 
       assert Reline.autocompletion
-      assert_equal IRB::RelineInputMethod::SHOW_DOC_DIALOG, Reline.dialog_proc(:show_doc).dialog_proc
+      assert_not_nil Reline.dialog_proc(:show_doc)
+      assert_not_equal empty_proc, Reline.dialog_proc(:show_doc).dialog_proc
     ensure
       Reline.add_dialog_proc(:show_doc, original_show_doc_proc, Reline::DEFAULT_DIALOG_CONTEXT)
     end
@@ -65,7 +67,7 @@ module TestIRB
       IRB.conf[:USE_AUTOCOMPLETE] = true
 
       without_rdoc do
-        IRB::RelineInputMethod.new
+        IRB::RelineInputMethod.new(completor: @completor)
       end
 
       assert Reline.autocompletion

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -23,8 +23,8 @@ module TestIRB
       assert_nil Reline.completion_append_character
       assert_equal '', Reline.completer_quote_characters
       assert_equal IRB::InputCompletor::BASIC_WORD_BREAK_CHARACTERS, Reline.basic_word_break_characters
-      assert_equal IRB::InputCompletor::CompletionProc, Reline.completion_proc
-      assert_equal IRB::InputCompletor::PerfectMatchedProc, Reline.dig_perfect_match_proc
+      assert_equal IRB::InputCompletor.method(:complete), Reline.completion_proc
+      assert_equal IRB::InputCompletor.method(:display_doc), Reline.dig_perfect_match_proc
     end
 
     def test_initialization_without_use_autocomplete
@@ -76,4 +76,3 @@ module TestIRB
     end
   end
 end
-

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -22,7 +22,7 @@ module TestIRB
 
       assert_nil Reline.completion_append_character
       assert_equal '', Reline.completer_quote_characters
-      assert_equal IRB::InputCompletor::BASIC_WORD_BREAK_CHARACTERS, Reline.basic_word_break_characters
+      assert_equal IRB::InputMethod::BASIC_WORD_BREAK_CHARACTERS, Reline.basic_word_break_characters
       assert_equal IRB::InputCompletor.method(:complete), Reline.completion_proc
       assert_equal IRB::InputCompletor.method(:display_doc), Reline.dig_perfect_match_proc
     end


### PR DESCRIPTION
Looking at #707, I think containing completion in procs make things harder to refactor and doesn't provide much value. Maybe we can just define them as methods, and pass the method objects to Reline/Readline?