### PR TITLE
Add command line option to select which completor to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,11 @@ IRB's default completion `IRB::RegexpCompletor` uses Regexp. IRB has another exp
 
 ### How to Enable IRB::TypeCompletion
 
-To enable IRB::TypeCompletion, write the code below to IRB's rc-file.
+To enable IRB::TypeCompletion, run IRB with `--type-completor` option
+```
+$ irb --type-completor
+```
+Or write the code below to IRB's rc-file.
 ```ruby
 IRB.conf[:COMPLETOR] = :type # default is :regexp
 ```

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -330,6 +330,10 @@ module IRB # :nodoc:
         @CONF[:USE_AUTOCOMPLETE] = true
       when "--noautocomplete"
         @CONF[:USE_AUTOCOMPLETE] = false
+      when "--regexp-completor"
+        @CONF[:COMPLETOR] = :regexp
+      when "--type-completor"
+        @CONF[:COMPLETOR] = :type
       when /^--prompt-mode(?:=(.+))?/, /^--prompt(?:=(.+))?/
         opt = $1 || argv.shift
         prompt_mode = opt.upcase.tr("-", "_").intern

--- a/lib/irb/lc/help-message
+++ b/lib/irb/lc/help-message
@@ -30,6 +30,9 @@ Usage:  irb.rb [options] [programfile] [arguments]
   --nocolorize      Don't use color-highlighting.
   --autocomplete    Use auto-completion (default).
   --noautocomplete  Don't use auto-completion.
+  --regexp-completor
+                    Use regexp based completion (default).
+  --type-completor  Use type based completion.
   --prompt prompt-mode, --prompt-mode prompt-mode
                     Set prompt mode. Pre-defined prompt modes are:
                     'default', 'classic', 'simple', 'inf-ruby', 'xmp', 'null'.

--- a/lib/irb/lc/ja/help-message
+++ b/lib/irb/lc/ja/help-message
@@ -21,6 +21,9 @@ Usage:  irb.rb [options] [programfile] [arguments]
   --nocolorize	    色付けを利用しない.
   --autocomplete    オートコンプリートを利用する.
   --noautocomplete  オートコンプリートを利用しない.
+  --regexp-completor
+                    補完に正規表現を利用する.
+  --type-completor  補完に型情報を利用する.
   --prompt prompt-mode/--prompt-mode prompt-mode
 		    プロンプトモードを切替えます. 現在定義されているプ
 		    ロンプトモードは, default, simple, xmp, inf-rubyが

--- a/man/irb.1
+++ b/man/irb.1
@@ -140,6 +140,13 @@ Use autocompletion.
 Don't use autocompletion.
 .Pp
 .Pp
+.It Fl -regexp-completor
+Use regexp based completion.
+.Pp
+.It Fl -type-completor
+Use type based completion.
+.Pp
+.Pp
 .It Fl -verbose
 Show details.
 .Pp

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -120,6 +120,22 @@ module TestIRB
       IRB.conf[:USE_AUTOCOMPLETE] = orig_use_autocomplete_conf
     end
 
+    def test_completor_setup_with_argv
+      orig_completor_conf = IRB.conf[:COMPLETOR]
+
+      # Default is :regexp
+      IRB.setup(__FILE__, argv: [])
+      assert_equal :regexp, IRB.conf[:COMPLETOR]
+
+      IRB.setup(__FILE__, argv: ['--type-completor'])
+      assert_equal :type, IRB.conf[:COMPLETOR]
+
+      IRB.setup(__FILE__, argv: ['--regexp-completor'])
+      assert_equal :regexp, IRB.conf[:COMPLETOR]
+    ensure
+      IRB.conf[:COMPLETOR] = orig_completor_conf
+    end
+
     def test_noscript
       argv = %w[--noscript -- -f]
       IRB.setup(eval("__FILE__"), argv: argv)


### PR DESCRIPTION
Command line option is more easy to try than writing to `.irbrc`
```
irb --type-completion
irb --regexp-completion
```

other possibilities
```
--type-completor
--regexp-completor

--use-type-(completion|completor)
--use-regexp-(completion|completor)
```

or ENV?
```
ENV['IRB_COMPLETOR'] = 'type' | 'regexp'
```
