### PR TITLE
Fix Reline's test failure running with `make test-all TESTS='reline irb'`

### DIFF
--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -91,7 +91,7 @@ module TestIRB
     end
 
     def test_prompt_n_deprecation
-      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new))
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), TestInputMethod.new)
 
       _, err = capture_output do
         irb.context.prompt_n = "foo"

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -15,6 +15,8 @@ module TestIRB
     def teardown
       IRB.conf.replace(@conf_backup)
       restore_encodings
+      # Reset Reline configuration overrided by RelineInputMethod.
+      Reline.instance_variable_set(:@core, nil)
     end
 
     def test_initialization

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -738,7 +738,7 @@ module TestIRB
       workspace = IRB::WorkSpace.new(TOPLEVEL_BINDING.dup)
 
       IRB.conf[:VERBOSE] = false
-      IRB::Irb.new(workspace)
+      IRB::Irb.new(workspace, TestInputMethod.new)
     end
   end
 end

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -222,7 +222,7 @@ module TestIRB
       end
 
       IRB.conf[:VERBOSE] = false
-      IRB::Context.new(nil, workspace)
+      IRB::Context.new(nil, workspace, TestInputMethod.new)
     end
 
     def assert_indent_level(lines, expected, local_variables: [])


### PR DESCRIPTION
## Desciption
`make test-all TESTS='reline irb'` in `ruby/ruby` rarely fails with

```
TestReline#test_completer_quote_characters [/Users/tomoya.ishida/github/ruby/ruby/test/reline/test_reline.rb:91]:
<"\"'"> expected but was
<"">.
```

This is because IRB's test overwrites `Reline.completer_quote_characters` in `RelineInputMethod#initialize` and does not restore it in teardown.
https://github.com/ruby/irb/blob/5669efa4c1526761d9f1a71c40892738937f5d00/lib/irb/input-method.rb#L236


`test_completer_quote_characters` fails only  when `Reline.completer_quote_characters` is overwritten to `''` before `test_reline.rb` is executed, and `test_completer_quote_characters` is the first executed test of all 25 tests in `test_reline.rb`


## Where is RelineInputMethod used?
In `test_context.rb`, `test_irb.rb` and `test_ruby_lex.rb` because input_method was not specified.
In `test_input_method.rb`. need to reset Reline's instance_variable `@core` just like in Reline's test https://github.com/ruby/reline/blob/c16d33dae5d47c741af8da275f7d09be862ab8e0/test/reline/helper.rb#L41

## How to reproduce

First, delete all test methods except `test_completer_quote_characters` in `test_reline.rb` to increase the reproduce probability.
Then, run one of these tests several times
```
make test-all TESTS='reline/test_reline.rb irb/test_irb.rb'
make test-all TESTS='reline/test_reline.rb irb/test_ruby_lex.rb'
make test-all TESTS='reline/test_reline.rb irb/test_input_method.rb'
make test-all TESTS='reline/test_reline.rb irb/test_context.rb'
```
