### PR TITLE
test_recovery_sigint: Ensure precondition is met

### DIFF
--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -69,9 +69,11 @@ module TestIRB
     def test_recovery_sigint
       pend "This test gets stuck on Solaris for unknown reason; contribution is welcome" if RUBY_PLATFORM =~ /solaris/
       bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []
-      status = assert_in_out_err(bundle_exec + %w[-W0 -rirb -e binding.irb;loop{Process.kill("SIGINT",$$)} -- -f --], "exit\n", //, //)
+      # IRB should restore SIGINT handler
+      status = assert_in_out_err(bundle_exec + %w[-W0 -rirb -e Signal.trap("SIGINT","DEFAULT");binding.irb;loop{Process.kill("SIGINT",$$)} -- -f --], "exit\n", //, //)
       Process.kill("SIGKILL", status.pid) if !status.exited? && !status.stopped? && !status.signaled?
     end
+
 
     def test_no_color_environment_variable
       orig_no_color = ENV['NO_COLOR']

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -66,7 +66,7 @@ module TestIRB
       end
     end
 
-    def test_recovery_sigint
+    def test_sigint_restore_default
       pend "This test gets stuck on Solaris for unknown reason; contribution is welcome" if RUBY_PLATFORM =~ /solaris/
       bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []
       # IRB should restore SIGINT handler
@@ -74,6 +74,12 @@ module TestIRB
       Process.kill("SIGKILL", status.pid) if !status.exited? && !status.stopped? && !status.signaled?
     end
 
+    def test_sigint_restore_block
+      bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []
+      # IRB should restore SIGINT handler
+      status = assert_in_out_err(bundle_exec + %w[-W0 -rirb -e x=false;Signal.trap("SIGINT"){x=true};binding.irb;loop{Process.kill("SIGINT",$$);if(x);break;end} -- -f --], "exit\n", //, //)
+      Process.kill("SIGKILL", status.pid) if !status.exited? && !status.stopped? && !status.signaled?
+    end
 
     def test_no_color_environment_variable
       orig_no_color = ENV['NO_COLOR']


### PR DESCRIPTION
1. Ensure precondition is met on test_recovery_sigint. It depends on its process has SIG_DFL sigaction for SIGINT. When its parent process set SIG_IGN which inherits to children, then this test fails. This patch ensures this precondition met regardless of inherited sigaction from its parent.
2. Add another variant of test_recovery_sigint to ensure IRB to preserve existing SIGINT handler other than SIG_DFL.

----

My build process had unintentionally had SIG_IGN for SIGINT so this test started to fail, and took time to understand the cause. But in general it'd be better to ensure precondition in each test case, so sending this patch with additional scenario.