### PR TITLE
Fix display_document params in noautocomplete mode

### DIFF
--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -90,7 +90,7 @@ module TestIRB
 
     def display_document(target, bind)
       input_method = IRB::RelineInputMethod.new(IRB::RegexpCompletor.new)
-      input_method.instance_variable_set(:@completion_params, [target, '', '', bind])
+      input_method.instance_variable_set(:@completion_params, ['', target, '', bind])
       input_method.display_document(target, driver: @driver)
     end
 


### PR DESCRIPTION
Fix destructuring completion params in display_document (only used in noautocomplete mode)

```ruby
# Line 250
Reline.completion_proc = ->(target, preposing, postposing) {
  ...
  @completion_params = [preposing, target, postposing, bind]
  ...
}

# Line 296
def show_doc_dialog_proc
  doc_namespace = ->(matched) {
    preposing, _target, postposing, bind = @completion_params
    ...
  }
  ...
end

# Line 422
def display_document(matched, driver: nil)
  ...
  _target, preposing, postposing, bind = @completion_params
  # Should be `preposing, _target, postposing, bind = @completion_params`
  ...
end
```

This bug only affects `irb --noautocomplete --type-completor` because RegexpCompletor does not use `preposing`.
```
$ irb --noautocomplete --type-completor
(type 1.ti[TAB][TAB])
irb(main):001> 1.ti[TAB]
irb(main):001> 1.times[TAB]
(should show rdoc but nothing happens. this pull request fixes it)
```

