### PR TITLE
Hide debugger hint after the input is submitted

### DIFF
--- a/lib/irb/debug.rb
+++ b/lib/irb/debug.rb
@@ -64,7 +64,7 @@ module IRB
             unless output.strip.empty?
               cmd = output.split(/\s/, 2).first
 
-              if DEBUGGER__.commands.key?(cmd)
+              if !complete && DEBUGGER__.commands.key?(cmd)
                 output = output.sub(/\n$/, " # debug command\n")
               end
             end

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -389,11 +389,15 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     script.close
     start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{script.to_path}}, startup_message: 'start IRB')
     write("debug\n")
-    write("n")
+    write("pp 1\n")
+    write("pp 1")
     close
 
     screen = result.join("\n").sub(/\n*\z/, "\n")
-    assert_include(screen, "irb:rdbg(main):002> n # debug command")
+    # submitted input shouldn't contain hint
+    assert_include(screen, "irb:rdbg(main):002> pp 1\n")
+    # unsubmitted input should contain hint
+    assert_include(screen, "irb:rdbg(main):003> pp 1 # debug command\n")
   ensure
     File.unlink(script) if script
   end


### PR DESCRIPTION
If `output_modifier_proc`'s `complete` arg is true, it means the input is submitted. In that case, debugger hint doesn't provide value to users and adds noise to the output. So we hide it in such case.