### PR TITLE
Restore IRB::InputCompletor for compatibility

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -415,4 +415,20 @@ module IRB
       end
     end
   end
+
+  module InputCompletor
+    class << self
+      private def regexp_completor
+        @regexp_completor ||= RegexpCompletor.new
+      end
+
+      def retrieve_completion_data(input, bind: IRB.conf[:MAIN_CONTEXT].workspace.binding, doc_namespace: false)
+        regexp_completor.retrieve_completion_data(input, bind: bind, doc_namespace: doc_namespace)
+      end
+    end
+    CompletionProc = ->(target, preposing = nil, postposing = nil) {
+      regexp_completor.completion_candidates(preposing, target, postposing, bind: IRB.conf[:MAIN_CONTEXT].workspace.binding)
+    }
+  end
+  deprecate_constant :InputCompletor
 end

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -265,4 +265,29 @@ module TestIRB
       assert_include(doc_namespace("private_hoge", bind), "private_hoge")
     end
   end
+
+  class DeprecatedInputCompletorTest < TestCase
+    def setup
+      @verbose, $VERBOSE = $VERBOSE, nil
+      IRB.init_config(nil)
+      IRB.conf[:MAIN_CONTEXT] = IRB::Context.new(IRB::WorkSpace.new(binding))
+    end
+
+    def teardown
+      $VERBOSE = @verbose
+    end
+
+    def test_completion_proc
+      assert_include(IRB::InputCompletor::CompletionProc.call('1.ab'), '1.abs')
+      assert_include(IRB::InputCompletor::CompletionProc.call('1.ab', '', ''), '1.abs')
+    end
+
+    def test_retrieve_completion_data
+      assert_include(IRB::InputCompletor.retrieve_completion_data('1.ab'), '1.abs')
+      assert_equal(IRB::InputCompletor.retrieve_completion_data('1.abs', doc_namespace: true), 'Integer.abs')
+      bind = eval('a = 1; binding')
+      assert_include(IRB::InputCompletor.retrieve_completion_data('a.ab', bind: bind), 'a.abs')
+      assert_equal(IRB::InputCompletor.retrieve_completion_data('a.abs', bind: bind, doc_namespace: true), 'Integer.abs')
+    end
+  end
 end


### PR DESCRIPTION
`CompletionProc` and `retrieve_completion_data` seems to be used
`ReservedWords` `Operators` is used in one repository
Other constants and methods does not seem to be used