### PR TITLE
Revert "Skip TypeCompletion test in ruby ci (#748)"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,9 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run tests
-        run: WITH_TYPE_COMPLETION_TEST=1 bundle exec rake test
+        run: bundle exec rake test
       - name: Run tests in isolation
-        run: WITH_TYPE_COMPLETION_TEST=1 bundle exec rake test_in_isolation
+        run: bundle exec rake test_in_isolation
   vterm-yamatanooroti:
     needs: ruby-versions
     name: >-

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -653,7 +653,6 @@ module TestIRB
     end
 
     def test_build_completor
-      pend 'set ENV["WITH_TYPE_COMPLETION_TEST"] to run this test' unless ENV['WITH_TYPE_COMPLETION_TEST']
       verbose, $VERBOSE = $VERBOSE, nil
       original_completor = IRB.conf[:COMPLETOR]
       IRB.conf[:COMPLETOR] = :regexp

--- a/test/irb/type_completion/test_scope.rb
+++ b/test/irb/type_completion/test_scope.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-return unless ENV['WITH_TYPE_COMPLETION_TEST']
-
 return unless RUBY_VERSION >= '3.0.0'
 return if RUBY_ENGINE == 'truffleruby' # needs endless method definition
 

--- a/test/irb/type_completion/test_type_analyze.rb
+++ b/test/irb/type_completion/test_type_analyze.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-return unless ENV['WITH_TYPE_COMPLETION_TEST']
-
 # Run test only when Ruby >= 3.0 and %w[prism rbs] are available
 return unless RUBY_VERSION >= '3.0.0'
 return if RUBY_ENGINE == 'truffleruby' # needs endless method definition

--- a/test/irb/type_completion/test_type_completor.rb
+++ b/test/irb/type_completion/test_type_completor.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-return unless ENV['WITH_TYPE_COMPLETION_TEST']
-
 # Run test only when Ruby >= 3.0 and %w[prism rbs] are available
 return unless RUBY_VERSION >= '3.0.0'
 return if RUBY_ENGINE == 'truffleruby' # needs endless method definition

--- a/test/irb/type_completion/test_types.rb
+++ b/test/irb/type_completion/test_types.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-return unless ENV['WITH_TYPE_COMPLETION_TEST']
-
 return unless RUBY_VERSION >= '3.0.0'
 return if RUBY_ENGINE == 'truffleruby' # needs endless method definition
 


### PR DESCRIPTION
This reverts commit d394af0bbce4570ebc2a38344132ab47ba4f73d2.

In `ruby/ruby` repository, we ignore to add `.bundle` path into `$LOAD_PATH` at https://github.com/ruby/ruby/pull/8878. It seems fine with https://github.com/ruby/ruby/pull/8879.

