### PR TITLE
Display aliases in help message

### DIFF
--- a/lib/irb/cmd/show_cmds.rb
+++ b/lib/irb/cmd/show_cmds.rb
@@ -16,6 +16,12 @@ module IRB
         commands_info = IRB::ExtendCommandBundle.all_commands_info
         commands_grouped_by_categories = commands_info.group_by { |cmd| cmd[:category] }
 
+        user_aliases = irb_context.instance_variable_get(:@user_aliases)
+
+        commands_grouped_by_categories["Aliases"] = user_aliases.map do |alias_name, target|
+          { display_name: alias_name, description: "Alias for `#{target}`" }
+        end
+
         if irb_context.with_debugger
           # Remove the original "Debugging" category
           commands_grouped_by_categories.delete("Debugging")

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -146,8 +146,20 @@ module IRB
         @newline_before_multiline_output = true
       end
 
-      @command_aliases = IRB.conf[:COMMAND_ALIASES]
+      @user_aliases = IRB.conf[:COMMAND_ALIASES].dup
+      @command_aliases = @user_aliases.merge(KEYWORD_ALIASES)
     end
+
+    # because all input will eventually be evaluated as Ruby code,
+    # command names that conflict with Ruby keywords need special workaround
+    # we can remove them once we implemented a better command system for IRB
+    KEYWORD_ALIASES = {
+      :break => :irb_break,
+      :catch => :irb_catch,
+      :next => :irb_next,
+    }.freeze
+
+    private_constant :KEYWORD_ALIASES
 
     private def build_completor
       completor_type = IRB.conf[:COMPLETOR]

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -188,10 +188,6 @@ module IRB # :nodoc:
       # Symbol aliases
       :'$' => :show_source,
       :'@' => :whereami,
-      # Keyword aliases
-      :break => :irb_break,
-      :catch => :irb_catch,
-      :next => :irb_next,
     }
   end
 

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -683,6 +683,16 @@ module TestIRB
       assert_match(/List all available commands and their description/, out)
       assert_match(/Start the debugger of debug\.gem/, out)
     end
+
+    def test_show_cmds_list_user_aliases
+      out, err = execute_lines(
+        "show_cmds\n"
+      )
+
+      assert_empty err
+      assert_match(/\$\s+Alias for `show_source`/, out)
+      assert_match(/@\s+Alias for `whereami`/, out)
+    end
   end
 
   class LsTest < CommandTestCase


### PR DESCRIPTION
Similar to Pry, it displays aliases in the help message with a dedicated section. With the current default aliases, it looks like:

```
...other sections...

Aliases
  $              Alias for `show_source`
  @              Alias for `whereami`
```

Addresses a point in #775 

> show_cmds doesn't show any of the aliases.