### PR TITLE
Add workaround for CI failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler --no-document
+          gem install rake
           gem rdoc --all --ri --no-rdoc
           WITH_VTERM=1 bundle install
       - name: rake test_yamatanooroti


### PR DESCRIPTION
The system on CI `rake` version is 13.0.6, while the bundle installing `rake` version is 13.1.0.
IRB's test on CI depends on the system's `rake` document.
Match the `rake` version installed on system to the version installed by bundler.