### PR TITLE
Make rake test run all tests under `test/irb/` directory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "test" << "test/lib"
   t.libs << "lib"
   t.ruby_opts << "-rhelper"
-  t.test_files = FileList["test/irb/test_*.rb", "test/irb/type_completion/test_*.rb"]
+  t.test_files = FileList["test/irb/**/test_*.rb"]
 end
 
 # To make sure they have been correctly setup for Ruby CI.


### PR DESCRIPTION
I just found that the newly added tests under `test/irb/cmd/` were not run with `rake test`.

I think `rake test` should run all tests under `test/irb/` directory without the need to update it every time we add a subdirectory under it. While this means tests under `test/irb/yamatanooroti` will be run too, without the vterm gem installed they will be skipped anyway.