### PR TITLE
Fix test runner exit bug

### DIFF
--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -22,7 +22,7 @@ module IRB # :nodoc:
     #
     # Same as <code>IRB.CurrentContext.exit</code>.
     def irb_exit(ret = 0)
-      irb_context&.exit(ret)
+      irb_context.exit(ret)
     end
 
     # Displays current configuration.

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -6,15 +6,6 @@ require_relative "helper"
 
 module TestIRB
   class CompletionTest < TestCase
-    def setup
-      # make sure require completion candidates are not cached
-      IRB::BaseCompletor.class_variable_set(:@@files_from_load_path, nil)
-    end
-
-    def teardown
-      IRB.conf[:MAIN_CONTEXT] = nil
-    end
-
     def completion_candidates(target, bind)
       IRB::RegexpCompletor.new.completion_candidates('', target, '', bind: bind)
     end

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -733,9 +733,13 @@ module TestIRB
 
     private
 
+    def build_binding
+      Object.new.instance_eval { binding }
+    end
+
     def build_irb
       IRB.init_config(nil)
-      workspace = IRB::WorkSpace.new(TOPLEVEL_BINDING.dup)
+      workspace = IRB::WorkSpace.new(build_binding)
 
       IRB.conf[:VERBOSE] = false
       IRB::Irb.new(workspace, TestInputMethod.new)


### PR DESCRIPTION
`make test-all TESTS=irb` was failing with ```irb_exit': private method `exit' called for nil (NoMethodError)`` (fixed in #727)


Removes useless test setup and teardown that sets `IRB.conf[:MAIN_CONTEXT] = nil`.
Remove safe navigation operator of `irb_context&.exit` because it won't be nil.
Avoid `test_irb.rb` overriding main object's `exit` method because it can be a potential bug.
