### PR TITLE
Try to use irb instead of rubygems for completion test

### DIFF
--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -125,8 +125,8 @@ module TestIRB
 
       def test_complete_require_library_name_first
         # Test that library name is completed first with subdirectories
-        candidates = IRB::RegexpCompletor.new.completion_candidates("require ", "'rubygems", "", bind: binding)
-        assert_equal "'rubygems", candidates.first
+        candidates = IRB::RegexpCompletor.new.completion_candidates("require ", "'irb", "", bind: binding)
+        assert_equal "'irb", candidates.first
       end
 
       def test_complete_require_relative


### PR DESCRIPTION
I'm not sure why OpenBSD suggest `rubygems_plugin` file for this.

https://rubyci.s3.amazonaws.com/openbsd-current/ruby-master/log/20240126T013005Z.fail.html.gz

It seems environmental issue, not irb.