### PR TITLE
Add rubocop with a few basic styling rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,17 @@ jobs:
     with:
       engine: cruby-truffleruby
       min_version: 2.7
-
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - name: Run rubocop
+        run: bundle exec rubocop
   irb:
     needs: ruby-versions
     name: rake test ${{ matrix.ruby }} ${{ matrix.with_latest_reline && '(latest reline)' || '' }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,32 @@
+AllCops:
+  TargetRubyVersion: 3.0
+  DisabledByDefault: true
+  SuggestExtensions: false
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
+Layout/TrailingEmptyLines:
+  Enabled: true
+
+Layout/IndentationConsistency:
+  Enabled: true
+
+Layout/CaseIndentation:
+  Enabled: true
+  EnforcedStyle: end
+
+Layout/CommentIndentation:
+  Enabled: true
+
+Layout/IndentationStyle:
+  Enabled: true
+
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
+Layout/SpaceBeforeComma:
+  Enabled: true
+
+Layout/SpaceAfterComma:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem "rake"
 gem "test-unit"
 gem "test-unit-ruby-core"
 
+gem "rubocop"
+
 gem "debug", github: "ruby/debug", platforms: [:mri, :mswin]
 
 if RUBY_VERSION >= "3.0.0" && !is_truffleruby

--- a/lib/irb/inspector.rb
+++ b/lib/irb/inspector.rb
@@ -46,7 +46,7 @@ module IRB # :nodoc:
     # Determines the inspector to use where +inspector+ is one of the keys passed
     # during inspector definition.
     def self.keys_with_inspector(inspector)
-      INSPECTORS.select{|k,v| v == inspector}.collect{|k, v| k}
+      INSPECTORS.select{|k, v| v == inspector}.collect{|k, v| k}
     end
 
     # Example

--- a/lib/irb/locale.rb
+++ b/lib/irb/locale.rb
@@ -94,7 +94,7 @@ module IRB # :nodoc:
       end
     end
 
-    def find(file , paths = $:)
+    def find(file, paths = $:)
       dir = File.dirname(file)
       dir = "" if dir == "."
       base = File.basename(file)

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -170,4 +170,3 @@ module TestIRB
     end
   end
 end
-

--- a/test/irb/test_workspace.rb
+++ b/test/irb/test_workspace.rb
@@ -91,7 +91,7 @@ module TestIRB
         irb_path = "#{top_srcdir}/#{dir}/irb"
         File.exist?(irb_path)
       end or omit 'irb command not found'
-      assert_in_out_err(bundle_exec + ['-W0', "-C#{top_srcdir}", '-e', <<~RUBY , '--', '-f', '--'], 'binding.local_variables', /\[:_\]/, [], bug17623)
+      assert_in_out_err(bundle_exec + ['-W0', "-C#{top_srcdir}", '-e', <<~RUBY, '--', '-f', '--'], 'binding.local_variables', /\[:_\]/, [], bug17623)
         version = 'xyz' # typical rubygems loading file
         load('#{irb_path}')
       RUBY


### PR DESCRIPTION
While I dislike excessive linting warnings/errors we sometimes experience in projects, I think having a tool to enforce some universally agreed styles is beneficial in the long term. So I want to start introducing a few very basic rubocop rules that has been widely followed in this codebase (see `.rubocop.yml`).

As we gradually adopt more rules, the CI job and our editor (through LSP servers like Ruby LSP) will make them easy to follow and enforce as well.
