### PR TITLE
Skip TypeCompletion test in ruby ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,9 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run tests
-        run: bundle exec rake test
+        run: WITH_TYPE_COMPLETION_TEST=1 bundle exec rake test
       - name: Run tests in isolation
-        run: bundle exec rake test_in_isolation
+        run: WITH_TYPE_COMPLETION_TEST=1 bundle exec rake test_in_isolation
   vterm-yamatanooroti:
     needs: ruby-versions
     name: >-

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -653,6 +653,7 @@ module TestIRB
     end
 
     def test_build_completor
+      pend 'set ENV["WITH_TYPE_COMPLETION_TEST"] to run this test' unless ENV['WITH_TYPE_COMPLETION_TEST']
       verbose, $VERBOSE = $VERBOSE, nil
       original_completor = IRB.conf[:COMPLETOR]
       IRB.conf[:COMPLETOR] = :regexp

--- a/test/irb/type_completion/test_scope.rb
+++ b/test/irb/type_completion/test_scope.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return unless ENV['WITH_TYPE_COMPLETION_TEST']
+
 return unless RUBY_VERSION >= '3.0.0'
 return if RUBY_ENGINE == 'truffleruby' # needs endless method definition
 

--- a/test/irb/type_completion/test_type_analyze.rb
+++ b/test/irb/type_completion/test_type_analyze.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return unless ENV['WITH_TYPE_COMPLETION_TEST']
+
 # Run test only when Ruby >= 3.0 and %w[prism rbs] are available
 return unless RUBY_VERSION >= '3.0.0'
 return if RUBY_ENGINE == 'truffleruby' # needs endless method definition

--- a/test/irb/type_completion/test_type_completor.rb
+++ b/test/irb/type_completion/test_type_completor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return unless ENV['WITH_TYPE_COMPLETION_TEST']
+
 # Run test only when Ruby >= 3.0 and %w[prism rbs] are available
 return unless RUBY_VERSION >= '3.0.0'
 return if RUBY_ENGINE == 'truffleruby' # needs endless method definition

--- a/test/irb/type_completion/test_types.rb
+++ b/test/irb/type_completion/test_types.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return unless ENV['WITH_TYPE_COMPLETION_TEST']
+
 return unless RUBY_VERSION >= '3.0.0'
 return if RUBY_ENGINE == 'truffleruby' # needs endless method definition
 


### PR DESCRIPTION
Ruby's CI is failing with
```
/tmp/ruby/src/trunk/lib/rubygems/deprecate.rb:72:in `<top (required)>': uninitialized constant Gem (NameError)
--
  | from /tmp/ruby/src/trunk/lib/rubygems/specification.rb:10:in `require_relative'
  | from /tmp/ruby/src/trunk/lib/rubygems/specification.rb:10:in `<top (required)>'
  | from /tmp/ruby/src/trunk/lib/bundler/rubygems_ext.rb:5:in `require'
  | from /tmp/ruby/src/trunk/lib/bundler/rubygems_ext.rb:5:in `<top (required)>'
  | from /tmp/ruby/src/trunk/lib/bundler.rb:10:in `require_relative'
  | from /tmp/ruby/src/trunk/lib/bundler.rb:10:in `<top (required)>'
  | from /tmp/ruby/src/trunk/.bundle/gems/rbs-3.2.2/lib/rbs/collection.rb:4:in `require'
  | from /tmp/ruby/src/trunk/.bundle/gems/rbs-3.2.2/lib/rbs/collection.rb:4:in `<top (required)>'
  | from /tmp/ruby/src/trunk/.bundle/gems/rbs-3.2.2/lib/rbs.rb:55:in `require'
  | from /tmp/ruby/src/trunk/.bundle/gems/rbs-3.2.2/lib/rbs.rb:55:in `<top (required)>'
  | from /tmp/ruby/src/trunk/test/irb/type_completion/test_type_analyze.rb:8:in `require'
  | from /tmp/ruby/src/trunk/test/irb/type_completion/test_type_analyze.rb:8:in `<top (required)>'
  | from /tmp/ruby/src/trunk/tool/lib/test/unit.rb:723:in `require'
  | from /tmp/ruby/src/trunk/tool/lib/test/unit.rb:723:in `block in _run_parallel'
```
http://ci.rvm.jp/results/trunk@ruby-sp1/4767992


As a workaround, run TypeCompletion test only in irb's ci