### PR TITLE
Remove redundant env cleanup in rendering test

### DIFF
--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -30,7 +30,6 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     FileUtils.rm_rf(@tmpdir)
     ENV['IRBRC'] = @irbrc_backup
     ENV['TERM'] = @original_term
-    ENV.delete('RELINE_TEST_PROMPT') if ENV['RELINE_TEST_PROMPT']
   end
 
   def test_launch


### PR DESCRIPTION
IRB doesn't use this env at all. It's likely copied from Reline's tests and never used.