### PR TITLE
Fix exception(backtrace=nil) prints nothing

### DIFF
--- a/test/irb/test_raise_exception.rb
+++ b/test/irb/test_raise_exception.rb
@@ -7,11 +7,8 @@ module TestIRB
   class RaiseExceptionTest < TestCase
     def test_raise_exception_with_nil_backtrace
       bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []
-      assert_in_out_err(bundle_exec + %w[-rirb -W0 -e IRB.start(__FILE__) -- -f --], <<-IRB, /Exception: foo/, [])
-      e = Exception.new("foo")
-      puts e.inspect
-      def e.backtrace; nil; end
-      raise e
+      assert_in_out_err(bundle_exec + %w[-rirb -W0 -e IRB.start(__FILE__) -- -f --], <<-IRB, /#<Exception: foo>/, [])
+      raise Exception.new("foo").tap {|e| def e.backtrace; nil; end }
 IRB
     end
 


### PR DESCRIPTION
When an exception that has backtrace=nil is raised, IRB prints nothing.

```
irb(main):001> raise StandardError.new('error').tap{def _1.backtrace()=nil}
irb(main):002> raise _
irb(main):003> _
=> #<StandardError: error>
irb(main):004> 
```

I removed `if exc.backtrace` condition. [files?w=1](https://github.com/ruby/irb/pull/782/files?w=1)
Any error on printing error with backtrace will be rescued after #780.

The original test properly ensures stderr to be empty, but it was not properly testing stdout.
```ruby
assert_in_out_err(bundle_exec + %w[-rirb -W0 -e IRB.start(__FILE__) -- -f --], <<-IRB, /Exception: foo/, [])
  e = Exception.new("foo")
  puts e.inspect
  def e.backtrace; nil; end
  raise e
IRB
```
```ruby
e = Exception.new("foo")  # prints "=> #<Exception: foo>" that makes test pass
puts e.inspect            # prints "#<Exception: foo>" and "nil" that also makes test pass
def e.backtrace; nil; end # prints "=> :backtrace"
raise e                   # should print some error message and this should be tested but it doesn't
```
