### PR TITLE
Implement `history` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ IRB
   source         Loads a given file in the current session.
   irb_info       Show information about IRB.
   show_cmds      List all available commands and their description.
+  history        Shows the input history. `-g [query]` or `-G [query]` allows you to filter the output.
 
 Multi-irb (DEPRECATED)
   irb            Start a child IRB.

--- a/lib/irb/cmd/history.rb
+++ b/lib/irb/cmd/history.rb
@@ -23,8 +23,8 @@ module IRB
         formatted_inputs = irb_context.io.class::HISTORY.each_with_index.reverse_each.map do |input, index|
           header = "#{index}: "
 
-          first_line, *other_lines = input.split("\n") || [""]
-          first_line.prepend header
+          first_line, *other_lines = input.split("\n")
+          first_line = "#{header}#{first_line}"
 
           truncated_lines = other_lines.slice!(1..) # Show 1 additional line (2 total)
           other_lines << "..." if truncated_lines&.any?

--- a/lib/irb/cmd/history.rb
+++ b/lib/irb/cmd/history.rb
@@ -13,15 +13,13 @@ module IRB
       description "Shows the input history. `-g [query]` or `-G [query]` allows you to filter the output."
 
       def self.transform_args(args)
-        if match = args&.match(/\A(?<args>.+\s|)(-g|-G)\s+(?<grep>[^\s]+)\s*\n\z/)
-          args = match[:args]
-          "#{args}#{',' unless args.chomp.empty?} grep: /#{match[:grep]}/"
-        else
-          args
-        end
+        match = args&.match(/(-g|-G)\s+(?<grep>[^\s]+)\s*\n\z/)
+        return unless match
+
+        "grep: /#{match[:grep]}/"
       end
 
-      def execute(*arg, grep: nil)
+      def execute(grep: nil)
         formatted_inputs = irb_context.io.class::HISTORY.each_with_index.reverse_each.map do |input, index|
           header = "#{index}: "
 

--- a/lib/irb/cmd/history.rb
+++ b/lib/irb/cmd/history.rb
@@ -35,7 +35,7 @@ module IRB
             " " * header.length + line
           end
 
-          StringIO.new.tap { |io| io.puts(first_line, *other_lines) }.string
+          [first_line, *other_lines].join("\n") + "\n"
         end
 
         Pager.page_content(formatted_inputs.join)

--- a/lib/irb/cmd/history.rb
+++ b/lib/irb/cmd/history.rb
@@ -13,7 +13,7 @@ module IRB
       description "Shows the input history. `-g [query]` or `-G [query]` allows you to filter the output."
 
       def self.transform_args(args)
-        match = args&.match(/(-g|-G)\s+(?<grep>[^\s]+)\s*\n\z/)
+        match = args&.match(/(-g|-G)\s+(?<grep>.+)\s*\n\z/)
         return unless match
 
         "grep: /#{match[:grep]}/"

--- a/lib/irb/cmd/history.rb
+++ b/lib/irb/cmd/history.rb
@@ -16,7 +16,7 @@ module IRB
         match = args&.match(/(-g|-G)\s+(?<grep>.+)\s*\n\z/)
         return unless match
 
-        "grep: /#{match[:grep]}/"
+        "grep: #{Regexp.new(match[:grep]).inspect}"
       end
 
       def execute(grep: nil)

--- a/lib/irb/cmd/history.rb
+++ b/lib/irb/cmd/history.rb
@@ -18,7 +18,7 @@ module IRB
           header = "#{index}: "
           header_length = header.size
 
-          lines = input.split("\n")
+          lines = input.split("\n") || [""]
           first_line = header + lines[0]
 
           truncated_input = lines[1..1]

--- a/lib/irb/cmd/history.rb
+++ b/lib/irb/cmd/history.rb
@@ -20,7 +20,9 @@ module IRB
       end
 
       def execute(grep: nil)
-        formatted_inputs = irb_context.io.class::HISTORY.each_with_index.reverse_each.map do |input, index|
+        formatted_inputs = irb_context.io.class::HISTORY.each_with_index.reverse_each.filter_map do |input, index|
+          next if grep && !input.match?(grep)
+
           header = "#{index}: "
 
           first_line, *other_lines = input.split("\n")
@@ -35,8 +37,6 @@ module IRB
 
           StringIO.new.tap { |io| io.puts(first_line, *other_lines) }.string
         end
-
-        formatted_inputs = formatted_inputs.grep(grep) if grep
 
         Pager.page_content(formatted_inputs.join)
       end

--- a/lib/irb/cmd/history.rb
+++ b/lib/irb/cmd/history.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "stringio"
+require_relative "nop"
+require_relative "../pager"
+
+module IRB
+  # :stopdoc:
+
+  module ExtendCommand
+    class History < Nop
+      category "IRB"
+      description "Show the input history."
+
+      def execute(*)
+        output = StringIO.new
+        irb_context.io.class::HISTORY.each_with_index.reverse_each do |input, index|
+          header = "#{index}: "
+          header_length = header.size
+
+          lines = input.split("\n")
+          first_line = header + lines[0]
+
+          truncated_input = lines[1..1]
+          truncated_input << "..." if lines.size > 2
+
+          truncated_input = truncated_input.map do |line|
+            " " * header_length + line
+          end
+
+          output.puts [first_line, *truncated_input].join("\n")
+        end
+
+        Pager.page_content(output.string)
+      end
+    end
+  end
+
+  # :startdoc:
+end

--- a/lib/irb/cmd/history.rb
+++ b/lib/irb/cmd/history.rb
@@ -16,19 +16,18 @@ module IRB
         output = StringIO.new
         irb_context.io.class::HISTORY.each_with_index.reverse_each do |input, index|
           header = "#{index}: "
-          header_length = header.size
 
-          lines = input.split("\n") || [""]
-          first_line = header + lines[0]
+          first_line, *other_lines = input.split("\n") || [""]
+          first_line.prepend header
 
-          truncated_input = lines[1..1]
-          truncated_input << "..." if lines.size > 2
+          truncated_lines = other_lines.slice!(1..) # Show 1 additional line (2 total)
+          other_lines << "..." if truncated_lines&.any?
 
-          truncated_input = truncated_input.map do |line|
-            " " * header_length + line
+          other_lines.map! do |line|
+            " " * header.length + line
           end
 
-          output.puts first_line, *truncated_input
+          output.puts first_line, *other_lines
         end
 
         Pager.page_content(output.string)

--- a/lib/irb/cmd/history.rb
+++ b/lib/irb/cmd/history.rb
@@ -28,7 +28,7 @@ module IRB
             " " * header_length + line
           end
 
-          output.puts [first_line, *truncated_input].join("\n")
+          output.puts first_line, *truncated_input
         end
 
         Pager.page_content(output.string)

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -191,6 +191,12 @@ module IRB # :nodoc:
       [
         :irb_show_cmds, :ShowCmds, "cmd/show_cmds",
         [:show_cmds, NO_OVERRIDE],
+      ],
+
+      [
+        :irb_history, :History, "cmd/history",
+        [:history, NO_OVERRIDE],
+        [:hist, NO_OVERRIDE],
       ]
     ]
 

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -1013,6 +1013,26 @@ module TestIRB
       EOF
       assert_empty err
     end
+
+    def test_history_grep
+      TestInputMethod.const_set("HISTORY", ["foo", "bar", <<~INPUT])
+        [].each do |x|
+          puts x
+        end
+      INPUT
+
+      out, err = without_rdoc do
+        execute_lines("hist -g each\n")
+      end
+
+      assert_include(out, <<~EOF)
+        2: [].each do |x|
+             puts x
+           ...
+      EOF
+      assert_empty err
+    end
+
   end
 
 end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -971,4 +971,48 @@ module TestIRB
       assert_match("command: ': code2'", out)
     end
   end
+
+  class HistoryCmdTest < CommandTestCase
+    def teardown
+      TestInputMethod.send(:remove_const, "HISTORY") if defined?(TestInputMethod::HISTORY)
+      super
+    end
+
+    def test_history
+      TestInputMethod.const_set("HISTORY", %w[foo bar baz])
+
+      out, err = without_rdoc do
+        execute_lines("history")
+      end
+
+      assert_include(out, <<~EOF)
+        2: baz
+        1: bar
+        0: foo
+      EOF
+      assert_empty err
+    end
+
+    def test_multiline_history_with_truncation
+      TestInputMethod.const_set("HISTORY", ["foo", "bar", <<~INPUT])
+        [].each do |x|
+          puts x
+        end
+      INPUT
+
+      out, err = without_rdoc do
+        execute_lines("hist")
+      end
+
+      assert_include(out, <<~EOF)
+        2: [].each do |x|
+             puts x
+           ...
+        1: bar
+        0: foo
+      EOF
+      assert_empty err
+    end
+  end
+
 end


### PR DESCRIPTION
This PR adds the `history` command (aliased as `hist`) which provides a list of previous IRB inputs. This supports multiline inputs but truncates them to two lines. Lines are displayed in reverse to show the most recent inputs first.

This command also supports grep (`-g` or `-G` option); similar to the `ls` command.

<img width="253" alt="image" src="https://github.com/ruby/irb/assets/20099646/587ce6aa-7b9b-408b-b504-3d6c687043f2">

Closes https://github.com/ruby/irb/issues/751