### PR TITLE
Add Racc as a development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,5 @@ gem "rake"
 gem "test-unit"
 gem "test-unit-ruby-core"
 gem "debug", github: "ruby/debug"
+
+gem "racc"


### PR DESCRIPTION
In https://github.com/ruby/rdoc/pull/1019 RDoc starts embedding Racc. But Racc in Ruby 3.3 will not be a default gem anymore, which requires explicit declaration in Gemfile.