### PR TITLE
Forward-port ruby-core changes

### DIFF
--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -124,8 +124,9 @@ module TestIRB
       end
 
       def test_complete_require_library_name_first
-        candidates = IRB::RegexpCompletor.new.completion_candidates("require ", "'coverage", "", bind: binding)
-        assert_equal "'coverage", candidates.first
+        # Test that library name is completed first with subdirectories
+        candidates = IRB::RegexpCompletor.new.completion_candidates("require ", "'rubygems", "", bind: binding)
+        assert_equal "'rubygems", candidates.first
       end
 
       def test_complete_require_relative

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -124,8 +124,8 @@ module TestIRB
       end
 
       def test_complete_require_library_name_first
-        candidates = IRB::RegexpCompletor.new.completion_candidates("require ", "'csv", "", bind: binding)
-        assert_equal "'csv", candidates.first
+        candidates = IRB::RegexpCompletor.new.completion_candidates("require ", "'coverage", "", bind: binding)
+        assert_equal "'coverage", candidates.first
       end
 
       def test_complete_require_relative


### PR DESCRIPTION
I changed irb related tests on `ruby/ruby` because irb has been extracted as bundled gems.