### PR TITLE
require 'irb/version to test completion of constant `IRB::VERSION`

### DIFF
--- a/test/irb/type_completion/test_type_analyze.rb
+++ b/test/irb/type_completion/test_type_analyze.rb
@@ -10,7 +10,7 @@ rescue LoadError
   return
 end
 
-
+require 'irb/version'
 require 'irb/completion'
 require 'irb/type_completion/completor'
 require_relative '../helper'

--- a/test/irb/type_completion/test_type_completor.rb
+++ b/test/irb/type_completion/test_type_completor.rb
@@ -10,6 +10,7 @@ rescue LoadError
   return
 end
 
+require 'irb/version'
 require 'irb/type_completion/completor'
 require_relative '../helper'
 


### PR DESCRIPTION
because test fails in ruby ci