### PR TITLE
Test should not depend on user's irbrc file specified by ENV['IRBRC']

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -113,6 +113,7 @@ module TestIRB
       # Test should not depend on user's irbrc file
       @envs["HOME"] ||= tmp_dir
       @envs["XDG_CONFIG_HOME"] ||= tmp_dir
+      @envs["IRBRC"] = nil unless @envs.key?("IRBRC")
 
       PTY.spawn(@envs.merge("TERM" => "dumb"), *cmd) do |read, write, pid|
         Timeout.timeout(TIMEOUT_SEC) do


### PR DESCRIPTION
This is a followup of #714, fixes #716

If user's irbrc file has `exit` and it is specified by `ENV['IRBRC']`, test was failing. Test should not depend on user's IRBRC.
```
$ echo exit > ~/exit_irbrc
$ IRBRC=~/exit_irbrc rake test
...
Finished in 7.503132 seconds.
------------------------------------------------------------------------------------------------
252 tests, 1822 assertions, 26 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
89.6825% passed
------------------------------------------------------------------------------------------------
33.59 tests/s, 242.83 assertions/s
...
```

## Background
RVM seems to set custom irbrc that overwrites `IRB.conf[:PROMPT_MODE] = :RVM`, `IRB.conf[:SAVE_HISTORY] = 100` and `IRB.conf[:HISTORY_FILE]`.
Although making test fail is only `IRB.conf[:PROMPT_MODE]`, all other config overwriting will make test insufficient. Test passing does not mean it is tested correctly. Loading irbrc should be suppressed.

