### PR TITLE
Enable completion setting through `IRB_COMPLETOR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ irb(main):002> a.first. # Completes Integer methods
 
 - `NO_COLOR`: Assigning a value to it disables IRB's colorization.
 - `IRB_USE_AUTOCOMPLETE`: Setting it to `false` disables IRB's autocompletion.
+- `IRB_COMPLETOR`: Configures IRB's auto-completion behavior, allowing settings for either `regexp` or `type`.
 - `VISUAL`: Its value would be used to open files by the `edit` command.
 - `EDITOR`: Its value would be used to open files by the `edit` command if `VISUAL` is unset.
 - `IRBRC`: The file specified would be evaluated as IRB's rc-file.

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -76,7 +76,7 @@ module IRB # :nodoc:
     @CONF[:USE_SINGLELINE] = false unless defined?(ReadlineInputMethod)
     @CONF[:USE_COLORIZE] = (nc = ENV['NO_COLOR']).nil? || nc.empty?
     @CONF[:USE_AUTOCOMPLETE] = ENV.fetch("IRB_USE_AUTOCOMPLETE", "true") != "false"
-    @CONF[:COMPLETOR] = :regexp
+    @CONF[:COMPLETOR] = ENV.fetch("IRB_COMPLETOR", "regexp").to_sym
     @CONF[:INSPECT_MODE] = true
     @CONF[:USE_TRACER] = false
     @CONF[:USE_LOADER] = false

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -120,6 +120,34 @@ module TestIRB
       IRB.conf[:USE_AUTOCOMPLETE] = orig_use_autocomplete_conf
     end
 
+    def test_completor_environment_variable
+      orig_use_autocomplete_env = ENV['IRB_COMPLETOR']
+      orig_use_autocomplete_conf = IRB.conf[:COMPLETOR]
+
+      ENV['IRB_COMPLETOR'] = nil
+      IRB.setup(__FILE__)
+      assert_equal(:regexp, IRB.conf[:COMPLETOR])
+
+      ENV['IRB_COMPLETOR'] = 'regexp'
+      IRB.setup(__FILE__)
+      assert_equal(:regexp, IRB.conf[:COMPLETOR])
+
+      ENV['IRB_COMPLETOR'] = 'type'
+      IRB.setup(__FILE__)
+      assert_equal(:type, IRB.conf[:COMPLETOR])
+
+      ENV['IRB_COMPLETOR'] = 'regexp'
+      IRB.setup(__FILE__, argv: ['--type-completor'])
+      assert_equal :type, IRB.conf[:COMPLETOR]
+
+      ENV['IRB_COMPLETOR'] = 'type'
+      IRB.setup(__FILE__, argv: ['--regexp-completor'])
+      assert_equal :regexp, IRB.conf[:COMPLETOR]
+    ensure
+      ENV['IRB_COMPLETOR'] = orig_use_autocomplete_env
+      IRB.conf[:COMPLETOR] = orig_use_autocomplete_conf
+    end
+
     def test_completor_setup_with_argv
       orig_completor_conf = IRB.conf[:COMPLETOR]
 


### PR DESCRIPTION
I propose introducing the capability to set the IRB completion kinds via an environment variable, specifically `IRB_COMPLETOR=type`.
This feature aims to enhance the Rails console experience by allowing Rails users to specify their preferred completion more conveniently.

Currently, when using the Rails console, there's no straightforward way to set the type completion across a Rails application repository.
It's possible to configure this setting by placing a `.irbrc` file at the project root. However, using a `.irbrc` file is not ideal as it allows for broad configurations and can potentially affect the production environment.
My suggestion focuses on allowing users to set the completion to `type` in a minimal.

This enhancement would be particularly beneficial for teams writing RBS in their Rails applications.
This type completor, integrated with RBS, would enhance completion accuracy, improving the Rails console experience.