### PR TITLE
Respect parent command line arguments in nested IRB scopes

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1513,8 +1513,8 @@ class Binding
   #
   # See IRB for more information.
   def irb(show_code: true)
-    # Setup IRB with the current file's path and no command line arguments
-    IRB.setup(source_location[0], argv: [])
+    # Setup IRB with the current file's path and current session command line arguments
+    IRB.setup(source_location[0], argv: IRB.conf[:ARGV])
     # Create a new workspace using the current binding
     workspace = IRB::WorkSpace.new(self)
     # Print the code around the binding if show_code is true

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -43,9 +43,9 @@ module IRB # :nodoc:
 
   # initialize config
   def IRB.setup(ap_path, argv: ::ARGV)
-    IRB.init_config(ap_path)
+    IRB.init_config(ap_path, argv: argv)
     IRB.init_error
-    IRB.parse_opts(argv: argv)
+    IRB.parse_opts
     IRB.run_config
     IRB.load_modules
 
@@ -55,7 +55,7 @@ module IRB # :nodoc:
   end
 
   # @CONF default setting
-  def IRB.init_config(ap_path)
+  def IRB.init_config(ap_path, argv: ::ARGV)
     # class instance variables
     @TRACER_INITIALIZED = false
 
@@ -68,6 +68,7 @@ module IRB # :nodoc:
 
     @CONF[:IRB_NAME] = "irb"
     @CONF[:IRB_LIB_PATH] = File.dirname(__FILE__)
+    @CONF[:ARGV] = argv.dup
 
     @CONF[:RC] = true
     @CONF[:LOAD_MODULES] = []
@@ -244,7 +245,8 @@ module IRB # :nodoc:
   end
 
   # option analyzing
-  def IRB.parse_opts(argv: ::ARGV)
+  def IRB.parse_opts
+    argv = @CONF[:ARGV].dup || []
     load_path = []
     while opt = argv.shift
       case opt

--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -112,7 +112,7 @@ EOF
       main.extend ExtendCommandBundle
     end
 
-    # Evaluate the given +statements+ within the  context of this workspace.
+    # Evaluate the given +statements+ within the context of this workspace.
     def evaluate(statements, file = __FILE__, line = __LINE__)
       eval(statements, @binding, file, line)
     end

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -172,6 +172,12 @@ module TestIRB
       IRB.conf[:COMPLETOR] = orig_completor_conf
     end
 
+    def test_setup_holds_a_copy_of_argv
+      argv = %w[--noinspect -w -- any number of arguments]
+      IRB.setup(eval("__FILE__"), argv: argv)
+      assert_equal(argv, IRB.conf[:ARGV])
+    end
+
     def test_noscript
       argv = %w[--noscript -- -f]
       IRB.setup(eval("__FILE__"), argv: argv)

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -182,44 +182,36 @@ module TestIRB
       argv = %w[--noscript -- -f]
       IRB.setup(eval("__FILE__"), argv: argv)
       assert_nil IRB.conf[:SCRIPT]
-      assert_equal(['-f'], argv)
 
       argv = %w[--noscript -- a]
       IRB.setup(eval("__FILE__"), argv: argv)
       assert_nil IRB.conf[:SCRIPT]
-      assert_equal(['a'], argv)
 
       argv = %w[--noscript a]
       IRB.setup(eval("__FILE__"), argv: argv)
       assert_nil IRB.conf[:SCRIPT]
-      assert_equal(['a'], argv)
 
       argv = %w[--script --noscript a]
       IRB.setup(eval("__FILE__"), argv: argv)
       assert_nil IRB.conf[:SCRIPT]
-      assert_equal(['a'], argv)
 
       argv = %w[--noscript --script a]
       IRB.setup(eval("__FILE__"), argv: argv)
       assert_equal('a', IRB.conf[:SCRIPT])
-      assert_equal([], argv)
     end
 
     def test_dash
       argv = %w[-]
       IRB.setup(eval("__FILE__"), argv: argv)
       assert_equal('-', IRB.conf[:SCRIPT])
-      assert_equal([], argv)
 
       argv = %w[-- -]
       IRB.setup(eval("__FILE__"), argv: argv)
       assert_equal('-', IRB.conf[:SCRIPT])
-      assert_equal([], argv)
 
       argv = %w[-- - -f]
       IRB.setup(eval("__FILE__"), argv: argv)
       assert_equal('-', IRB.conf[:SCRIPT])
-      assert_equal(['-f'], argv)
     end
 
     private

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -49,6 +49,42 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     EOC
   end
 
+  def test_configuration_file_is_skipped_with_dash_f
+    write_irbrc <<~'LINES'
+      puts '.irbrc file should be ignored when -f is used'
+    LINES
+    start_terminal(25, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb -f}, startup_message: '')
+    write(<<~EOC)
+      'Hello, World!'
+    EOC
+    close
+    assert_screen(<<~EOC)
+      irb(main):001> 'Hello, World!'
+      => "Hello, World!"
+      irb(main):002>
+    EOC
+  end
+
+  def test_configuration_file_is_skipped_with_dash_f_for_nested_sessions
+    write_irbrc <<~'LINES'
+      puts '.irbrc file should be ignored when -f is used'
+    LINES
+    start_terminal(25, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb -f}, startup_message: '')
+    write(<<~EOC)
+      'Hello, World!'
+      binding.irb
+      exit!
+    EOC
+    close
+    assert_screen(<<~EOC)
+      irb(main):001> 'Hello, World!'
+      => "Hello, World!"
+      irb(main):002> binding.irb
+      irb(main):003> exit!
+      irb(main):001>
+    EOC
+  end
+
   def test_nomultiline
     write_irbrc <<~'LINES'
       puts 'start IRB'


### PR DESCRIPTION
When `binding.irb` is called, the new session is setup without command line arguments:
https://github.com/ruby/irb/blob/a641746b18faa35ef32eec55255894fffcd4b063/lib/irb.rb#L1516-L1517

This means that the child session does not respect the parent command line arguments.
Therefore when using `$ irb -f` (to ignore RC file), and opening a child session with `biding.irb`, the new session will load the RC file (if it exists).

See more in:
- https://github.com/ruby/irb/issues/625

The solution I present here is to hold a copy of ARGV in `@CONF`, and use that to setup child sessions.

Closes https://github.com/ruby/irb/issues/625