### PR TITLE
Refactor exit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,21 +109,22 @@ Hello World
 
 The following commands are available on IRB. You can get the same output from the `show_cmds` command.
 
-```
-Workspace
-  cwws           Show the current workspace.
-  chws           Change the current workspace to an object.
-  workspaces     Show workspaces.
-  pushws         Push an object to the workspace stack.
-  popws          Pop a workspace from the workspace stack.
-
+```txt
 IRB
+  exit           Exit the current irb session.
   irb_load       Load a Ruby file.
   irb_require    Require a Ruby file.
   source         Loads a given file in the current session.
   irb_info       Show information about IRB.
   show_cmds      List all available commands and their description.
   history        Shows the input history. `-g [query]` or `-G [query]` allows you to filter the output.
+
+Workspace
+  cwws           Show the current workspace.
+  chws           Change the current workspace to an object.
+  workspaces     Show workspaces.
+  pushws         Push an object to the workspace stack.
+  popws          Pop a workspace from the workspace stack.
 
 Multi-irb (DEPRECATED)
   irb            Start a child IRB.
@@ -153,6 +154,10 @@ Context
   ls             Show methods, constants, and variables. `-g [query]` or `-G [query]` allows you to filter out the output.
   show_source    Show the source code of a given method or constant.
   whereami       Show the source code around binding.irb again.
+
+Aliases
+  $              Alias for `show_source`
+  @              Alias for `whereami`
 ```
 
 ## Debugging with IRB

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -886,8 +886,8 @@ module IRB
   end
 
   # Quits irb
-  def IRB.irb_exit(irb, ret)
-    throw :IRB_EXIT, ret
+  def IRB.irb_exit(*)
+    throw :IRB_EXIT
   end
 
   # Aborts then interrupts irb.

--- a/lib/irb/cmd/exit.rb
+++ b/lib/irb/cmd/exit.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "nop"
+
+module IRB
+  # :stopdoc:
+
+  module ExtendCommand
+    class Exit < Nop
+      category "IRB"
+      description "Exit the current irb session."
+
+      def execute(*)
+        IRB.irb_exit
+      rescue UncaughtThrowError
+        Kernel.exit
+      end
+    end
+  end
+
+  # :startdoc:
+end

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -573,14 +573,6 @@ module IRB
       @inspect_method.inspect_value(@last_value)
     end
 
-    alias __exit__ exit
-    # Exits the current session, see IRB.irb_exit
-    def exit(ret = 0)
-      IRB.irb_exit(@irb, ret)
-    rescue UncaughtThrowError
-      super
-    end
-
     NOPRINTING_IVARS = ["@last_value"] # :nodoc:
     NO_INSPECTING_IVARS = ["@irb", "@io"] # :nodoc:
     IDNAME_IVARS = ["@prompt_mode"] # :nodoc:

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -21,8 +21,10 @@ module IRB # :nodoc:
     # +ret+ is the optional signal or message to send to Context#exit
     #
     # Same as <code>IRB.CurrentContext.exit</code>.
-    def irb_exit(ret = 0)
-      irb_context.exit(ret)
+    def irb_exit(*)
+      IRB.irb_exit
+    rescue UncaughtThrowError
+      Kernel.exit
     end
 
     # Displays current configuration.

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -16,17 +16,6 @@ module IRB # :nodoc:
     # See #install_alias_method.
     OVERRIDE_ALL = 0x02
 
-    # Quits the current irb context
-    #
-    # +ret+ is the optional signal or message to send to Context#exit
-    #
-    # Same as <code>IRB.CurrentContext.exit</code>.
-    def irb_exit(*)
-      IRB.irb_exit
-    rescue UncaughtThrowError
-      Kernel.exit
-    end
-
     # Displays current configuration.
     #
     # Modifying the configuration is achieved by sending a message to IRB.conf.
@@ -37,13 +26,16 @@ module IRB # :nodoc:
     @ALIASES = [
       [:context, :irb_context, NO_OVERRIDE],
       [:conf, :irb_context, NO_OVERRIDE],
-      [:irb_quit, :irb_exit, OVERRIDE_PRIVATE_ONLY],
-      [:exit, :irb_exit, OVERRIDE_PRIVATE_ONLY],
-      [:quit, :irb_exit, OVERRIDE_PRIVATE_ONLY],
     ]
 
 
     @EXTEND_COMMANDS = [
+      [
+        :irb_exit, :Exit, "cmd/exit",
+        [:exit, OVERRIDE_PRIVATE_ONLY],
+        [:quit, OVERRIDE_PRIVATE_ONLY],
+        [:irb_quit, OVERRIDE_PRIVATE_ONLY],
+      ],
       [
         :irb_current_working_workspace, :CurrentWorkingWorkspace, "cmd/chws",
         [:cwws, NO_OVERRIDE],


### PR DESCRIPTION
I did 2 changes around the exit command, though none of them should change its behaviour:

1. I removed unnecessary code/declaration around its implementation:
    1. The parameters of `IRB.irb_exit` were never used. But there are some
       libraries seem to call it with arguments ([example](https://github.com/apache/hbase/blob/4aeabdcc7156f21aea4155972b0d0d8c5dff4966/hbase-shell/src/main/ruby/shell.rb#L112)) + it's declared on the top-level IRB constant. So I changed the params to anonymous splat instead of removing them.
    2. `Context#exit` was completely unnecessary as `IRB.irb_exit` doesn't use
       the `@irb` instance it passes. And since it's (or should be treated as)
       a private method, I simply removed it.
    3. The `exit` command doesn't use the status argument it receives at all.
       But to avoid raising errors on usages like `exit 1`, I changed the argument to anonymous
       splat instead removing it.
2. I converted `exit` to an official command so it's now listed in the help message too.