### PR TITLE
Ensure history file directory exists

### DIFF
--- a/lib/irb/history.rb
+++ b/lib/irb/history.rb
@@ -59,6 +59,8 @@ module IRB
           append_history = true
         end
 
+        FileUtils.mkdir_p(File.dirname(history_file)) unless File.exist?(history_file)
+        
         File.open(history_file, (append_history ? 'a' : 'w'), 0o600, encoding: IRB.conf[:LC_MESSAGES]&.encoding) do |f|
           hist = history.map{ |l| l.scrub.split("\n").join("\\\n") }
           unless append_history


### PR DESCRIPTION
This PR fixes a bug I encountered when configuring IRB with a `HISTORY_FILE` value set to a non-existent path. Steps to reproduce:

```sh
docker run --init --rm -it ruby:3.3.0 /bin/bash

echo 'IRB.conf[:HISTORY_FILE] = "~/.local/share/irb/irb_history"' > ~/.irbrc

irb

irb(main):001> exit
/usr/local/lib/ruby/3.3.0/irb/history.rb:62:in `initialize': No such file or directory @ rb_sysopen - /root/.local/share/irb/irb_history (Errno::ENOENT)
  from /usr/local/lib/ruby/3.3.0/irb/history.rb:62:in `open'
  from /usr/local/lib/ruby/3.3.0/irb/history.rb:62:in `save_history'
  from /usr/local/lib/ruby/3.3.0/irb.rb:1007:in `run'
  from /usr/local/lib/ruby/3.3.0/irb.rb:903:in `start'
  from /usr/local/lib/ruby/gems/3.3.0/gems/irb-1.11.0/exe/irb:9:in `<top (required)>'
  from /usr/local/bin/irb:25:in `load'
  from /usr/local/bin/irb:25:in `<main>'
```

This PR addresses the issue by `mkdir_p`-ing the configured history file's directory if the history file doesn't already exist.

There's a chance that the directory exists and the history file itself doesn't exist which would result in a small bit of extra work being done. I _think_ that's okay given the simplicity of the solution.

Notes:

- For simplicity, I used Docker, but I don't believe that to be necessary to confirm the bug.
- `~/.local/share/irb/irb_history` is an XDG-style path, but for the purposes of demonstrating the underlying issue, any non-existent path would do (e.g. `/foo/bar/biz/baz/irb_history`).
