### PR TITLE
Hint debugger command in `irb:rdbg` session

### DIFF
--- a/lib/irb/debug.rb
+++ b/lib/irb/debug.rb
@@ -57,6 +57,24 @@ module IRB
           DEBUGGER__::ThreadClient.prepend(SkipPathHelperForIRB)
         end
 
+        if !@output_modifier_defined && !DEBUGGER__::CONFIG[:no_hint]
+          irb_output_modifier_proc = Reline.output_modifier_proc
+
+          Reline.output_modifier_proc = proc do |output, complete:|
+            unless output.strip.empty?
+              cmd = output.split(/\s/, 2).first
+
+              if DEBUGGER__.commands.key?(cmd)
+                output = output.sub(/\n$/, " # debug command\n")
+              end
+            end
+
+            irb_output_modifier_proc.call(output, complete: complete)
+          end
+
+          @output_modifier_defined = true
+        end
+
         true
       end
 


### PR DESCRIPTION
## Background

In https://github.com/ruby/debug/pull/1024#issuecomment-1811928142, @ko1 raised the concern that users may accidentally hit `debug` commands when trying to evaluate variables with certain names. I then talked to a few IRB users during RubyConf and some of them confirmed that this did happen to them before. So I think we should explore methods to avoid such confusion.

## Description

When user enters `irb:rdbg` session, they don't get the same hint that the `debug` gem provides, like

```
(rdbg) n    # next command
```

This means that users may accidentally execute commands when they want to retrieve the value of a variable.

So this commit adds a Reline output modifier to add a simiar hint:

```
irb:rdbg(main):002> n # debug command
```

It is not exactly the same as `debug`'s because in this case the importance is to help users distinguish between value evaluation and debugger command execution.