### PR TITLE
Support disabling pager

### DIFF
--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -82,6 +82,7 @@ module IRB # :nodoc:
     @CONF[:USE_LOADER] = false
     @CONF[:IGNORE_SIGINT] = true
     @CONF[:IGNORE_EOF] = false
+    @CONF[:USE_PAGER] = true
     @CONF[:EXTRA_DOC_DIRS] = []
     @CONF[:ECHO] = nil
     @CONF[:ECHO_ON_ASSIGNMENT] = nil
@@ -285,6 +286,8 @@ module IRB # :nodoc:
         end
       when "--noinspect"
         @CONF[:INSPECT_MODE] = false
+      when "--no-pager"
+        @CONF[:USE_PAGER] = false
       when "--singleline", "--readline", "--legacy"
         @CONF[:USE_SINGLELINE] = true
       when "--nosingleline", "--noreadline"

--- a/lib/irb/lc/help-message
+++ b/lib/irb/lc/help-message
@@ -22,6 +22,7 @@ Usage:  irb.rb [options] [programfile] [arguments]
                     Show truncated result on assignment (default).
   --inspect         Use 'inspect' for output.
   --noinspect       Don't use 'inspect' for output.
+  --no-pager        Don't use pager.
   --multiline       Use multiline editor module (default).
   --nomultiline     Don't use multiline editor module.
   --singleline      Use single line editor module.

--- a/lib/irb/pager.rb
+++ b/lib/irb/pager.rb
@@ -18,7 +18,7 @@ module IRB
       end
 
       def page
-        if STDIN.tty? && pager = setup_pager
+        if IRB.conf[:USE_PAGER] && STDIN.tty? && pager = setup_pager
           begin
             pid = pager.pid
             yield pager

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -23,9 +23,6 @@ module TestIRB
       save_encodings
       IRB.instance_variable_get(:@CONF).clear
       @is_win = (RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/)
-      STDIN.singleton_class.define_method :tty? do
-        false
-      end
     end
 
     def teardown
@@ -34,13 +31,13 @@ module TestIRB
       Dir.chdir(@pwd)
       FileUtils.rm_rf(@tmpdir)
       restore_encodings
-      STDIN.singleton_class.remove_method :tty?
     end
 
     def execute_lines(*lines, conf: {}, main: self, irb_path: nil)
       IRB.init_config(nil)
       IRB.conf[:VERBOSE] = false
       IRB.conf[:PROMPT_MODE] = :SIMPLE
+      IRB.conf[:USE_PAGER] = false
       IRB.conf.merge!(conf)
       input = TestInputMethod.new(lines)
       irb = IRB::Irb.new(IRB::WorkSpace.new(main), input)

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -346,9 +346,11 @@ module TestIRB
     end
 
     def test_show_cmds_display_different_content_when_debugger_is_enabled
+      write_rc <<~RUBY
+        IRB.conf[:USE_PAGER] = false
+      RUBY
+
       write_ruby <<~'ruby'
-        # disable pager
-        STDIN.singleton_class.define_method(:tty?) { false }
         binding.irb
       ruby
 

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -7,8 +7,7 @@ module TestIRB
   class InputTest < IntegrationTestCase
     def test_symbol_aliases_are_handled_correctly
       write_rc <<~RUBY
-        # disable pager
-        STDIN.singleton_class.define_method(:tty?) { false }
+        IRB.conf[:USE_PAGER] = false
       RUBY
 
       write_ruby <<~'RUBY'
@@ -27,8 +26,7 @@ module TestIRB
 
     def test_symbol_aliases_are_handled_correctly_with_singleline_mode
       write_rc <<~RUBY
-        # disable pager
-        STDIN.singleton_class.define_method(:tty?) { false }
+        IRB.conf[:USE_PAGER] = false
         IRB.conf[:USE_SINGLELINE] = true
       RUBY
 


### PR DESCRIPTION
With either `IRB.conf[:NO_PAGER] = true` or `--no-pager` commnad line flag.

I decided use `--no-pager` instead of `--use-pager` because it matches with Pry and git's command line flags.