### PR TITLE
Fix undef and alias indent

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -290,7 +290,7 @@ module IRB
         when :on_embdoc_beg
           indent_level = 0
         else
-          indent_level += 1
+          indent_level += 1 unless t.tok == 'alias' || t.tok == 'undef'
         end
       end
       indent_level

--- a/test/irb/test_nesting_parser.rb
+++ b/test/irb/test_nesting_parser.rb
@@ -280,6 +280,44 @@ module TestIRB
       end
     end
 
+    def test_undef_alias
+      codes = [
+        'undef foo',
+        'alias foo bar',
+        'undef !',
+        'alias + -',
+        'alias $a $b',
+        'undef do',
+        'alias do do',
+        'undef :do',
+        'alias :do :do',
+        'undef :"#{alias do do}"',
+        'alias :"#{undef do}" do',
+        'alias do :"#{undef do}"'
+      ]
+      code_with_comment = <<~EOS
+        undef #
+        #
+        do #
+        alias #
+        #
+        do #
+        #
+        do #
+      EOS
+      code_with_heredoc = <<~EOS
+        <<~A; alias
+        A
+        :"#{<<~A}"
+        A
+        do
+      EOS
+      [*codes, code_with_comment, code_with_heredoc].each do |code|
+        opens = IRB::NestingParser.open_tokens(IRB::RubyLex.ripper_lex_without_warning('(' + code + "\nif"))
+        assert_equal(%w[( if], opens.map(&:tok))
+      end
+    end
+
     def test_case_in
       if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
         pend 'This test requires ruby version that supports case-in syntax'


### PR DESCRIPTION
Fixes #767 


![image](https://github.com/ruby/irb/assets/1780201/727676c3-9fc8-45fa-9771-7e9de5fade9d)
