### PR TITLE
Require prism >= 0.18.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,5 +20,5 @@ gem "debug", github: "ruby/debug"
 
 if RUBY_VERSION >= "3.0.0"
   gem "rbs"
-  gem "prism", ">= 0.17.1"
+  gem "prism", ">= 0.18.0"
 end

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -164,7 +164,7 @@ module IRB
       RegexpCompletor.new
     end
 
-    TYPE_COMPLETION_REQUIRED_PRISM_VERSION = '0.17.1'
+    TYPE_COMPLETION_REQUIRED_PRISM_VERSION = '0.18.0'
 
     private def build_type_completor
       unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0') && RUBY_ENGINE != 'truffleruby'


### PR DESCRIPTION
`MatchWriteNode#locals` is changed to `MatchWriteNode#targets`
`CaseNode`(`case-when` and `case-in`) is split to `CaseNode` and `CaseMatchNode`
