### PR TITLE
Use absolute link to `COMPATED_WITH_PRY.md` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ gem install irb
 
 > **Note**
 >
-> We're working hard to match Pry's variety of powerful features in IRB, and you can track our progress or find contribution ideas in [this document](COMPARED_WITH_PRY.md).
+> We're working hard to match Pry's variety of powerful features in IRB, and you can track our progress or find contribution ideas in [this document](https://github.com/ruby/irb/blob/master/COMPARED_WITH_PRY.md).
 
 ### The `irb` Executable
 


### PR DESCRIPTION
GitHub seems to render relative document links differently inside/outside the special note block. I'm not sure if that's intentional or not, but for the time being we can work around the issue by using absolute link.