### PR TITLE
Fix flaky test case test_autocomplete_with_multiple_doc_namespaces

### DIFF
--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -207,15 +207,13 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     write_irbrc <<~'LINES'
       puts 'start IRB'
     LINES
-    start_terminal(4, 40, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(3, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
     write("{}.__id_")
     write("\C-i")
     close
-    assert_screen(<<~EOC)
-      start IRB
-      irb(main):001> {}.__id__
-                      }.__id__
-    EOC
+    screen = result.join("\n").sub(/\n*\z/, "\n")
+    # This assertion passes whether showdoc dialog completed or not.
+    assert_match(/start\ IRB\nirb\(main\):001> {}\.__id__\n                }\.__id__(?:Press )?/, screen)
   end
 
   def test_autocomplete_with_showdoc_in_gaps_on_narrow_screen_right


### PR DESCRIPTION
Not the only solution, but I think this PR will fix #785.

The test_autocomplete_with_multiple_doc_namespaces test case result is unstable due to a delay in the showdoc display, as described in #785.

I assumed that the subject of the test case for test_autocomplete_with_multiple_doc_namespaces was not RDoc display with showdoc.
And I took the approach of ignoring whether or not there is a showdoc display in this PR.