### PR TITLE
Fix calling exit if irb_context is nil

### DIFF
--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -22,7 +22,7 @@ module IRB # :nodoc:
     #
     # Same as <code>IRB.CurrentContext.exit</code>.
     def irb_exit(ret = 0)
-      irb_context.exit(ret)
+      irb_context&.exit(ret)
     end
 
     # Displays current configuration.


### PR DESCRIPTION
ruby/ruby master is randomly experiencing this error:

```
  D:/a/ruby/ruby/src/lib/irb/extend-command.rb:25:in `irb_exit': private method `exit' called for nil (NoMethodError)
  
        irb_context.exit(ret)
                   ^^^^^
  	from D:/a/ruby/ruby/src/tool/test/runner.rb:23:in `<top (required)>'
  	from ../src/test/runner.rb:16:in `require_relative'
  	from ../src/test/runner.rb:16:in `<main>'
```

I'm not sure how to deterministically reproduce this issue (I suspect there's a loading order that could mess this up), but since it's failing on a `nil` receiver, we could address this by checking if the receiver is nil.