### PR TITLE
Fix irb-1.9.0 crash on `{}.` completion

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -210,16 +210,16 @@ module IRB
         end
 
       when /^([^\}]*\})\.([^.]*)$/
-        # Proc or Hash
+        # Hash or Proc
         receiver = $1
         message = $2
 
         if doc_namespace
-          ["Proc.#{message}", "Hash.#{message}"]
+          ["Hash.#{message}", "Proc.#{message}"]
         else
-          proc_candidates = Proc.instance_methods.collect{|m| m.to_s}
           hash_candidates = Hash.instance_methods.collect{|m| m.to_s}
-          select_message(receiver, message, proc_candidates | hash_candidates)
+          proc_candidates = Proc.instance_methods.collect{|m| m.to_s}
+          select_message(receiver, message, hash_candidates | proc_candidates)
         end
 
       when /^(:[^:.]+)$/

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -312,6 +312,9 @@ module IRB
         return nil if result.nil? or pointer.nil? or pointer < 0
 
         name = doc_namespace.call(result[pointer])
+        # Use first one because document dialog does not support multiple namespaces.
+        name = name.first if name.is_a?(Array)
+
         show_easter_egg = name&.match?(/\ARubyVM/) && !ENV['RUBY_YES_I_AM_NOT_A_NORMAL_USER']
 
         options = {}

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -37,11 +37,11 @@ module TestIRB
       def test_complete_hash_and_proc
         # hash
         assert_include(completion_candidates("{}.an", binding), "{}.any?")
-        assert_equal(["Proc.any?", "Hash.any?"], doc_namespace("{}.any?", binding))
+        assert_equal(["Hash.any?", "Proc.any?"], doc_namespace("{}.any?", binding))
 
         # proc
         assert_include(completion_candidates("{}.bin", binding), "{}.binding")
-        assert_equal(["Proc.binding", "Hash.binding"], doc_namespace("{}.binding", binding))
+        assert_equal(["Hash.binding", "Proc.binding"], doc_namespace("{}.binding", binding))
       end
 
       def test_complete_numeric

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -203,6 +203,21 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     EOC
   end
 
+  def test_autocomplete_with_multiple_doc_namespaces
+    write_irbrc <<~'LINES'
+      puts 'start IRB'
+    LINES
+    start_terminal(4, 40, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    write("{}.__id_")
+    write("\C-i")
+    close
+    assert_screen(<<~EOC)
+      start IRB
+      irb(main):001> {}.__id__
+                      }.__id__
+    EOC
+  end
+
   def test_autocomplete_with_showdoc_in_gaps_on_narrow_screen_right
     rdoc_dir = File.join(@tmpdir, 'rdoc')
     system("bundle exec rdoc -r -o #{rdoc_dir}")


### PR DESCRIPTION
Fix IRB crash when showing document of `{}.`

In RegexpCompletor, doc_namespace of `{}.` will return an array `["Proc.#{message}", "Hash.#{message}"]`
When `name = doc_namespace.call(result[pointer])` is not a String nor nil, IRB crashes.

Change to use the first namespaces. This will fix a bug that document of `{}.` was not shown from the beginning(irb 1.4.0, 
 first version that implements autocomplete and document dialog).

I also changed the order of Hash and Proc because Hash is more important to show in document dialog.

### Reproduce
Run irb with `irb -f`
Type `{}.`
Press TAB key

```
$ irb -f
irb(main):001> {}.parameters/Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb/input-method.rb:315:in `block in show_doc_dialog_proc': undefined method `match?' for ["Proc.parameters", "Hash.parameters"]:Array (NoMethodError)         }.parameters                     ▀
                }.hash                            
        show_easter_egg = name&.match?(/\ARubyVM/) && !ENV['RUBY_YES_I_AM_NOT_A_NORMAL_USER']
                              ^^^^^^^^            
        from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline/line_editor.rb:588:in `instance_exec'
        from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline/line_editor.rb:588:in `call'
        from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline/line_editor.rb:623:in `call'
        from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline/line_editor.rb:776:in `update_each_dialog'
        from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline/line_editor.rb:652:in `block in render_dialog'
        from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline/line_editor.rb:650:in `map'
        from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline/line_editor.rb:650:in `render_dialog'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline/line_editor.rb:500:in `rerender'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline.rb:351:in `block (3 levels) in inner_readline'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline.rb:349:in `each'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline.rb:349:in `block (2 levels) in inner_readline'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline.rb:424:in `block in read_io'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline.rb:394:in `loop'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline.rb:394:in `read_io'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline.rb:347:in `block in inner_readline'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline.rb:345:in `loop'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline.rb:345:in `inner_readline'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline.rb:273:in `block in readmultiline'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline/ansi.rb:152:in `block in with_raw_input'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline/ansi.rb:152:in `raw'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline/ansi.rb:152:in `with_raw_input'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.0/lib/reline.rb:269:in `readmultiline'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/3.2.0/forwardable.rb:240:in `readmultiline'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb/input-method.rb:449:in `gets'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb.rb:539:in `block in read_input'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb.rb:823:in `signal_status'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb.rb:537:in `read_input'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb.rb:559:in `readmultiline'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb.rb:586:in `block in each_top_level_statement'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb.rb:585:in `loop'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb.rb:585:in `each_top_level_statement'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb.rb:507:in `eval_input'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb.rb:494:in `block in run'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb.rb:493:in `catch'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb.rb:493:in `run'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/lib/irb.rb:395:in `start'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.9.0/exe/irb:9:in `<top (required)>'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/bin/irb:25:in `load'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/bin/irb:25:in `<main>'
```