### PR TITLE
Remove racc from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,6 @@ gem "test-unit"
 gem "test-unit-ruby-core"
 gem "debug", github: "ruby/debug"
 
-gem "racc"
-
 if RUBY_VERSION >= "3.0.0"
   gem "rbs"
   gem "prism", ">= 0.17.1"


### PR DESCRIPTION
It was added to workaround a build failure. But it doesn't seem to be needed anymore.