### PR TITLE
Only install debug with CRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,8 @@ gem "reline", github: "ruby/reline" if ENV["WITH_LATEST_RELINE"] == "true"
 gem "rake"
 gem "test-unit"
 gem "test-unit-ruby-core"
-gem "debug", github: "ruby/debug"
+
+gem "debug", github: "ruby/debug", platforms: [:mri, :mswin]
 
 if RUBY_VERSION >= "3.0.0" && !is_truffleruby
   gem "repl_type_completor"


### PR DESCRIPTION
Since we don't run any `debug` related tests against TruffleRuby, we don't have to install it with TruffleRuby, which is breaking IRB CI atm.

And after https://github.com/ruby/debug/pull/1039 is merged, `debug` itself will test compilation against TruffleRuby directly.