### PR TITLE
Test should not depend on user's irbrc file

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -110,6 +110,10 @@ module TestIRB
 
       yield
 
+      # Test should not depend on user's irbrc file
+      @envs["HOME"] ||= tmp_dir
+      @envs["XDG_CONFIG_HOME"] ||= tmp_dir
+
       PTY.spawn(@envs.merge("TERM" => "dumb"), *cmd) do |read, write, pid|
         Timeout.timeout(TIMEOUT_SEC) do
           while line = safe_gets(read)


### PR DESCRIPTION
Fixes #713 
Many test was failing in local environment If user's irbrc file is:
```ruby
# $HOME/.irbrc
exit
```
or
```ruby
# $XDG_CONFIG_HOME/irb/irbrc
exit
```

Some other settings (example: `IRB.conf[:PROMPT_MODE] = :FOOBAR`) was also making test fail.
