### PR TITLE
Disable pager when TERM is not set too

### DIFF
--- a/lib/irb/pager.rb
+++ b/lib/irb/pager.rb
@@ -41,7 +41,7 @@ module IRB
       private
 
       def should_page?
-        IRB.conf[:USE_PAGER] && STDIN.tty? && ENV["TERM"] != "dumb"
+        IRB.conf[:USE_PAGER] && STDIN.tty? && (ENV.key?("TERM") && ENV["TERM"] != "dumb")
       end
 
       def content_exceeds_screen_height?(content)


### PR DESCRIPTION
To minimise disruption to other projects' CI, I think it's even safer to assume if a shell's `TERM` is not set it's also not fit for pager.