### PR TITLE
Require Reline v0.4.2+

### DIFF
--- a/irb.gemspec
+++ b/irb.gemspec
@@ -41,6 +41,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 2.7")
 
-  spec.add_dependency "reline", ">= 0.3.8"
+  spec.add_dependency "reline", ">= 0.4.2"
   spec.add_dependency "rdoc"
 end


### PR DESCRIPTION
After #832 is merged, pasting tab would crash IRB with Reline < 0.4.2. So we need to bump up its requirement.