### PR TITLE
Use IRB's own doc for doc dialog tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,8 +72,6 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler --no-document
-          gem install rake
-          gem rdoc --all --ri --no-rdoc
           WITH_VTERM=1 bundle install
       - name: rake test_yamatanooroti
         run: WITH_VTERM=1 bundle exec rake test_yamatanooroti

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -204,7 +204,6 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
   end
 
   def test_autocomplete_with_showdoc_in_gaps_on_narrow_screen_right
-    omit if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.1')
     rdoc_dir = File.join(@tmpdir, 'rdoc')
     system("bundle exec rdoc -r -o #{rdoc_dir}")
     write_irbrc <<~LINES
@@ -241,7 +240,6 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
   end
 
   def test_autocomplete_with_showdoc_in_gaps_on_narrow_screen_left
-    omit if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.1')
     rdoc_dir = File.join(@tmpdir, 'rdoc')
     system("bundle exec rdoc -r -o #{rdoc_dir}")
     write_irbrc <<~LINES

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -205,7 +205,10 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
 
   def test_autocomplete_with_showdoc_in_gaps_on_narrow_screen_right
     omit if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.1')
-    write_irbrc <<~'LINES'
+    rdoc_dir = File.join(@tmpdir, 'rdoc')
+    system("bundle exec rdoc -r -o #{rdoc_dir}")
+    write_irbrc <<~LINES
+      IRB.conf[:EXTRA_DOC_DIRS] = ['#{rdoc_dir}']
       IRB.conf[:PROMPT][:MY_PROMPT] = {
         :PROMPT_I => "%03n> ",
         :PROMPT_S => "%03n> ",
@@ -214,8 +217,8 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       IRB.conf[:PROMPT_MODE] = :MY_PROMPT
       puts 'start IRB'
     LINES
-    start_terminal(4, 19, %W{ruby -I/home/aycabta/ruby/reline/lib -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
-    write("Str\C-i")
+    start_terminal(4, 19, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    write("IR\C-i")
     close
 
     # This is because on macOS we display different shortcut for displaying the full doc
@@ -223,23 +226,26 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     if RUBY_PLATFORM =~ /darwin/
       assert_screen(<<~EOC)
         start IRB
-        001> String
-             StringPress O
-             StructString
+        001> IRB
+             IRBPress Opti
+                IRB
       EOC
     else
       assert_screen(<<~EOC)
         start IRB
-        001> String
-             StringPress A
-             StructString
+        001> IRB
+             IRBPress Alt+
+                IRB
       EOC
     end
   end
 
   def test_autocomplete_with_showdoc_in_gaps_on_narrow_screen_left
     omit if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.1')
-    write_irbrc <<~'LINES'
+    rdoc_dir = File.join(@tmpdir, 'rdoc')
+    system("bundle exec rdoc -r -o #{rdoc_dir}")
+    write_irbrc <<~LINES
+      IRB.conf[:EXTRA_DOC_DIRS] = ['#{rdoc_dir}']
       IRB.conf[:PROMPT][:MY_PROMPT] = {
         :PROMPT_I => "%03n> ",
         :PROMPT_S => "%03n> ",
@@ -249,13 +255,13 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       puts 'start IRB'
     LINES
     start_terminal(4, 12, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
-    write("Str\C-i")
+    write("IR\C-i")
     close
     assert_screen(<<~EOC)
       start IRB
-      001> String
-      PressString
-      StrinStruct
+      001> IRB
+      PressIRB
+      IRB
     EOC
   end
 


### PR DESCRIPTION
This helps us reduce those doc dialog tests' external dependencies as they actually depend on `String` doc indexed with the `rake` gem ([original explanation](https://github.com/ruby/irb/pull/742#issuecomment-1785623032) by @tompng).