### PR TITLE
Avoid completing empty input

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -406,7 +406,13 @@ module IRB
         else
           select_message(receiver, message, candidates.sort)
         end
-
+      when /^\s*$/
+        # empty input
+        if doc_namespace
+          nil
+        else
+          []
+        end
       else
         if doc_namespace
           vars = (bind.local_variables | bind.eval_instance_variables).collect{|m| m.to_s}

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -204,6 +204,13 @@ module TestIRB
       end
     end
 
+    def test_not_completing_empty_string
+      assert_equal([], completion_candidates("", binding))
+      assert_equal([], completion_candidates(" ", binding))
+      assert_equal([], completion_candidates("\t", binding))
+      assert_equal(nil, doc_namespace("", binding))
+    end
+
     def test_complete_symbol
       symbols = %w"UTF-16LE UTF-7".map do |enc|
         "K".force_encoding(enc).to_sym

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -232,7 +232,8 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       puts 'start IRB'
     LINES
     start_terminal(4, 19, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
-    write("IR\C-i")
+    write("IR")
+    write("\C-i")
     close
 
     # This is because on macOS we display different shortcut for displaying the full doc
@@ -268,7 +269,8 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       puts 'start IRB'
     LINES
     start_terminal(4, 12, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
-    write("IR\C-i")
+    write("IR")
+    write("\C-i")
     close
     assert_screen(<<~EOC)
       start IRB


### PR DESCRIPTION
The candidate list for empty input is all methods + all variables + all constants + all keywords. It's a long list that is not useful.