### PR TITLE
Command implementation not by method

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -929,7 +929,7 @@ module IRB
     # Creates a new irb session
     def initialize(workspace = nil, input_method = nil)
       @context = Context.new(self, workspace, input_method)
-      @context.workspace.load_commands_to_main
+      @context.workspace.load_helper_methods_to_main
       @signal_status = :IN_IRB
       @scanner = RubyLex.new
       @line_no = 1
@@ -950,7 +950,7 @@ module IRB
     def debug_readline(binding)
       workspace = IRB::WorkSpace.new(binding)
       context.replace_workspace(workspace)
-      context.workspace.load_commands_to_main
+      context.workspace.load_helper_methods_to_main
       @line_no += 1
 
       # When users run:
@@ -1028,7 +1028,7 @@ module IRB
               return statement.code
             end
 
-            @context.evaluate(statement.evaluable_code, line_no)
+            statement.execute(@context, line_no)
 
             if @context.echo? && !statement.suppresses_echo?
               if statement.is_assignment?
@@ -1084,10 +1084,7 @@ module IRB
         end
 
         code << line
-
-        # Accept any single-line input for symbol aliases or commands that transform
-        # args
-        return code if single_line_command?(code)
+        return code if command?(code)
 
         tokens, opens, terminated = @scanner.check_code_state(code, local_variables: @context.local_variables)
         return code if terminated
@@ -1114,23 +1111,46 @@ module IRB
       end
 
       code.force_encoding(@context.io.encoding)
-      command_or_alias, arg = code.split(/\s/, 2)
-      # Transform a non-identifier alias (@, $) or keywords (next, break)
-      command_name = @context.command_aliases[command_or_alias.to_sym]
-      command = command_name || command_or_alias
-      command_class = ExtendCommandBundle.load_command(command)
-
-      if command_class
-        Statement::Command.new(code, command, arg, command_class)
+      if (command, arg = parse_command(code))
+        command_class = ExtendCommandBundle.load_command(command)
+        Statement::Command.new(code, command_class, arg)
       else
         is_assignment_expression = @scanner.assignment_expression?(code, local_variables: @context.local_variables)
         Statement::Expression.new(code, is_assignment_expression)
       end
     end
 
-    def single_line_command?(code)
-      command = code.split(/\s/, 2).first
-      @context.symbol_alias?(command) || @context.transform_args?(command)
+    ASSIGN_OPERATORS = %w[= += -= *= /= %= **= &= |= &&= ||= ^= <<= >>=]
+    COMMAND_LIKE_ASSIGN_REGEXP = /\A[a-z_]\w* #{Regexp.union(ASSIGN_OPERATORS)}( |$)/
+
+    def parse_command(code)
+      command_name, arg = code.strip.split(/\s/, 2)
+      return unless code.lines.size == 1 && command_name
+      return if COMMAND_LIKE_ASSIGN_REGEXP.match?(code)
+
+      arg ||= ''
+      command = command_name.to_sym
+      # Command aliases are always command. example: $, @
+      if (alias_name = @context.command_aliases[command])
+        return [alias_name, arg]
+      end
+
+      # Check visibility
+      local_variable = @context.local_variables.include?(command)
+      public_method = !!Kernel.instance_method(:public_method).bind_call(@context.main, command) rescue false
+      private_method = !public_method && !!Kernel.instance_method(:method).bind_call(@context.main, command) rescue false
+      if ExtendCommandBundle.execute_as_command?(
+        command,
+        public_method: public_method,
+        private_method: private_method,
+        local_variable: local_variable
+      )
+        [command, arg]
+      end
+    end
+
+    def command?(code)
+      !!parse_command(code)
     end
 
     def configure_io
@@ -1148,9 +1168,7 @@ module IRB
               false
             end
           else
-            # Accept any single-line input for symbol aliases or commands that transform
-            # args
-            next true if single_line_command?(code)
+            next true if command?(code)
 
             _tokens, _opens, terminated = @scanner.check_code_state(code, local_variables: @context.local_variables)
             terminated

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1124,7 +1124,7 @@ module IRB
     COMMAND_LIKE_ASSIGN_REGEXP = /\A[a-z_]\w* #{Regexp.union(ASSIGN_OPERATORS)}( |$)/
 
     def parse_command(code)
-      command_name, arg = code.strip.split(/\s/, 2)
+      command_name, arg = code.strip.split(/\s+/, 2)
       return unless code.lines.size == 1 && command_name
       return if COMMAND_LIKE_ASSIGN_REGEXP.match?(code)
 

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1128,13 +1128,9 @@ module IRB
       end
     end
 
-    ASSIGN_OPERATORS = %w[= += -= *= /= %= **= &= |= &&= ||= ^= <<= >>=]
-    COMMAND_LIKE_ASSIGN_REGEXP = /\A[a-z_]\w* #{Regexp.union(ASSIGN_OPERATORS)}( |$)/
-
     def parse_command(code)
       command_name, arg = code.strip.split(/\s+/, 2)
       return unless code.lines.size == 1 && command_name
-      return if COMMAND_LIKE_ASSIGN_REGEXP.match?(code)
 
       arg ||= ''
       command = command_name.to_sym
@@ -1144,15 +1140,9 @@ module IRB
       end
 
       # Check visibility
-      local_variable = @context.local_variables.include?(command)
       public_method = !!Kernel.instance_method(:public_method).bind_call(@context.main, command) rescue false
       private_method = !public_method && !!Kernel.instance_method(:method).bind_call(@context.main, command) rescue false
-      if ExtendCommandBundle.execute_as_command?(
-        command,
-        public_method: public_method,
-        private_method: private_method,
-        local_variable: local_variable
-      )
+      if ExtendCommandBundle.execute_as_command?(command, public_method: public_method, private_method: private_method)
         [command, arg]
       end
     end

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1028,7 +1028,15 @@ module IRB
               return statement.code
             end
 
-            statement.execute(@context, line_no)
+            case statement
+            when Statement::EmptyInput
+              # Do nothing
+            when Statement::Expression
+              @context.evaluate(statement.code, line_no)
+            when Statement::Command
+              ret = statement.command_class.execute(@context, statement.arg)
+              @context.set_last_value(ret)
+            end
 
             if @context.echo? && !statement.suppresses_echo?
               if statement.is_assignment?

--- a/lib/irb/command.rb
+++ b/lib/irb/command.rb
@@ -12,29 +12,17 @@ module IRB # :nodoc:
 
   # Installs the default irb extensions command bundle.
   module ExtendCommandBundle
-    EXCB = ExtendCommandBundle # :nodoc:
-
-    # See #install_alias_method.
+    # See ExtendCommandBundle.execute_as_command?.
     NO_OVERRIDE = 0
-    # See #install_alias_method.
     OVERRIDE_PRIVATE_ONLY = 0x01
-    # See #install_alias_method.
     OVERRIDE_ALL = 0x02
 
-    # Displays current configuration.
-    #
-    # Modifying the configuration is achieved by sending a message to IRB.conf.
-    def irb_context
-      IRB.CurrentContext
-    end
-
-    @ALIASES = [
-      [:context, :irb_context, NO_OVERRIDE],
-      [:conf, :irb_context, NO_OVERRIDE],
-    ]
-
-
     @EXTEND_COMMANDS = [
+      [
+        :irb_context, :Context, "command/context",
+        [:context, NO_OVERRIDE],
+        [:conf, NO_OVERRIDE],
+      ],
       [
         :irb_exit, :Exit, "command/exit",
         [:exit, OVERRIDE_PRIVATE_ONLY],
@@ -204,6 +192,30 @@ module IRB # :nodoc:
       ],
     ]
 
+    def self.command_override_policies
+      @@command_override_policies ||= @EXTEND_COMMANDS.flat_map do |cmd_name, cmd_class, load_file, *aliases|
+        [[cmd_name, OVERRIDE_ALL]] + aliases
+      end.to_h
+    end
+
+    def self.execute_as_command?(name, public_method:, private_method:, local_variable:)
+      case command_override_policies[name]
+      when OVERRIDE_ALL
+        true
+      when OVERRIDE_PRIVATE_ONLY
+        !public_method && !local_variable
+      when NO_OVERRIDE
+        !public_method && !private_method && !local_variable
+      end
+    end
+
+    def self.has_helper_method?
+      IRB::ExtendCommandBundle.instance_methods.any?
+    end
+
+    def self.command_names
+      command_override_policies.keys.map(&:to_s)
+    end
 
     @@commands = []
 
@@ -247,77 +259,13 @@ module IRB # :nodoc:
       nil
     end
 
-    # Installs the default irb commands.
-    def self.install_extend_commands
-      for args in @EXTEND_COMMANDS
-        def_extend_command(*args)
-      end
-    end
-
-    # Evaluate the given +cmd_name+ on the given +cmd_class+ Class.
-    #
-    # Will also define any given +aliases+ for the method.
-    #
-    # The optional +load_file+ parameter will be required within the method
-    # definition.
     def self.def_extend_command(cmd_name, cmd_class, load_file, *aliases)
-      case cmd_class
-      when Symbol
-        cmd_class = cmd_class.id2name
-      when String
-      when Class
-        cmd_class = cmd_class.name
-      end
+      @EXTEND_COMMANDS.delete_if { |name,| name == cmd_name }
+      @EXTEND_COMMANDS << [cmd_name, cmd_class, load_file, *aliases]
 
-      line = __LINE__; eval %[
-        def #{cmd_name}(*opts, **kwargs, &b)
-          Kernel.require_relative "#{load_file}"
-          ::IRB::Command::#{cmd_class}.execute(irb_context, *opts, **kwargs, &b)
-        end
-      ], nil, __FILE__, line
-
-      for ali, flag in aliases
-        @ALIASES.push [ali, cmd_name, flag]
-      end
+      # Just clear memoized values
+      @@commands = []
+      @@command_override_policies = nil
     end
-
-    # Installs alias methods for the default irb commands, see
-    # ::install_extend_commands.
-    def install_alias_method(to, from, override = NO_OVERRIDE)
-      to = to.id2name unless to.kind_of?(String)
-      from = from.id2name unless from.kind_of?(String)
-
-      if override == OVERRIDE_ALL or
-          (override == OVERRIDE_PRIVATE_ONLY) && !respond_to?(to) or
-          (override == NO_OVERRIDE) &&  !respond_to?(to, true)
-        target = self
-        (class << self; self; end).instance_eval{
-          if target.respond_to?(to, true) &&
-            !target.respond_to?(EXCB.irb_original_method_name(to), true)
-            alias_method(EXCB.irb_original_method_name(to), to)
-          end
-          alias_method to, from
-        }
-      else
-        Kernel.warn "irb: warn: can't alias #{to} from #{from}.\n"
-      end
-    end
-
-    def self.irb_original_method_name(method_name) # :nodoc:
-      "irb_" + method_name + "_org"
-    end
-
-    # Installs alias methods for the default irb commands on the given object
-    # using #install_alias_method.
-    def self.extend_object(obj)
-      unless (class << obj; ancestors; end).include?(EXCB)
-        super
-        for ali, com, flg in @ALIASES
-          obj.install_alias_method(ali, com, flg)
-        end
-      end
-    end
-
-    install_extend_commands
   end
 end

--- a/lib/irb/command.rb
+++ b/lib/irb/command.rb
@@ -198,14 +198,14 @@ module IRB # :nodoc:
       end.to_h
     end
 
-    def self.execute_as_command?(name, public_method:, private_method:, local_variable:)
+    def self.execute_as_command?(name, public_method:, private_method:)
       case command_override_policies[name]
       when OVERRIDE_ALL
         true
       when OVERRIDE_PRIVATE_ONLY
-        !public_method && !local_variable
+        !public_method
       when NO_OVERRIDE
-        !public_method && !private_method && !local_variable
+        !public_method && !private_method
       end
     end
 

--- a/lib/irb/command.rb
+++ b/lib/irb/command.rb
@@ -209,10 +209,6 @@ module IRB # :nodoc:
       end
     end
 
-    def self.has_helper_method?
-      IRB::ExtendCommandBundle.instance_methods.any?
-    end
-
     def self.command_names
       command_override_policies.keys.map(&:to_s)
     end

--- a/lib/irb/command/backtrace.rb
+++ b/lib/irb/command/backtrace.rb
@@ -7,12 +7,8 @@ module IRB
 
   module Command
     class Backtrace < DebugCommand
-      def self.transform_args(args)
-        args&.dump
-      end
-
-      def execute(*args)
-        super(pre_cmds: ["backtrace", *args].join(" "))
+      def execute(arg)
+        execute_debug_command(pre_cmds: "backtrace #{arg}".rstrip)
       end
     end
   end

--- a/lib/irb/command/base.rb
+++ b/lib/irb/command/base.rb
@@ -10,6 +10,10 @@ module IRB
   module Command
     class CommandArgumentError < StandardError; end
 
+    def self.extract_ruby_args(*args, **kwargs)
+      throw :EXTRACT_RUBY_ARGS, [args, kwargs]
+    end
+
     class Base
       class << self
         def category(category = nil)
@@ -29,19 +33,13 @@ module IRB
 
         private
 
-        def string_literal?(args)
-          sexp = Ripper.sexp(args)
-          sexp && sexp.size == 2 && sexp.last&.first&.first == :string_literal
-        end
-
         def highlight(text)
           Color.colorize(text, [:BOLD, :BLUE])
         end
       end
 
-      def self.execute(irb_context, *opts, **kwargs, &block)
-        command = new(irb_context)
-        command.execute(*opts, **kwargs, &block)
+      def self.execute(irb_context, arg)
+        new(irb_context).execute(arg)
       rescue CommandArgumentError => e
         puts e.message
       end
@@ -52,7 +50,26 @@ module IRB
 
       attr_reader :irb_context
 
-      def execute(*opts)
+      def unwrap_string_literal(str)
+        return if str.empty?
+
+        sexp = Ripper.sexp(str)
+        if sexp && sexp.size == 2 && sexp.last&.first&.first == :string_literal
+          @irb_context.workspace.binding.eval(str).to_s
+        else
+          str
+        end
+      end
+
+      def ruby_args(arg)
+        # Use throw and catch to handle arg that includes `;`
+        # For example: "1, kw: (2; 3); 4" will be parsed to [[1], { kw: 3 }]
+        catch(:EXTRACT_RUBY_ARGS) do
+          @irb_context.workspace.binding.eval "IRB::ExtendCommand.extract_ruby_args #{arg}"
+        end || [[], {}]
+      end
+
+      def execute(arg)
         #nop
       end
     end

--- a/lib/irb/command/base.rb
+++ b/lib/irb/command/base.rb
@@ -65,7 +65,7 @@ module IRB
         # Use throw and catch to handle arg that includes `;`
         # For example: "1, kw: (2; 3); 4" will be parsed to [[1], { kw: 3 }]
         catch(:EXTRACT_RUBY_ARGS) do
-          @irb_context.workspace.binding.eval "IRB::ExtendCommand.extract_ruby_args #{arg}"
+          @irb_context.workspace.binding.eval "IRB::Command.extract_ruby_args #{arg}"
         end || [[], {}]
       end
 

--- a/lib/irb/command/break.rb
+++ b/lib/irb/command/break.rb
@@ -7,12 +7,8 @@ module IRB
 
   module Command
     class Break < DebugCommand
-      def self.transform_args(args)
-        args&.dump
-      end
-
-      def execute(args = nil)
-        super(pre_cmds: "break #{args}")
+      def execute(arg)
+        execute_debug_command(pre_cmds: "break #{arg}".rstrip)
       end
     end
   end

--- a/lib/irb/command/catch.rb
+++ b/lib/irb/command/catch.rb
@@ -7,12 +7,8 @@ module IRB
 
   module Command
     class Catch < DebugCommand
-      def self.transform_args(args)
-        args&.dump
-      end
-
-      def execute(*args)
-        super(pre_cmds: ["catch", *args].join(" "))
+      def execute(arg)
+        execute_debug_command(pre_cmds: "catch #{arg}".rstrip)
       end
     end
   end

--- a/lib/irb/command/chws.rb
+++ b/lib/irb/command/chws.rb
@@ -14,7 +14,7 @@ module IRB
       category "Workspace"
       description "Show the current workspace."
 
-      def execute(*obj)
+      def execute(_arg)
         irb_context.main
       end
     end
@@ -23,8 +23,13 @@ module IRB
       category "Workspace"
       description "Change the current workspace to an object."
 
-      def execute(*obj)
-        irb_context.change_workspace(*obj)
+      def execute(arg)
+        if arg.empty?
+          irb_context.change_workspace
+        else
+          obj = eval(arg, irb_context.workspace.binding)
+          irb_context.change_workspace(obj)
+        end
         irb_context.main
       end
     end

--- a/lib/irb/command/context.rb
+++ b/lib/irb/command/context.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module IRB
+  module Command
+    class Context < Base
+      category "IRB"
+      description "Displays current configuration."
+
+      def execute(_arg)
+        # This command just displays the configuration.
+        # Modifying the configuration is achieved by sending a message to IRB.conf.
+        Pager.page_content(IRB.CurrentContext.inspect)
+      end
+    end
+  end
+end

--- a/lib/irb/command/continue.rb
+++ b/lib/irb/command/continue.rb
@@ -7,8 +7,8 @@ module IRB
 
   module Command
     class Continue < DebugCommand
-      def execute(*args)
-        super(do_cmds: ["continue", *args].join(" "))
+      def execute(arg)
+        execute_debug_command(do_cmds: "continue #{arg}".rstrip)
       end
     end
   end

--- a/lib/irb/command/debug.rb
+++ b/lib/irb/command/debug.rb
@@ -13,7 +13,11 @@ module IRB
         binding.method(:irb).source_location.first,
       ].map { |file| /\A#{Regexp.escape(file)}:\d+:in (`|'Binding#)irb'\z/ }
 
-      def execute(pre_cmds: nil, do_cmds: nil)
+      def execute(_arg)
+        execute_debug_command
+      end
+
+      def execute_debug_command(pre_cmds: nil, do_cmds: nil)
         if irb_context.with_debugger
           # If IRB is already running with a debug session, throw the command and IRB.debug_readline will pass it to the debugger.
           if cmd = pre_cmds || do_cmds

--- a/lib/irb/command/delete.rb
+++ b/lib/irb/command/delete.rb
@@ -7,8 +7,8 @@ module IRB
 
   module Command
     class Delete < DebugCommand
-      def execute(*args)
-        super(pre_cmds: ["delete", *args].join(" "))
+      def execute(arg)
+        execute_debug_command(pre_cmds: "delete #{arg}".rstrip)
       end
     end
   end

--- a/lib/irb/command/edit.rb
+++ b/lib/irb/command/edit.rb
@@ -26,19 +26,9 @@ module IRB
           edit Foo#bar
       HELP_MESSAGE
 
-      class << self
-        def transform_args(args)
-          # Return a string literal as is for backward compatibility
-          if args.nil? || args.empty? || string_literal?(args)
-            args
-          else # Otherwise, consider the input as a String for convenience
-            args.strip.dump
-          end
-        end
-      end
-
-      def execute(*args)
-        path = args.first
+      def execute(arg)
+        # Accept string literal for backward compatibility
+        path = unwrap_string_literal(arg)
 
         if path.nil?
           path = @irb_context.irb_path

--- a/lib/irb/command/finish.rb
+++ b/lib/irb/command/finish.rb
@@ -7,8 +7,8 @@ module IRB
 
   module Command
     class Finish < DebugCommand
-      def execute(*args)
-        super(do_cmds: ["finish", *args].join(" "))
+      def execute(arg)
+        execute_debug_command(do_cmds: "finish #{arg}".rstrip)
       end
     end
   end

--- a/lib/irb/command/help.rb
+++ b/lib/irb/command/help.rb
@@ -6,18 +6,9 @@ module IRB
       category "Help"
       description "List all available commands. Use `help <command>` to get information about a specific command."
 
-      class << self
-        def transform_args(args)
-          # Return a string literal as is for backward compatibility
-          if args.empty? || string_literal?(args)
-            args
-          else # Otherwise, consider the input as a String for convenience
-            args.strip.dump
-          end
-        end
-      end
-
-      def execute(command_name = nil)
+      def execute(arg)
+        # Accept string literal for backward compatibility
+        command_name = unwrap_string_literal(arg)
         content =
           if command_name
             if command_class = ExtendCommandBundle.load_command(command_name)

--- a/lib/irb/command/help.rb
+++ b/lib/irb/command/help.rb
@@ -6,18 +6,17 @@ module IRB
       category "Help"
       description "List all available commands. Use `help <command>` to get information about a specific command."
 
-      def execute(arg)
+      def execute(command_name)
         # Accept string literal for backward compatibility
-        command_name = unwrap_string_literal(arg)
         content =
-          if command_name
+          if command_name.empty?
+            help_message
+          else
             if command_class = ExtendCommandBundle.load_command(command_name)
               command_class.help_message || command_class.description
             else
               "Can't find command `#{command_name}`. Please check the command name and try again.\n\n"
             end
-          else
-            help_message
           end
         Pager.page_content(content)
       end

--- a/lib/irb/command/help.rb
+++ b/lib/irb/command/help.rb
@@ -7,7 +7,6 @@ module IRB
       description "List all available commands. Use `help <command>` to get information about a specific command."
 
       def execute(command_name)
-        # Accept string literal for backward compatibility
         content =
           if command_name.empty?
             help_message

--- a/lib/irb/command/history.rb
+++ b/lib/irb/command/history.rb
@@ -12,14 +12,12 @@ module IRB
       category "IRB"
       description "Shows the input history. `-g [query]` or `-G [query]` allows you to filter the output."
 
-      def self.transform_args(args)
-        match = args&.match(/(-g|-G)\s+(?<grep>.+)\s*\n\z/)
-        return unless match
+      def execute(arg)
 
-        "grep: #{Regexp.new(match[:grep]).inspect}"
-      end
+        if (match = arg&.match(/(-g|-G)\s+(?<grep>.+)\s*\n\z/))
+          grep = Regexp.new(match[:grep])
+        end
 
-      def execute(grep: nil)
         formatted_inputs = irb_context.io.class::HISTORY.each_with_index.reverse_each.filter_map do |input, index|
           next if grep && !input.match?(grep)
 

--- a/lib/irb/command/info.rb
+++ b/lib/irb/command/info.rb
@@ -7,12 +7,8 @@ module IRB
 
   module Command
     class Info < DebugCommand
-      def self.transform_args(args)
-        args&.dump
-      end
-
-      def execute(*args)
-        super(pre_cmds: ["info", *args].join(" "))
+      def execute(arg)
+        execute_debug_command(pre_cmds: "info #{arg}".rstrip)
       end
     end
   end

--- a/lib/irb/command/irb_info.rb
+++ b/lib/irb/command/irb_info.rb
@@ -8,7 +8,7 @@ module IRB
       category "IRB"
       description "Show information about IRB."
 
-      def execute
+      def execute(_arg)
         str  = "Ruby version: #{RUBY_VERSION}\n"
         str += "IRB version: #{IRB.version}\n"
         str += "InputMethod: #{IRB.CurrentContext.io.inspect}\n"

--- a/lib/irb/command/load.rb
+++ b/lib/irb/command/load.rb
@@ -21,7 +21,12 @@ module IRB
       category "IRB"
       description "Load a Ruby file."
 
-      def execute(file_name = nil, priv = nil)
+      def execute(arg)
+        args, kwargs = ruby_args(arg)
+        execute_internal(*args, **kwargs)
+      end
+
+      def execute_internal(file_name = nil, priv = nil)
         raise_cmd_argument_error unless file_name
         irb_load(file_name, priv)
       end
@@ -30,7 +35,13 @@ module IRB
     class Require < LoaderCommand
       category "IRB"
       description "Require a Ruby file."
-      def execute(file_name = nil)
+
+      def execute(arg)
+        args, kwargs = ruby_args(arg)
+        execute_internal(*args, **kwargs)
+      end
+
+      def execute_internal(file_name = nil)
         raise_cmd_argument_error unless file_name
 
         rex = Regexp.new("#{Regexp.quote(file_name)}(\.o|\.rb)?")
@@ -63,7 +74,12 @@ module IRB
       category "IRB"
       description "Loads a given file in the current session."
 
-      def execute(file_name = nil)
+      def execute(arg)
+        args, kwargs = ruby_args(arg)
+        execute_internal(*args, **kwargs)
+      end
+
+      def execute_internal(file_name = nil)
         raise_cmd_argument_error unless file_name
 
         source_file(file_name)

--- a/lib/irb/command/ls.rb
+++ b/lib/irb/command/ls.rb
@@ -21,11 +21,11 @@ module IRB
       HELP_MESSAGE
 
       def execute(arg)
-        if match = arg.match(/\A(?<args>.+\s|)(-g|-G)\s+(?<grep>.+)$/)
-          if match[:args].empty?
+        if match = arg.match(/\A(?<target>.+\s|)(-g|-G)\s+(?<grep>.+)$/)
+          if match[:target].empty?
             use_main = true
           else
-            obj = @irb_context.workspace.binding.eval(match[:args])
+            obj = @irb_context.workspace.binding.eval(match[:target])
           end
           grep = Regexp.new(match[:grep])
         else

--- a/lib/irb/command/ls.rb
+++ b/lib/irb/command/ls.rb
@@ -20,27 +20,35 @@ module IRB
           -g [query]  Filter the output with a query.
       HELP_MESSAGE
 
-      def self.transform_args(args)
-        if match = args&.match(/\A(?<args>.+\s|)(-g|-G)\s+(?<grep>[^\s]+)\s*\n\z/)
-          args = match[:args]
-          "#{args}#{',' unless args.chomp.empty?} grep: /#{match[:grep]}/"
+      def execute(arg)
+        if match = arg.match(/\A(?<args>.+\s|)(-g|-G)\s+(?<grep>.+)$/)
+          if match[:args].empty?
+            use_main = true
+          else
+            obj = @irb_context.workspace.binding.eval(match[:args])
+          end
+          grep = Regexp.new(match[:grep])
         else
-          args
+          args, kwargs = ruby_args(arg)
+          use_main = args.empty?
+          obj = args.first
+          grep = kwargs[:grep]
         end
-      end
 
-      def execute(*arg, grep: nil)
+        if use_main
+          obj = irb_context.workspace.main
+          locals = irb_context.workspace.binding.local_variables
+        end
+
         o = Output.new(grep: grep)
 
-        obj    = arg.empty? ? irb_context.workspace.main : arg.first
-        locals = arg.empty? ? irb_context.workspace.binding.local_variables : []
         klass  = (obj.class == Class || obj.class == Module ? obj : obj.class)
 
         o.dump("constants", obj.constants) if obj.respond_to?(:constants)
         dump_methods(o, klass, obj)
         o.dump("instance variables", obj.instance_variables)
         o.dump("class variables", klass.class_variables)
-        o.dump("locals", locals)
+        o.dump("locals", locals) if locals
         o.print_result
       end
 

--- a/lib/irb/command/measure.rb
+++ b/lib/irb/command/measure.rb
@@ -10,15 +10,19 @@ module IRB
         super(*args)
       end
 
-      def execute(type = nil, arg = nil)
-        # Please check IRB.init_config in lib/irb/init.rb that sets
-        # IRB.conf[:MEASURE_PROC] to register default "measure" methods,
-        # "measure :time" (abbreviated as "measure") and "measure :stackprof".
-
-        if block_given?
+      def execute(arg)
+        if arg&.match?(/^do$|^do[^\w]|^\{/)
           warn 'Configure IRB.conf[:MEASURE_PROC] to add custom measure methods.'
           return
         end
+        args, kwargs = ruby_args(arg)
+        execute_internal(*args, **kwargs)
+      end
+
+      def execute_internal(type = nil, arg = nil)
+        # Please check IRB.init_config in lib/irb/init.rb that sets
+        # IRB.conf[:MEASURE_PROC] to register default "measure" methods,
+        # "measure :time" (abbreviated as "measure") and "measure :stackprof".
 
         case type
         when :off

--- a/lib/irb/command/next.rb
+++ b/lib/irb/command/next.rb
@@ -7,8 +7,8 @@ module IRB
 
   module Command
     class Next < DebugCommand
-      def execute(*args)
-        super(do_cmds: ["next", *args].join(" "))
+      def execute(arg)
+        execute_debug_command(do_cmds: "next #{arg}".rstrip)
       end
     end
   end

--- a/lib/irb/command/pushws.rb
+++ b/lib/irb/command/pushws.rb
@@ -14,7 +14,7 @@ module IRB
       category "Workspace"
       description "Show workspaces."
 
-      def execute(*obj)
+      def execute(_arg)
         inspection_resuls = irb_context.instance_variable_get(:@workspace_stack).map do |ws|
           truncated_inspect(ws.main)
         end
@@ -39,8 +39,13 @@ module IRB
       category "Workspace"
       description "Push an object to the workspace stack."
 
-      def execute(*obj)
-        irb_context.push_workspace(*obj)
+      def execute(arg)
+        if arg.empty?
+          irb_context.push_workspace
+        else
+          obj = eval(arg, irb_context.workspace.binding)
+          irb_context.push_workspace(obj)
+        end
         super
       end
     end
@@ -49,8 +54,8 @@ module IRB
       category "Workspace"
       description "Pop a workspace from the workspace stack."
 
-      def execute(*obj)
-        irb_context.pop_workspace(*obj)
+      def execute(_arg)
+        irb_context.pop_workspace
         super
       end
     end

--- a/lib/irb/command/show_doc.rb
+++ b/lib/irb/command/show_doc.rb
@@ -3,17 +3,6 @@
 module IRB
   module Command
     class ShowDoc < Base
-      class << self
-        def transform_args(args)
-          # Return a string literal as is for backward compatibility
-          if args.empty? || string_literal?(args)
-            args
-          else # Otherwise, consider the input as a String for convenience
-            args.strip.dump
-          end
-        end
-      end
-
       category "Context"
       description "Look up documentation with RI."
 
@@ -31,7 +20,9 @@ module IRB
 
       HELP_MESSAGE
 
-      def execute(*names)
+      def execute(arg)
+        # Accept string literal for backward compatibility
+        name = unwrap_string_literal(arg)
         require 'rdoc/ri/driver'
 
         unless ShowDoc.const_defined?(:Ri)
@@ -39,15 +30,13 @@ module IRB
           ShowDoc.const_set(:Ri, RDoc::RI::Driver.new(opts))
         end
 
-        if names.empty?
+        if name.nil?
           Ri.interactive
         else
-          names.each do |name|
-            begin
-              Ri.display_name(name.to_s)
-            rescue RDoc::RI::Error
-              puts $!.message
-            end
+          begin
+            Ri.display_name(name)
+          rescue RDoc::RI::Error
+            puts $!.message
           end
         end
 

--- a/lib/irb/command/show_source.rb
+++ b/lib/irb/command/show_source.rb
@@ -24,18 +24,9 @@ module IRB
           show_source Foo::BAR
       HELP_MESSAGE
 
-      class << self
-        def transform_args(args)
-          # Return a string literal as is for backward compatibility
-          if args.empty? || string_literal?(args)
-            args
-          else # Otherwise, consider the input as a String for convenience
-            args.strip.dump
-          end
-        end
-      end
-
-      def execute(str = nil)
+      def execute(arg)
+        # Accept string literal for backward compatibility
+        str = unwrap_string_literal(arg)
         unless str.is_a?(String)
           puts "Error: Expected a string but got #{str.inspect}"
           return

--- a/lib/irb/command/step.rb
+++ b/lib/irb/command/step.rb
@@ -7,8 +7,8 @@ module IRB
 
   module Command
     class Step < DebugCommand
-      def execute(*args)
-        super(do_cmds: ["step", *args].join(" "))
+      def execute(arg)
+        execute_debug_command(do_cmds: "step #{arg}".rstrip)
       end
     end
   end

--- a/lib/irb/command/subirb.rb
+++ b/lib/irb/command/subirb.rb
@@ -9,10 +9,6 @@ module IRB
 
   module Command
     class MultiIRBCommand < Base
-      def execute(*args)
-        extend_irb_context
-      end
-
       private
 
       def print_deprecated_warning
@@ -36,7 +32,12 @@ module IRB
       category "Multi-irb (DEPRECATED)"
       description "Start a child IRB."
 
-      def execute(*obj)
+      def execute(arg)
+        args, kwargs = ruby_args(arg)
+        execute_internal(*args, **kwargs)
+      end
+
+      def execute_internal(*obj)
         print_deprecated_warning
 
         if irb_context.with_debugger
@@ -44,7 +45,7 @@ module IRB
           return
         end
 
-        super
+        extend_irb_context
         IRB.irb(nil, *obj)
       end
     end
@@ -53,7 +54,7 @@ module IRB
       category "Multi-irb (DEPRECATED)"
       description "List of current sessions."
 
-      def execute
+      def execute(_arg)
         print_deprecated_warning
 
         if irb_context.with_debugger
@@ -61,7 +62,7 @@ module IRB
           return
         end
 
-        super
+        extend_irb_context
         IRB.JobManager
       end
     end
@@ -70,7 +71,12 @@ module IRB
       category "Multi-irb (DEPRECATED)"
       description "Switches to the session of the given number."
 
-      def execute(key = nil)
+      def execute(arg)
+        args, kwargs = ruby_args(arg)
+        execute_internal(*args, **kwargs)
+      end
+
+      def execute_internal(key = nil)
         print_deprecated_warning
 
         if irb_context.with_debugger
@@ -78,7 +84,7 @@ module IRB
           return
         end
 
-        super
+        extend_irb_context
 
         raise CommandArgumentError.new("Please specify the id of target IRB job (listed in the `jobs` command).") unless key
         IRB.JobManager.switch(key)
@@ -89,7 +95,12 @@ module IRB
       category "Multi-irb (DEPRECATED)"
       description "Kills the session with the given number."
 
-      def execute(*keys)
+      def execute(arg)
+        args, kwargs = ruby_args(arg)
+        execute_internal(*args, **kwargs)
+      end
+
+      def execute_internal(*keys)
         print_deprecated_warning
 
         if irb_context.with_debugger
@@ -97,7 +108,7 @@ module IRB
           return
         end
 
-        super
+        extend_irb_context
         IRB.JobManager.kill(*keys)
       end
     end

--- a/lib/irb/command/whereami.rb
+++ b/lib/irb/command/whereami.rb
@@ -8,7 +8,7 @@ module IRB
       category "Context"
       description "Show the source code around binding.irb again."
 
-      def execute(*)
+      def execute(_arg)
         code = irb_context.workspace.code_around_binding
         if code
           puts code

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -646,17 +646,5 @@ module IRB
     def local_variables # :nodoc:
       workspace.binding.local_variables
     end
-
-    # Return true if it's aliased from the argument and it's not an identifier.
-    def symbol_alias?(command)
-      return nil if command.match?(/\A\w+\z/)
-      command_aliases.key?(command.to_sym)
-    end
-
-    # Return true if the command supports transforming args
-    def transform_args?(command)
-      command = command_aliases.fetch(command.to_sym, command)
-      ExtendCommandBundle.load_command(command)&.respond_to?(:transform_args)
-    end
   end
 end

--- a/lib/irb/ext/change-ws.rb
+++ b/lib/irb/ext/change-ws.rb
@@ -29,11 +29,9 @@ module IRB # :nodoc:
         return main
       end
 
-      replace_workspace(WorkSpace.new(_main[0]))
-
-      if !(class<<main;ancestors;end).include?(ExtendCommandBundle)
-        main.extend ExtendCommandBundle
-      end
+      workspace = WorkSpace.new(_main[0])
+      replace_workspace(workspace)
+      workspace.load_helper_methods_to_main
     end
   end
 end

--- a/lib/irb/ext/workspaces.rb
+++ b/lib/irb/ext/workspaces.rb
@@ -19,10 +19,9 @@ module IRB # :nodoc:
           @workspace_stack.push current_workspace, previous_workspace
         end
       else
-        @workspace_stack.push WorkSpace.new(workspace.binding, _main[0])
-        if !(class<<main;ancestors;end).include?(ExtendCommandBundle)
-          main.extend ExtendCommandBundle
-        end
+        new_workspace = WorkSpace.new(workspace.binding, _main[0])
+        @workspace_stack.push new_workspace
+        new_workspace.load_helper_methods_to_main
       end
     end
 

--- a/lib/irb/statement.rb
+++ b/lib/irb/statement.rb
@@ -37,10 +37,6 @@ module IRB
       def code
         ""
       end
-
-      def execute(context, line_no)
-        nil
-      end
     end
 
     class Expression < Statement
@@ -60,17 +56,15 @@ module IRB
       def is_assignment?
         @is_assignment
       end
-
-      def execute(context, line_no)
-        context.evaluate(@code, line_no)
-      end
     end
 
     class Command < Statement
+      attr_reader :command_class, :arg
+
       def initialize(original_code, command_class, arg)
+        @code = original_code
         @command_class = command_class
         @arg = arg
-        @code = original_code
       end
 
       def is_assignment?
@@ -84,11 +78,6 @@ module IRB
       def should_be_handled_by_debugger?
         require_relative 'command/debug'
         IRB::Command::DebugCommand > @command_class
-      end
-
-      def execute(context, line_no)
-        ret = @command_class.execute(context, @arg)
-        context.set_last_value(ret)
       end
     end
   end

--- a/lib/irb/statement.rb
+++ b/lib/irb/statement.rb
@@ -16,10 +16,6 @@ module IRB
       raise NotImplementedError
     end
 
-    def execute(context, line_no)
-      raise NotImplementedError
-    end
-
     class EmptyInput < Statement
       def is_assignment?
         false

--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -109,7 +109,7 @@ EOF
     attr_reader :main
 
     def load_helper_methods_to_main
-      if ExtendCommandBundle.has_helper_method? && !(class<<main;ancestors;end).include?(ExtendCommandBundle)
+      if !(class<<main;ancestors;end).include?(ExtendCommandBundle)
         main.extend ExtendCommandBundle
       end
     end

--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -108,8 +108,10 @@ EOF
     # <code>IRB.conf[:__MAIN__]</code>
     attr_reader :main
 
-    def load_commands_to_main
-      main.extend ExtendCommandBundle
+    def load_helper_methods_to_main
+      if ExtendCommandBundle.has_helper_method? && !(class<<main;ancestors;end).include?(ExtendCommandBundle)
+        main.extend ExtendCommandBundle
+      end
     end
 
     # Evaluate the given +statements+ within the  context of this workspace.

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -213,7 +213,7 @@ module TestIRB
   class CustomCommandTestCase < CommandTestCase
     def setup
       super
-      execute_lines("show_cmds\n") # To ensure command initialization is done
+      execute_lines("help\n") # To ensure command initialization is done
       @EXTEND_COMMANDS_backup = IRB::ExtendCommandBundle.instance_variable_get(:@EXTEND_COMMANDS).dup
       @cvars_backup = IRB::ExtendCommandBundle.class_variables.to_h do |cvar|
         [cvar, IRB::ExtendCommandBundle.class_variable_get(cvar)]

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -601,26 +601,12 @@ module TestIRB
     end
 
     def test_pushws_extends_the_new_workspace_with_command_bundle
-      IRB::ExtendCommandBundle.module_eval do
-        def foobar; end
-      end
       out, err = execute_lines(
         "pushws Object.new",
         "self.singleton_class.ancestors"
       )
       assert_empty err
       assert_include(out, "IRB::ExtendCommandBundle")
-    ensure
-      IRB::ExtendCommandBundle.remove_method :foobar
-    end
-
-    def test_pushws_does_not_extend_command_bundle_by_default
-      out, err = execute_lines(
-        "pushws Object.new\n",
-        "self.singleton_class.ancestors"
-      )
-      assert_empty err
-      assert_not_include(out, "IRB::ExtendCommandBundle")
     end
 
     def test_pushws_prints_workspace_stack_when_no_arg_is_given
@@ -1062,21 +1048,12 @@ module TestIRB
   end
 
   class HelperMethodInsallTest < CommandTestCase
-    def test_extend_command_bundle_not_installed_by_default
-      out, err = execute_lines("self.singleton_class.ancestors")
-      assert_empty err
-      assert_not_include(out, 'IRB::ExtendCommandBundle')
-    end
-
     def test_helper_method_install
       IRB::ExtendCommandBundle.module_eval do
         def foobar
           "test_helper_method_foobar"
         end
       end
-      out, err = execute_lines("self.singleton_class.ancestors")
-      assert_empty err
-      assert_include(out, "IRB::ExtendCommandBundle")
 
       out, err = execute_lines("foobar.upcase")
       assert_empty err

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -373,17 +373,19 @@ module TestIRB
         }
       }
       out, err = execute_lines(
-        "measure :foo",
-        "measure :on, :bar",
-        "3\n",
+        "measure :foo\n",
+        "1\n",
+        "measure :on, :bar\n",
+        "2\n",
         "measure :off, :foo\n",
-        "measure :off, :bar\n",
         "3\n",
+        "measure :off, :bar\n",
+        "4\n",
         conf: conf
       )
 
       assert_empty err
-      assert_match(/\AFOO is added\.\n=> nil\nfoo\nBAR is added\.\n=> nil\nbar\nfoo\n=> 3\nbar\nfoo\n=> nil\nbar\n=> nil\n=> 3\n/, out)
+      assert_match(/\AFOO is added\.\n=> nil\nfoo\n=> 1\nBAR is added\.\n=> nil\nbar\nfoo\n=> 2\n=> nil\nbar\n=> 3\n=> nil\n=> 4\n/, out)
     end
 
     def test_measure_with_proc_warning
@@ -402,7 +404,6 @@ module TestIRB
       out, err = execute_lines(
         "3\n",
         "measure do\n",
-        "end\n",
         "3\n",
         conf: conf,
         main: c
@@ -554,7 +555,8 @@ module TestIRB
       out, err = execute_lines(
         "pushws Foo.new\n",
         "popws\n",
-        "cwws.class",
+        "cwws\n",
+        "_.class",
       )
       assert_empty err
       assert_include(out, "=> #{self.class}")
@@ -573,7 +575,8 @@ module TestIRB
     def test_chws_replaces_the_current_workspace
       out, err = execute_lines(
         "chws #{self.class}::Foo.new\n",
-        "cwws.class",
+        "cwws\n",
+        "_.class",
       )
       assert_empty err
       assert_include(out, "=> #{self.class}::Foo")
@@ -582,7 +585,8 @@ module TestIRB
     def test_chws_does_nothing_when_receiving_no_argument
       out, err = execute_lines(
         "chws\n",
-        "cwws.class",
+        "cwws\n",
+        "_.class",
       )
       assert_empty err
       assert_include(out, "=> #{self.class}")
@@ -730,18 +734,18 @@ module TestIRB
     def test_ls_grep_empty
       out, err = execute_lines("ls\n")
       assert_empty err
-      assert_match(/whereami/, out)
-      assert_match(/show_source/, out)
+      assert_match(/assert/, out)
+      assert_match(/refute/, out)
 
       [
-        "ls grep: /whereami/\n",
-        "ls -g whereami\n",
-        "ls -G whereami\n",
+        "ls grep: /assert/\n",
+        "ls -g assert\n",
+        "ls -G assert\n",
       ].each do |line|
         out, err = execute_lines(line)
         assert_empty err
-        assert_match(/whereami/, out)
-        assert_not_match(/show_source/, out)
+        assert_match(/assert/, out)
+        assert_not_match(/refute/, out)
       end
     end
 

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -14,6 +14,13 @@ module TestIRB
       IRB::RegexpCompletor.new.doc_namespace('', target, '', bind: bind)
     end
 
+    class CommandCompletionTest < CompletionTest
+      def test_command_completion
+        assert_include(IRB::RegexpCompletor.new.completion_candidates('', 'show_s', '', bind: binding), 'show_source')
+        assert_not_include(IRB::RegexpCompletor.new.completion_candidates(';', 'show_s', '', bind: binding), 'show_source')
+      end
+    end
+
     class MethodCompletionTest < CompletionTest
       def test_complete_string
         assert_include(completion_candidates("'foo'.up", binding), "'foo'.upcase")

--- a/test/irb/test_type_completor.rb
+++ b/test/irb/test_type_completor.rb
@@ -9,6 +9,8 @@ rescue LoadError
   return
 end
 
+require 'irb/context'
+require 'irb/command'
 require 'irb/completion'
 require 'tempfile'
 require_relative './helper'
@@ -53,6 +55,11 @@ module TestIRB
       candidates = @completor.completion_candidates('(', ')', '', bind: binding)
       assert_equal [], candidates
       assert_doc_namespace('(', ')', nil)
+    end
+
+    def test_command_completion
+      assert_include(@completor.completion_candidates('', 'show_s', '', bind: binding), 'show_source')
+      assert_not_include(@completor.completion_candidates(';', 'show_s', '', bind: binding), 'show_source')
     end
   end
 

--- a/test/irb/test_type_completor.rb
+++ b/test/irb/test_type_completor.rb
@@ -9,9 +9,7 @@ rescue LoadError
   return
 end
 
-require 'irb/context'
-require 'irb/command'
-require 'irb/completion'
+require 'irb'
 require 'tempfile'
 require_relative './helper'
 


### PR DESCRIPTION
Command implementation without using `obj.extend IRB::ExtendCommandBundle`. Command is not a method anymore.
Fixes #592
Continuation of #547

Command `command arg` was executed by `eval("#{command} #{arg}")` or `eval("command #{transformed_args(arg)}")`.
This pull request will change command execution to `load_command(command).execute(arg)`.

## No main object method polluting by default
Now, IRB has no helper method by default.
~If more than one helper method is defined in ExtendCommandBundle, (like Rails console adds `app` `new_session` `reload!` `helper` `controller`), IRB will reluctantly pollute main object.~ (postponed)

## What kind of input is a command?

IRB has command override policy `NO_OVERRIDE` `OVERRIDE_PRIVATE_ONLY` and `OVERRIDE_ALL` for defined methods.
New command recognition is:
- Every command is single line, so multiline input is not a command
- `command_name arg` might be a command
- check private_method and public_method with the same name exists or not, and follow the override policy.

| input | situation | type(before) | reason(before) | type(after) | reason(after) |
| --- | --- | --- | --- | --- | --- |
| `exit` | private method `Kernel.exit` is defined | command | alias `irb_exit` to `exit` because it's ORVERRIDE_PRIVATE_ONLY | command | command name exists and it's OVERRIDE_PRIVATE_ONLY |
| `exit` | public method `exit` defined by user | expression | does not alias `irb_exit` to `exit` | expression | command name exists but it's OVERRIDE_PRIVATE_ONLY |
| `irb_measure` | | command | ruby evaluates as method because command method exists | command | command name exists |
| `measure` | local var `measure` defined | expression | ruby evaluates as lvar | command | command name exists |
| `measure off` | local var `measure` defined | command | ruby evaluates as method call | command | command name exists |
| `info 'a' + 'b'` | context.main is Logger.new | wrong expression | `logger.info("'a' + 'b'")` because IRB transform args even if command is not installed by NO_OVERRIDE policy | expression | `logger.info('a' + 'b')` because info is NO_OVERRIDE |
| `show_source * -s` | local var `show_source` defined | command | `show_source("* -s")` because transorm_args is defined | command | command name exists |
| `show_source += 1` | | command | `show_source("+= 1")` because transform_args is defined | command | command name exists |
| `info += 1` | | expression | ruby evaluates as opassign | command | command name exists |

## Command completion
Command was a method, so completor can complete it without extra effort.
Now, command is not a method, so this pull request adds command name completion to both RegexpCompletor and TypeCompletor.

## `conf` and `context` method
`conf` `context` method can be used as `conf.eval_history = 100` before.
It is now a command only to show configuration.

The source code comment says it just displays the configuration, and navigates to use `IRB.conf` for modifying it.
```
# Displays current configuration.
#
# Modifying the configuration is achieved by sending a message to IRB.conf.
def irb_context
  IRB.CurrentContext
end

@ALIASES = [
  [:context, :irb_context, NO_OVERRIDE],
  [:conf, :irb_context, NO_OVERRIDE],
  ...
]
```
But a different thing is written in the document that you can use `conf.eval_history = N`.

We can:
- Fix the document (My proposal)
- Show a message when input is `/\A(conf|context)\./`v
- Add a special path to allow it, e.g. `context.evaluate(code.gsub(/\A(conf|context)\./, 'IRB.CurrentContext.'))`
- Keep `conf` and `context` as a method. Polluting main object problem remains.
