### PR TITLE
Fix failure of more command with -R option

### DIFF
--- a/lib/irb/pager.rb
+++ b/lib/irb/pager.rb
@@ -62,7 +62,7 @@ module IRB
           pager = Shellwords.split(pager)
           next if pager.empty?
 
-          if pager.first == 'less' || pager.first == 'more'
+          if pager.first == 'less'
             pager << '-R' unless pager.include?('-R')
           end
 


### PR DESCRIPTION
I believe the more command generally does not accept the raw option (-R).
As an example, the more command man included in util-linux shown below does not have the -R option.
https://man7.org/linux/man-pages/man1/more.1.html
When I run pager with irb in an environment where the -less command does not exist, I get the following error

```console
root@12afc3afe8da:/app# irb
irb(main):001> ls File
more: invalid option -- 'R'
Try 'more --help' for more information.
=> nil
irb(main):002> 
```

After installing the irb gem with this Pulll Request modification, I was able to successfully execute pagenation with more.