### PR TITLE
Disable pager in eval_history test

### DIFF
--- a/test/irb/test_eval_history.rb
+++ b/test/irb/test_eval_history.rb
@@ -18,6 +18,7 @@ module TestIRB
       IRB.init_config(nil)
       IRB.conf[:VERBOSE] = false
       IRB.conf[:PROMPT_MODE] = :SIMPLE
+      IRB.conf[:USE_PAGER] = false
       IRB.conf.merge!(conf)
       input = TestInputMethod.new(lines)
       irb = IRB::Irb.new(IRB::WorkSpace.new(main), input)


### PR DESCRIPTION
`rake test TEST=test/irb/test_eval_history.rb` fails when terminal height <= 6

Just like #720, found in https://jinroq.hatenablog.jp/entry/2023/12/01/202216

