### PR TITLE
Pager should be disabled when TERM=dumb

### DIFF
--- a/lib/irb/pager.rb
+++ b/lib/irb/pager.rb
@@ -18,7 +18,7 @@ module IRB
       end
 
       def page(retain_content: false)
-        if IRB.conf[:USE_PAGER] && STDIN.tty? && pager = setup_pager(retain_content: retain_content)
+        if should_page? && pager = setup_pager(retain_content: retain_content)
           begin
             pid = pager.pid
             yield pager
@@ -39,6 +39,10 @@ module IRB
       end
 
       private
+
+      def should_page?
+        IRB.conf[:USE_PAGER] && STDIN.tty? && ENV["TERM"] != "dumb"
+      end
 
       def content_exceeds_screen_height?(content)
         screen_height, screen_width = begin


### PR DESCRIPTION
For apps/libs that test against IRB, it's recommended to set `TERM=dumb` so they get minimum disruption from Reline's interactive-focus features.

Therefore, we should follow the convention to disable pager when `TERM=dumb`.

This should address https://github.com/rails/rails/issues/50267