### PR TITLE
Simplify show_source's super calculation

### DIFF
--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -27,17 +27,14 @@ module IRB
           puts "Error: Expected a string but got #{str.inspect}"
           return
         end
-        if str.include? " -s"
-          str, esses = str.split(" -")
-          s_count = esses.count("^s").zero? ? esses.size : 1
-          source = SourceFinder.new(@irb_context).find_source(str, s_count)
-        else
-          source = SourceFinder.new(@irb_context).find_source(str)
-        end
+
+        str, esses = str.split(" -")
+        super_level = esses ? esses.count("s") : 0
+        source = SourceFinder.new(@irb_context).find_source(str, super_level)
 
         if source
           show_source(source)
-        elsif s_count
+        elsif super_level > 0
           puts "Error: Couldn't locate a super definition for #{str}"
         else
           puts "Error: Couldn't locate a definition for #{str}"

--- a/test/irb/cmd/test_show_source.rb
+++ b/test/irb/cmd/test_show_source.rb
@@ -39,6 +39,19 @@ module TestIRB
       assert_match(%r[/irb\/init\.rb], out)
     end
 
+    def test_show_source_with_missing_signature
+      write_ruby <<~'RUBY'
+        binding.irb
+      RUBY
+
+      out = run_ruby_file do
+        type "show_source foo"
+        type "exit"
+      end
+
+      assert_match(%r[Couldn't locate a definition for foo], out)
+    end
+
     def test_show_source_string
       write_ruby <<~'RUBY'
         binding.irb


### PR DESCRIPTION
We can simplify `show_source` command's `-s` flag handling by removing the possibility to have it `nil`. 

I'm also working on a more sophisticated flag parsing mechanism for all commands. And this change will help simplify that solution too.