### PR TITLE
Update SourceFinder's find_end algorithm

### DIFF
--- a/lib/irb/cmd/edit.rb
+++ b/lib/irb/cmd/edit.rb
@@ -31,7 +31,7 @@ module IRB
         if !File.exist?(path)
           source =
             begin
-              SourceFinder.new(@irb_context).find_source(path)
+              SourceFinder.new(@irb_context.workspace.binding).find_source(path)
             rescue NameError
               # if user enters a path that doesn't exist, it'll cause NameError when passed here because find_source would try to evaluate it as well
               # in this case, we should just ignore the error

--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -28,7 +28,7 @@ module IRB
           return
         end
 
-        source = SourceFinder.new(@irb_context).find_source(str)
+        source = SourceFinder.new(@irb_context.workspace.binding).find_source(str)
 
         if source
           show_source(source)

--- a/lib/irb/source_finder.rb
+++ b/lib/irb/source_finder.rb
@@ -12,53 +12,52 @@ module IRB
     )
     private_constant :Source
 
-    def initialize(irb_context)
-      @irb_context = irb_context
+    def initialize(binding)
+      @binding = binding
     end
 
     def find_source(signature)
-      context_binding = @irb_context.workspace.binding
       case signature
       when /\A[A-Z]\w*(::[A-Z]\w*)*\z/ # Const::Name
-        eval(signature, context_binding) # trigger autoload
-        base = context_binding.receiver.yield_self { |r| r.is_a?(Module) ? r : Object }
+        eval(signature, @binding) # trigger autoload
+        base = @binding.receiver.yield_self { |r| r.is_a?(Module) ? r : Object }
         file, line = base.const_source_location(signature)
       when /\A(?<owner>[A-Z]\w*(::[A-Z]\w*)*)#(?<method>[^ :.]+)\z/ # Class#method
-        owner = eval(Regexp.last_match[:owner], context_binding)
+        owner = eval(Regexp.last_match[:owner], @binding)
         method = Regexp.last_match[:method]
         if owner.respond_to?(:instance_method)
           methods = owner.instance_methods + owner.private_instance_methods
           file, line = owner.instance_method(method).source_location if methods.include?(method.to_sym)
         end
       when /\A((?<receiver>.+)(\.|::))?(?<method>[^ :.]+)\z/ # method, receiver.method, receiver::method
-        receiver = eval(Regexp.last_match[:receiver] || 'self', context_binding)
+        receiver = eval(Regexp.last_match[:receiver] || 'self', @binding)
         method = Regexp.last_match[:method]
         file, line = receiver.method(method).source_location if receiver.respond_to?(method, true)
       end
       if file && line && File.exist?(file)
-        Source.new(file: file, first_line: line, last_line: find_end(file, line))
+        code = File.read(file)
+        Source.new(file: file, first_line: line, last_line: find_end(code, line))
       end
     end
 
     private
 
-    def find_end(file, first_line)
-      lex = RubyLex.new
-      lines = File.read(file).lines[(first_line - 1)..-1]
-      tokens = RubyLex.ripper_lex_without_warning(lines.join)
-      prev_tokens = []
+    def find_end(code, first_line)
+      tokens = RubyLex.ripper_lex_without_warning(code)
+      line_results = NestingParser.parse_by_line(tokens)
+      _tokens, prev_opens, next_opens, _min_depth = line_results[first_line - 1]
+      in_heredoc = prev_opens.last&.event == :on_heredoc_beg
+      # New open tokens in first_line. Need to find end_line that closes all of them.
+      tokens_to_be_closed = next_opens - prev_opens
+      # If the content is inside heredoc, find the end of the heredoc.
+      tokens_to_be_closed << next_opens.last if in_heredoc
 
-      # chunk with line number
-      tokens.chunk { |tok| tok.pos[0] }.each do |lnum, chunk|
-        code = lines[0..lnum].join
-        prev_tokens.concat chunk
-        continue = lex.should_continue?(prev_tokens)
-        syntax = lex.check_code_syntax(code, local_variables: [])
-        if !continue && syntax == :valid
-          return first_line + lnum
-        end
+      line_tokens = line_results.map { |_tokens, prev, _next, _min_depth| prev }
+      end_line = (first_line...line_tokens.size).find do |index|
+        (line_tokens[index] & tokens_to_be_closed).empty?
       end
-      first_line
+      return line_tokens.size unless end_line
+      in_heredoc ? end_line - 1 : end_line
     end
   end
 end

--- a/test/irb/test_source_finder.rb
+++ b/test/irb/test_source_finder.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: false
+require 'irb/source_finder'
+
+require_relative "helper"
+
+module TestIRB
+  class SourceFinderTest < TestCase
+    def setup
+      @source_finder = IRB::SourceFinder.new(TOPLEVEL_BINDING)
+    end
+
+    def test_find_source
+      first_line = __LINE__ - 1
+      source = @source_finder.find_source('TestIRB::SourceFinderTest#test_find_source')
+      assert_equal(__FILE__, source.file)
+      assert_equal(first_line, source.first_line)
+      assert_equal(__LINE__ + 1, source.last_line)
+    end
+
+    def test_find_end
+      assert_equal(4, @source_finder.send(:find_end, <<~RUBY, 2))
+        class A
+          def foo
+            42
+          end
+        end
+      RUBY
+
+      assert_equal(2, @source_finder.send(:find_end, <<~RUBY, 2))
+        class A
+          def foo() = 42
+        end
+      RUBY
+
+      assert_equal(4, @source_finder.send(:find_end, <<~RUBY, 2))
+        class A
+          B = Struct.new(
+            :foo
+          )
+        end
+      RUBY
+
+      assert_equal(5, @source_finder.send(:find_end, <<~'RUBY', 3))
+        class A
+          eval(<<~CODE, binding, __FILE__, __LINE__ + 1)
+            def #{method_name}
+              42
+            end
+          CODE
+        end
+      RUBY
+
+      assert_equal(5, @source_finder.send(:find_end, <<~'RUBY', 2))
+        class A
+          def f(a = <<~CODE)
+            CODE
+            42
+          end
+        end
+      RUBY
+
+      assert_equal(4, @source_finder.send(:find_end, <<~'RUBY', 2))
+        class A
+          define_method(:bar) do
+            42
+          end.then do
+            42
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
For a very large module, `show_source` was slow.

```ruby
# master branch
IRB::SourceFinder.new(context).find_source('Reline::LineEditor')
processing time: 4.850789s
=> #<struct IRB::SourceFinder::Source file="...", first_line=6, last_line=3300>

# this pull request
IRB::SourceFinder.new(binding).find_source('Reline::LineEditor')
processing time: 0.080596s
=> #<struct IRB::SourceFinder::Source file="...", first_line=6, last_line=3300>
```


## How to find end
```ruby
module M
  class A
    B = C.new([ # Find new open-tokens found in start_line. It's `(` and `[`.
      f(),
      g(),
      h()
    ]
    ) # The line that closes all tokens opened in start_line is the end_line
  end
end
```

## Improvement
Can show `show_source A#foo` of this.
```ruby
class A
  method_name = 'foo'
  module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
    def #{method_name}(args)
      42
    end
  RUBY
end
```
It cannot handled in previous implementation because `"def \#{method_name}(args)\n42"` is an invalid code.

```ruby
# master branch
irb> show_source A#foo
def #{method_name}(args)

# this pull request
irb> show_source A#foo
def #{method_name}(args)
  42
end
```

## Degration
For this code,
```ruby
A.module_eval(<<~METHOD, __FILE__, __LINE__ + 1)
  def f
  end
  def g
  end
METHOD

```

`show_source A#f` will show both f and g
```ruby
# master branch
irb> show_source A#f
def f
end

# this pull request
irb> show_source A#f
def f
end
def g
end
```

