### PR TITLE
Add up command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Debugging
   finish         Start the debugger of debug.gem and run its `finish` command.
   backtrace      Start the debugger of debug.gem and run its `backtrace` command.
   info           Start the debugger of debug.gem and run its `info` command.
+  up             Start the debugger of debug.gem and run its `up` command.
 
 Misc
   edit           Open a file with the editor command defined with `ENV["VISUAL"]` or `ENV["EDITOR"]`.

--- a/lib/irb/cmd/up.rb
+++ b/lib/irb/cmd/up.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "debug"
+
+module IRB
+  # :stopdoc:
+
+  module ExtendCommand
+    class Up < DebugCommand
+      def execute(*args)
+        super(pre_cmds: ["up", *args].join(" "))
+      end
+    end
+  end
+
+  # :startdoc:
+end

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -154,6 +154,10 @@ module IRB # :nodoc:
         :irb_debug_info, :Info, "cmd/info",
         [:info, NO_OVERRIDE],
       ],
+      [
+        :irb_up, :Up, "cmd/up",
+        [:up, NO_OVERRIDE],
+      ],
 
       [
         :irb_help, :Help, "cmd/help",

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -225,6 +225,22 @@ module TestIRB
       assert_match(/a = "Hello"/, output)
     end
 
+    def test_up
+      write_ruby <<~'RUBY'
+        def foo; binding.irb; end
+        def bar; foo; end
+        bar
+      RUBY
+
+      output = run_ruby_file do
+        type "up"
+        type "continue"
+      end
+
+      assert_match(/irb\(main\):001> up/, output)
+      assert_match(/=>   2| def bar; foo; end/, output)
+    end
+
     def test_catch
       write_ruby <<~'RUBY'
         binding.irb


### PR DESCRIPTION
Using binding.irb, I sometimes run into a situation where I want to see the caller frame's context. This PR supports `up` command to seamlessly enter the `rdbg:irb` mode just like other commands that do so.

There are also `down` and `frame`. However, I think we don't need `down` in the IRB side because you don't need to use it before `up`. Similarly, you likely don't use `frame` before running `backtrace`. So I think it's fine to leave them as is.