### PR TITLE
Prevent a warning: setting Encoding.default_external

### DIFF
--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -149,8 +149,10 @@ module TestIRB
     end
 
     def test_history_different_encodings
+      verbose_bak = nil
       backup_default_external = Encoding.default_external
       IRB.conf[:SAVE_HISTORY] = 2
+      $VERBOSE = nil
       Encoding.default_external = Encoding::US_ASCII
       locale = IRB::Locale.new("C")
       assert_history(<<~EXPECTED_HISTORY.encode(Encoding::US_ASCII), <<~INITIAL_HISTORY.encode(Encoding::UTF_8), <<~INPUT, locale: locale)
@@ -163,6 +165,7 @@ module TestIRB
       INPUT
     ensure
       Encoding.default_external = backup_default_external
+      $VERBOSE = verbose_bak
     end
 
     private

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -149,10 +149,9 @@ module TestIRB
     end
 
     def test_history_different_encodings
-      verbose_bak = nil
       backup_default_external = Encoding.default_external
       IRB.conf[:SAVE_HISTORY] = 2
-      $VERBOSE = nil
+      verbose_bak, $VERBOSE = $VERBOSE, nil
       Encoding.default_external = Encoding::US_ASCII
       locale = IRB::Locale.new("C")
       assert_history(<<~EXPECTED_HISTORY.encode(Encoding::US_ASCII), <<~INITIAL_HISTORY.encode(Encoding::UTF_8), <<~INPUT, locale: locale)


### PR DESCRIPTION
This is a sync to changes in ruby/ruby master