### PR TITLE
Fix thread leak in test

### DIFF
--- a/lib/irb/type_completion/types.rb
+++ b/lib/irb/type_completion/types.rb
@@ -10,10 +10,7 @@ module IRB
       singleton_class.attr_reader :rbs_builder, :rbs_load_error
 
       def self.preload_in_thread
-        return if @preload_started
-
-        @preload_started = true
-        Thread.new do
+        @preloading_thread ||= Thread.new do
           load_rbs_builder
         end
       end

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -660,6 +660,7 @@ module TestIRB
       IRB.conf[:COMPLETOR] = :type
       if RUBY_VERSION >= '3.0.0' && RUBY_ENGINE != 'truffleruby'
         assert_equal 'IRB::TypeCompletion::Completor', @context.send(:build_completor).class.name
+        IRB::TypeCompletion::Types.instance_variable_get(:@preloading_thread).join
       else
         assert_equal 'IRB::RegexpCompletor', @context.send(:build_completor).class.name
       end


### PR DESCRIPTION
Ruby's leak check will catch thread (and file descriptor reading RBS) leak in `TestIRB::ContextTest#test_build_completor`

This pull request will wait for IRB:TypeCompletion::Types preloading thread to stop.
