### PR TITLE
Remove dead doc

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -705,12 +705,6 @@ require_relative "irb/pager"
 # Command-line option <tt>-W[_level_]<tt>
 # sets warning level; 0=silence, 1=medium, 2=verbose.
 #
-# :stopdoc:
-# === Performance Measurement
-#
-# IRB.conf[:MEASURE] IRB.conf[:MEASURE_CALLBACKS] IRB.conf[:MEASURE_PROC]
-# :startdoc:
-#
 # == Other Features
 #
 # === Load Modules
@@ -771,12 +765,6 @@ require_relative "irb/pager"
 #
 # Note that the configuration file entry overrides the command-line options.
 #
-# :stopdoc:
-# === \Context Mode
-#
-# IRB.conf[:CONTEXT_MODE]
-# :startdoc:
-#
 # === \IRB Name
 #
 # You can specify a name for \IRB.
@@ -814,12 +802,6 @@ require_relative "irb/pager"
 #
 # Each time the configuration is changed,
 # that proc is called with argument +conf+:
-#
-# :stopdoc:
-# === \Locale
-#
-# IRB.conf[:LC_MESSAGES]
-# :startdoc:
 #
 # === Encodings
 #


### PR DESCRIPTION
:stopdoc:/startdoc: did not work for me.  These removed items, which still need to be documented, are for now represented in https://github.com/ruby/irb/issues/815,