### PR TITLE
Warn and do nothing if block is passed to measure command

### DIFF
--- a/lib/irb/cmd/measure.rb
+++ b/lib/irb/cmd/measure.rb
@@ -12,32 +12,29 @@ module IRB
         super(*args)
       end
 
-      def execute(type = nil, arg = nil, &block)
+      def execute(type = nil, arg = nil)
         # Please check IRB.init_config in lib/irb/init.rb that sets
         # IRB.conf[:MEASURE_PROC] to register default "measure" methods,
         # "measure :time" (abbreviated as "measure") and "measure :stackprof".
+
+        if block_given?
+          warn 'Configure IRB.conf[:MEASURE_PROC] to add custom measure methods.'
+          return
+        end
+
         case type
         when :off
-          IRB.conf[:MEASURE] = nil
           IRB.unset_measure_callback(arg)
         when :list
           IRB.conf[:MEASURE_CALLBACKS].each do |type_name, _, arg_val|
             puts "- #{type_name}" + (arg_val ? "(#{arg_val.inspect})" : '')
           end
         when :on
-          IRB.conf[:MEASURE] = true
-          added = IRB.set_measure_callback(type, arg)
+          added = IRB.set_measure_callback(arg)
           puts "#{added[0]} is added." if added
         else
-          if block_given?
-            IRB.conf[:MEASURE] = true
-            added = IRB.set_measure_callback(&block)
-            puts "#{added[0]} is added." if added
-          else
-            IRB.conf[:MEASURE] = true
-            added = IRB.set_measure_callback(type, arg)
-            puts "#{added[0]} is added." if added
-          end
+          added = IRB.set_measure_callback(type, arg)
+          puts "#{added[0]} is added." if added
         end
         nil
       end

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -215,6 +215,7 @@ module IRB # :nodoc:
       added = [:TIME, IRB.conf[:MEASURE_PROC][:TIME], arg]
     end
     if added
+      IRB.conf[:MEASURE] = true
       found = IRB.conf[:MEASURE_CALLBACKS].find{ |m| m[0] == added[0] && m[2] == added[2] }
       if found
         # already added
@@ -235,6 +236,7 @@ module IRB # :nodoc:
       type_sym = type.upcase.to_sym
       IRB.conf[:MEASURE_CALLBACKS].reject!{ |t, | t == type_sym }
     end
+    IRB.conf[:MEASURE] = nil if IRB.conf[:MEASURE_CALLBACKS].empty?
   end
 
   def IRB.init_error

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -226,8 +226,11 @@ module TestIRB
 
       c = Class.new(Object)
       out, err = execute_lines(
-        "3\n",
         "measure\n",
+        "3\n",
+        "measure :off\n",
+        "3\n",
+        "measure :on\n",
         "3\n",
         "measure :off\n",
         "3\n",
@@ -236,7 +239,7 @@ module TestIRB
       )
 
       assert_empty err
-      assert_match(/\A=> 3\nTIME is added\.\n=> nil\nprocessing time: .+\n=> 3\n=> nil\n=> 3\n/, out)
+      assert_match(/\A(TIME is added\.\n=> nil\nprocessing time: .+\n=> 3\n=> nil\n=> 3\n){2}/, out)
       assert_empty(c.class_variables)
     end
 
@@ -353,7 +356,43 @@ module TestIRB
       assert_match(/\A=> 3\nCUSTOM is added\.\n=> nil\ncustom processing time: .+\n=> 3\n=> nil\n=> 3\n/, out)
     end
 
-    def test_measure_with_proc
+    def test_measure_toggle
+      measuring_proc = proc { |line, line_no, &block|
+        time = Time.now
+        result = block.()
+        puts 'custom processing time: %fs' % (Time.now - time) if IRB.conf[:MEASURE]
+        result
+      }
+      conf = {
+        PROMPT: {
+          DEFAULT: {
+            PROMPT_I: '> ',
+            PROMPT_S: '> ',
+            PROMPT_C: '> '
+          }
+        },
+        PROMPT_MODE: :DEFAULT,
+        MEASURE: false,
+        MEASURE_PROC: {
+          FOO: proc { |&block| puts 'foo'; block.call },
+          BAR: proc { |&block| puts 'bar'; block.call }
+        }
+      }
+      out, err = execute_lines(
+        "measure :foo",
+        "measure :on, :bar",
+        "3\n",
+        "measure :off, :foo\n",
+        "measure :off, :bar\n",
+        "3\n",
+        conf: conf
+      )
+
+      assert_empty err
+      assert_match(/\AFOO is added\.\n=> nil\nfoo\nBAR is added\.\n=> nil\nbar\nfoo\n=> 3\nbar\nfoo\n=> nil\nbar\n=> nil\n=> 3\n/, out)
+    end
+
+    def test_measure_with_proc_warning
       conf = {
         PROMPT: {
           DEFAULT: {
@@ -368,26 +407,15 @@ module TestIRB
       c = Class.new(Object)
       out, err = execute_lines(
         "3\n",
-        "measure { |context, code, line_no, &block|\n",
-        "  result = block.()\n",
-        "  puts 'aaa' if IRB.conf[:MEASURE]\n",
-        "  result\n",
-        "}\n",
-        "3\n",
-        "measure { |context, code, line_no, &block|\n",
-        "  result = block.()\n",
-        "  puts 'bbb' if IRB.conf[:MEASURE]\n",
-        "  result\n",
-        "}\n",
-        "3\n",
-        "measure :off\n",
+        "measure do\n",
+        "end\n",
         "3\n",
         conf: conf,
         main: c
       )
 
-      assert_empty err
-      assert_match(/\A=> 3\nBLOCK is added\.\n=> nil\naaa\n=> 3\nBLOCK is added.\naaa\n=> nil\nbbb\n=> 3\n=> nil\n=> 3\n/, out)
+      assert_match(/to add custom measure/, err)
+      assert_match(/\A=> 3\n=> nil\n=> 3\n/, out)
       assert_empty(c.class_variables)
     end
   end


### PR DESCRIPTION
Ruby 3.3 is a good opportunity to add a warning message for measure command with block.
(Although, I think no one reads the warning because (maybe) no one use it.)

I searched the commit that added measure with block but it had no desciption. https://github.com/ruby/irb/pull/183 https://github.com/ruby/irb/pull/184


Measure command with block is
- Not documented
- Misleading. Usage is not `measure{heavy_logic_to_be_measured}`.
- Hard to use as a command
- Has alternative way
- Just making IRB's command system complicated


Usage of measure with block was
```ruby
# Type this in IRB session.
irb> measure do |context, code, line_no, &block|
irb>   t = Time.now
irb>   result = block.call
irb>   puts "time: #{Time.now - t}"
irb>   result
irb> end
# We already have "TIME" measure, so the actual measure command will be longer and complicated than this example.
```

Alternative API of measure with block
```ruby
# Can write this to .irbrc
irb> IRB.conf[:MEASURE_PROC][:FOOBAR] = measure_logic_proc
# Enable it
irb> measure :foobar

# Same as `measure do end`.
irb> IRB.set_measure_callback do |*, &block| measure_logic end
```

Alternative workaround for measure with block
```ruby
irb> t=Time.now; measure_target_code; Time.now - t

irb> def m; t = Time.now; [yield, Time.now - t]; end
irb> m { measure_target_code }
```
Measure with block will register a session-only measure method that you don't need to write to `.irbrc`` for reusing. For this purpose, these workaround is enough and easier than using measure command with block. That's why I think no one use it.
