### PR TITLE
Make show_source accept top-level constant names

### DIFF
--- a/lib/irb/source_finder.rb
+++ b/lib/irb/source_finder.rb
@@ -19,7 +19,7 @@ module IRB
     def find_source(signature, super_level = 0)
       context_binding = @irb_context.workspace.binding
       case signature
-      when /\A[A-Z]\w*(::[A-Z]\w*)*\z/ # Const::Name
+      when /\A(::)?[A-Z]\w*(::[A-Z]\w*)*\z/ # Const::Name
         eval(signature, context_binding) # trigger autoload
         base = context_binding.receiver.yield_self { |r| r.is_a?(Module) ? r : Object }
         file, line = base.const_source_location(signature)

--- a/test/irb/cmd/test_show_source.rb
+++ b/test/irb/cmd/test_show_source.rb
@@ -272,5 +272,33 @@ module TestIRB
 
       assert_match(%r[#{@ruby_file.to_path}:2\s+def foo\r\n  end], out)
     end
+
+    def test_show_source_with_double_colons
+      write_ruby <<~RUBY
+        class Foo
+        end
+
+        class Foo
+          class Bar
+          end
+        end
+
+        binding.irb
+      RUBY
+
+      out = run_ruby_file do
+        type "show_source ::Foo"
+        type "exit"
+      end
+
+      assert_match(%r[#{@ruby_file.to_path}:1\s+class Foo\r\nend], out)
+
+      out = run_ruby_file do
+        type "show_source ::Foo::Bar"
+        type "exit"
+      end
+
+      assert_match(%r[#{@ruby_file.to_path}:5\s+class Bar\r\n  end], out)
+    end
   end
 end


### PR DESCRIPTION
Currently `show_source` can't handle top-level class names/signatures like `::Foo` or `::Foo#bar` due to the regexp it uses. This PR fixes the issue.