### PR TITLE
Avoid locking the debug UI to a single thread

### DIFF
--- a/lib/irb/debug.rb
+++ b/lib/irb/debug.rb
@@ -32,17 +32,14 @@ module IRB
           end
           DEBUGGER__::CONFIG.set_config
           configure_irb_for_debugger(irb)
-          thread = Thread.current
 
-          DEBUGGER__.initialize_session{ IRB::Debug::UI.new(thread, irb) }
+          DEBUGGER__.initialize_session{ IRB::Debug::UI.new(irb) }
         end
 
         # When debug session was previously started but not by IRB
         if defined?(DEBUGGER__::SESSION) && !irb.context.with_debugger
           configure_irb_for_debugger(irb)
-          thread = Thread.current
-
-          DEBUGGER__::SESSION.reset_ui(IRB::Debug::UI.new(thread, irb))
+          DEBUGGER__::SESSION.reset_ui(IRB::Debug::UI.new(irb))
         end
 
         # Apply patches to debug gem so it skips IRB frames

--- a/lib/irb/debug/ui.rb
+++ b/lib/irb/debug/ui.rb
@@ -4,8 +4,7 @@ require 'debug/console'
 module IRB
   module Debug
     class UI < DEBUGGER__::UI_Base
-      def initialize(thread, irb)
-        @thread = thread
+      def initialize(irb)
         @irb = irb
       end
 
@@ -56,7 +55,7 @@ module IRB
 
       def readline _
         setup_interrupt do
-          tc = DEBUGGER__::SESSION.get_thread_client(@thread)
+          tc = DEBUGGER__::SESSION.instance_variable_get(:@tc)
           cmd = @irb.debug_readline(tc.current_frame.binding || TOPLEVEL_BINDING)
 
           case cmd


### PR DESCRIPTION
Since `debug` stores and updates the target thread via its Session's `@tc` variable, we don't need to and shouldn't lock the UI to the thread that activates the integration.