### PR TITLE
Minor refactors around irb.rb

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -835,16 +835,6 @@ module IRB
       end
     end
 
-    # Evaluates the given block using the given +context+ as the Context.
-    def suspend_context(context)
-      @context, back_context = context, @context
-      begin
-        yield back_context
-      ensure
-        @context = back_context
-      end
-    end
-
     # Handler for the signal SIGINT, see Kernel#trap for more information.
     def signal_handle
       unless @context.ignore_sigint?

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -413,6 +413,11 @@ module IRB
     PROMPT_MAIN_TRUNCATE_OMISSION = '...'.freeze
     CONTROL_CHARACTERS_PATTERN = "\x00-\x1F".freeze
 
+    # Returns the current context of this irb session
+    attr_reader :context
+    # The lexer used by this irb session
+    attr_accessor :scanner
+
     # Creates a new irb session
     def initialize(workspace = nil, input_method = nil)
       @context = Context.new(self, workspace, input_method)
@@ -490,11 +495,6 @@ module IRB
         context.io.save_history if save_history
       end
     end
-
-    # Returns the current context of this irb session
-    attr_reader :context
-    # The lexer used by this irb session
-    attr_accessor :scanner
 
     # Evaluates input for this session.
     def eval_input

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -367,22 +367,6 @@ module IRB
   # An exception raised by IRB.irb_abort
   class Abort < Exception;end
 
-  @CONF = {}
-  # Displays current configuration.
-  #
-  # Modifying the configuration is achieved by sending a message to IRB.conf.
-  #
-  # See IRB@Configuration for more information.
-  def IRB.conf
-    @CONF
-  end
-
-  # Returns the current version of IRB, including release version and last
-  # updated date.
-  def IRB.version
-    format("irb %s (%s)", @RELEASE_VERSION, @LAST_UPDATE_DATE)
-  end
-
   # The current IRB::Context of the session, see IRB.conf
   #
   #   irb
@@ -968,26 +952,6 @@ module IRB
         end
       end
     end
-  end
-
-  def @CONF.inspect
-    array = []
-    for k, v in sort{|a1, a2| a1[0].id2name <=> a2[0].id2name}
-      case k
-      when :MAIN_CONTEXT, :__TMP__EHV__
-        array.push format("CONF[:%s]=...myself...", k.id2name)
-      when :PROMPT
-        s = v.collect{
-          |kk, vv|
-          ss = vv.collect{|kkk, vvv| ":#{kkk.id2name}=>#{vvv.inspect}"}
-          format(":%s=>{%s}", kk.id2name, ss.join(", "))
-        }
-        array.push format("CONF[:%s]={%s}", k.id2name, s.join(", "))
-      else
-        array.push format("CONF[:%s]=%s", k.id2name, v.inspect)
-      end
-    end
-    array.join("\n")
   end
 end
 

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -380,9 +380,7 @@ module IRB
   # Returns the current version of IRB, including release version and last
   # updated date.
   def IRB.version
-    if v = @CONF[:VERSION] then return v end
-
-    @CONF[:VERSION] = format("irb %s (%s)", @RELEASE_VERSION, @LAST_UPDATE_DATE)
+    format("irb %s (%s)", @RELEASE_VERSION, @LAST_UPDATE_DATE)
   end
 
   # The current IRB::Context of the session, see IRB.conf
@@ -971,8 +969,6 @@ module IRB
   end
 
   def @CONF.inspect
-    IRB.version unless self[:VERSION]
-
     array = []
     for k, v in sort{|a1, a2| a1[0].id2name <=> a2[0].id2name}
       case k

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -28,6 +28,7 @@ module IRB # :nodoc:
     unless ap_path and @CONF[:AP_NAME]
       ap_path = File.join(File.dirname(File.dirname(__FILE__)), "irb.rb")
     end
+    @CONF[:VERSION] = version
     @CONF[:AP_NAME] = File::basename(ap_path, ".rb")
 
     @CONF[:IRB_NAME] = "irb"

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -5,6 +5,41 @@
 #
 
 module IRB # :nodoc:
+  @CONF = {}
+  # Displays current configuration.
+  #
+  # Modifying the configuration is achieved by sending a message to IRB.conf.
+  #
+  # See IRB@Configuration for more information.
+  def IRB.conf
+    @CONF
+  end
+
+  def @CONF.inspect
+    array = []
+    for k, v in sort{|a1, a2| a1[0].id2name <=> a2[0].id2name}
+      case k
+      when :MAIN_CONTEXT, :__TMP__EHV__
+        array.push format("CONF[:%s]=...myself...", k.id2name)
+      when :PROMPT
+        s = v.collect{
+          |kk, vv|
+          ss = vv.collect{|kkk, vvv| ":#{kkk.id2name}=>#{vvv.inspect}"}
+          format(":%s=>{%s}", kk.id2name, ss.join(", "))
+        }
+        array.push format("CONF[:%s]={%s}", k.id2name, s.join(", "))
+      else
+        array.push format("CONF[:%s]=%s", k.id2name, v.inspect)
+      end
+    end
+    array.join("\n")
+  end
+
+  # Returns the current version of IRB, including release version and last
+  # updated date.
+  def IRB.version
+    format("irb %s (%s)", @RELEASE_VERSION, @LAST_UPDATE_DATE)
+  end
 
   # initialize config
   def IRB.setup(ap_path, argv: ::ARGV)

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -453,7 +453,7 @@ module TestIRB
         "show_source IRB.conf\n",
       )
       assert_empty err
-      assert_match(%r[/irb\.rb], out)
+      assert_match(%r[/irb\/init\.rb], out)
     end
 
     def test_show_source_method
@@ -461,7 +461,7 @@ module TestIRB
         "p show_source('IRB.conf')\n",
       )
       assert_empty err
-      assert_match(%r[/irb\.rb], out)
+      assert_match(%r[/irb\/init\.rb], out)
     end
 
     def test_show_source_string
@@ -469,7 +469,7 @@ module TestIRB
         "show_source 'IRB.conf'\n",
       )
       assert_empty err
-      assert_match(%r[/irb\.rb], out)
+      assert_match(%r[/irb\/init\.rb], out)
     end
 
     def test_show_source_alias
@@ -478,7 +478,7 @@ module TestIRB
         conf: { COMMAND_ALIASES: { :'$' => :show_source } }
       )
       assert_empty err
-      assert_match(%r[/irb\.rb], out)
+      assert_match(%r[/irb\/init\.rb], out)
     end
 
     def test_show_source_end_finder


### PR DESCRIPTION
With recent changes around `RubyLex`, `irb.rb`'s size has grown quite a bit. So I think it's worth doing some cleanup and put things at or conventional places to make it easier to navigate.