### PR TITLE
Suppress "Switch to inspect mode" messages

### DIFF
--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -271,6 +271,7 @@ module TestIRB
       save_encodings
       @verbose, $VERBOSE = $VERBOSE, nil
       IRB.init_config(nil)
+      IRB.conf[:VERBOSE] = false
       IRB.conf[:MAIN_CONTEXT] = IRB::Context.new(IRB::WorkSpace.new(binding))
     end
 


### PR DESCRIPTION
This message is displayed if STDIN is not a tty.  The parallel test is the case.