### PR TITLE
Fallback to non-colored inspect when coloring takes too long

### DIFF
--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -61,6 +61,8 @@ module IRB
       @io = nil
 
       self.inspect_mode = IRB.conf[:INSPECT_MODE]
+      @inspect_coloring_timeout = IRB.conf[:INSPECT_COLORING_TIMEOUT]
+
       self.use_tracer = IRB.conf[:USE_TRACER] if IRB.conf[:USE_TRACER]
       self.use_loader = IRB.conf[:USE_LOADER] if IRB.conf[:USE_LOADER]
       self.eval_history = IRB.conf[:EVAL_HISTORY] if IRB.conf[:EVAL_HISTORY]
@@ -251,6 +253,8 @@ module IRB
     attr_reader :use_autocomplete
     # A copy of the default <code>IRB.conf[:INSPECT_MODE]</code>
     attr_reader :inspect_mode
+    # Timeout (in seconds) for inspect coloring when INSPECT_MODE is :pp or :pretty_inspect.
+    attr_reader :inspect_coloring_timeout
 
     # A copy of the default <code>IRB.conf[:PROMPT_MODE]</code>
     attr_reader :prompt_mode

--- a/lib/irb/pp_printer.rb
+++ b/lib/irb/pp_printer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'pp'
+
+module IRB
+  class PpPrinter < ::PP
+    METHOD_RESPOND_TO = Object.instance_method(:respond_to?)
+    METHOD_INSPECT = Object.instance_method(:inspect)
+
+    class << self
+      def pp(obj, out = $>, width = screen_width)
+        q = PpPrinter.new(out, width)
+        q.guard_inspect_key {q.pp obj}
+        q.flush
+        out << "\n"
+      end
+
+      private
+
+      def screen_width
+        Reline.get_screen_size.last
+      rescue Errno::EINVAL # in `winsize': Invalid argument - <STDIN>
+        79
+      end
+    end
+
+    def pp(obj)
+      if String === obj
+        # Avoid calling Ruby 2.4+ String#pretty_print that splits a string by "\n"
+        obj.inspect
+      elsif !METHOD_RESPOND_TO.bind(obj).call(:inspect)
+        text(METHOD_INSPECT.bind(obj).call)
+      else
+        super
+      end
+    end
+  end
+end


### PR DESCRIPTION
Inspecting large objects may take a long time since IRB colors the entire output of #inspect all at once.
This patch lets IRB to give up coloring after a certain time and fall back to non-colored output.
Changes can be observed by inspecting large Arrays, for example `[1] * 1000000`.

The default timeout is 2 seconds, but this can be configured through `IRB.conf[:INSPECT_COLORING_TIMEOUT]`.
Passing nil to this option will disable timeouts (IRB will never fall back to non-colored output).