### PR TITLE
Warn users about errors in loading RC files

### DIFF
--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -389,18 +389,16 @@ module IRB # :nodoc:
     $LOAD_PATH.unshift(*load_path)
   end
 
-  # running config
+  # Run the config file
   def IRB.run_config
     if @CONF[:RC]
       begin
-        load rc_file
-      rescue LoadError, Errno::ENOENT
-      rescue # StandardError, ScriptError
-        print "load error: #{rc_file}\n"
-        print $!.class, ": ", $!, "\n"
-        for err in $@[0, $@.size - 2]
-          print "\t", err, "\n"
-        end
+        file = rc_file
+        # Because rc_file always returns `HOME/.irbrc` even if no rc file is present, we can't warn users about missing rc files.
+        # Otherwise, it'd be very noisy.
+        load file if File.exist?(file)
+      rescue StandardError, ScriptError => e
+        warn "Error loading RC file '#{file}':\n#{e.full_message(highlight: false)}"
       end
     end
   end
@@ -418,7 +416,7 @@ module IRB # :nodoc:
     end
     case rc_file = @CONF[:RC_NAME_GENERATOR].call(ext)
     when String
-      return rc_file
+      rc_file
     else
       fail IllegalRCNameGenerator
     end


### PR DESCRIPTION
1. Because `IRB.rc_file` always generates an rc file name, even if the file doesn't exist, we should check the file exists before trying to load it.
2. If any type of errors occur while loading the rc file, we should warn the user about it.

Closes #579 