### PR TITLE
Fix dancing-ruby Ctrl+C stop

### DIFF
--- a/lib/irb/easter-egg.rb
+++ b/lib/irb/easter-egg.rb
@@ -109,7 +109,9 @@ module IRB
           end
         end
       when :dancing
-        begin
+        STDOUT.cooked do
+          interrupted = false
+          prev_trap = trap("SIGINT") { interrupted = true }
           canvas = Canvas.new(Reline.get_screen_size)
           Reline::IOGate.set_winch_handler do
             canvas = Canvas.new(Reline.get_screen_size)
@@ -125,10 +127,12 @@ module IRB
             buff[0, 20] = "\e[0mPress Ctrl+C to stop\e[31m\e[1m"
             print "\e[H" + buff
             sleep 0.05
+            break if interrupted
           end
         rescue Interrupt
         ensure
           print "\e[0m\e[?1049l"
+          trap("SIGINT", prev_trap)
         end
       end
     end


### PR DESCRIPTION
IRB has an easter egg
```ruby
$ irb --noautocomplete
irb(main):001> RubyVM[PRESS TAB KEY]
easter egg ([:logo and :dancing] two patterns randomly)
```
Since reline 0.3.3, dancing ruby easter egg does not stop with CTRL+C because STDOUT is raw mode. I added `STDOUT.cooked do end`
(I think it's from https://github.com/ruby/reline/pull/474, reline stopped changing  raw-mode and cooked mode frequently while rendering)

Stopping dancing-ruby with CTRL+C will abort input to IRB.
```
if true
  RubyVM[PRESS TAB KEY] [CTRL+C] # The input `if true\n  RUBYVM` is cleared
```
To avoid it, I also added `trap("SIGINT")`