### PR TITLE
Introduce exit! command

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -889,6 +889,10 @@ module IRB
     throw :IRB_EXIT
   end
 
+  def IRB.irb_exit!(*)
+    throw :IRB_EXIT
+  end
+
   # Aborts then interrupts irb.
   #
   # Will raise an Abort exception, or the given +exception+.

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -886,11 +886,11 @@ module IRB
 
   # Quits irb
   def IRB.irb_exit(*)
-    throw :IRB_EXIT
+    throw :IRB_EXIT, false
   end
 
   def IRB.irb_exit!(*)
-    throw :IRB_EXIT!
+    throw :IRB_EXIT, true
   end
 
   # Aborts then interrupts irb.
@@ -984,21 +984,18 @@ module IRB
       end
 
       begin
-        @forced_exit = false
+        forced_exit = false
 
-        catch(:IRB_EXIT) do
-          catch(:IRB_EXIT!) do
-            eval_input
-          end
-          @forced_exit = true
+        forced_exit = catch(:IRB_EXIT) do
+          eval_input
         end
       ensure
         trap("SIGINT", prev_trap)
         conf[:AT_EXIT].each{|hook| hook.call}
 
-        if @forced_exit
+        if forced_exit
           context.io.save_history if supports_history_saving
-          Kernel.exit!
+          Kernel.exit!(0)
         else
           context.io.save_history if save_history
         end

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -995,7 +995,7 @@ module IRB
 
         if forced_exit
           context.io.save_history if supports_history_saving
-          Kernel.exit!(0)
+          Kernel.exit(0)
         else
           context.io.save_history if save_history
         end

--- a/lib/irb/cmd/exit_forced_action.rb
+++ b/lib/irb/cmd/exit_forced_action.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "nop"
+
+module IRB
+  # :stopdoc:
+
+  module ExtendCommand
+    class ExitForcedAction < Nop
+      category "IRB"
+      description "Exit the current irb session with exit!."
+
+      def execute(*)
+        IRB.irb_exit!
+      rescue UncaughtThrowError
+        Kernel.exit
+      end
+    end
+  end
+
+  # :startdoc:
+end

--- a/lib/irb/cmd/exit_forced_action.rb
+++ b/lib/irb/cmd/exit_forced_action.rb
@@ -8,12 +8,12 @@ module IRB
   module ExtendCommand
     class ExitForcedAction < Nop
       category "IRB"
-      description "Exit the current irb session with exit!."
+      description "Exit the current process."
 
       def execute(*)
         IRB.irb_exit!
       rescue UncaughtThrowError
-        Kernel.exit
+        Kernel.exit(0)
       end
     end
   end

--- a/lib/irb/extend-command.rb
+++ b/lib/irb/extend-command.rb
@@ -37,6 +37,11 @@ module IRB # :nodoc:
         [:irb_quit, OVERRIDE_PRIVATE_ONLY],
       ],
       [
+        :irb_exit!, :ExitForcedAction, "cmd/exit_forced_action",
+        [:exit!, OVERRIDE_PRIVATE_ONLY],
+      ],
+
+      [
         :irb_current_working_workspace, :CurrentWorkingWorkspace, "cmd/chws",
         [:cwws, NO_OVERRIDE],
         [:pwws, NO_OVERRIDE],

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -257,12 +257,12 @@ module TestIRB
 
     def test_forced_exit
       write_ruby <<~'ruby'
-        puts "first line"
+        puts "First line"
+        puts "Second line"
         binding.irb
-        puts "second line"
+        puts "Third line"
         binding.irb
-        puts "third"
-        binding.irb
+        puts "Fourth line"
       ruby
 
       output = run_ruby_file do
@@ -271,10 +271,12 @@ module TestIRB
         type "exit!"
       end
 
+      assert_match(/First line\r\n/, output)
+      assert_match(/Second line\r\n/, output)
       assert_match(/irb\(main\):001> 123/, output)
       assert_match(/irb\(main\):002> 456/, output)
-      assert_match(/irb\(main\):003> exit!/, output)
-      output.end_with?("003> exit!")
+      refute_match(/Third line\r\n/, output)
+      refute_match(/Fourth line\r\n/, output)
     end
 
     def test_quit

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -255,6 +255,28 @@ module TestIRB
       assert_match(/irb\(main\):001> next/, output)
     end
 
+    def test_forced_exit
+      write_ruby <<~'ruby'
+        puts "first line"
+        binding.irb
+        puts "second line"
+        binding.irb
+        puts "third"
+        binding.irb
+      ruby
+
+      output = run_ruby_file do
+        type "123"
+        type "456"
+        type "exit!"
+      end
+
+      assert_match(/irb\(main\):001> 123/, output)
+      assert_match(/irb\(main\):002> 456/, output)
+      assert_match(/irb\(main\):003> exit!/, output)
+      output.end_with?("003> exit!")
+    end
+
     def test_quit
       write_ruby <<~'RUBY'
         binding.irb

--- a/test/irb/test_debug_cmd.rb
+++ b/test/irb/test_debug_cmd.rb
@@ -255,7 +255,7 @@ module TestIRB
       assert_match(/irb\(main\):001> next/, output)
     end
 
-    def test_forced_exit
+    def test_forced_exit_finishes_process_when_nested_sessions
       write_ruby <<~'ruby'
         puts "First line"
         puts "Second line"
@@ -277,6 +277,23 @@ module TestIRB
       assert_match(/irb\(main\):002> 456/, output)
       refute_match(/Third line\r\n/, output)
       refute_match(/Fourth line\r\n/, output)
+    end
+
+    def test_forced_exit
+      write_ruby <<~'ruby'
+        puts "Hello"
+        binding.irb
+      ruby
+
+      output = run_ruby_file do
+        type "123"
+        type "456"
+        type "exit!"
+      end
+
+      assert_match(/Hello\r\n/, output)
+      assert_match(/irb\(main\):001> 123/, output)
+      assert_match(/irb\(main\):002> 456/, output)
     end
 
     def test_quit

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -366,6 +366,24 @@ module TestIRB
       HISTORY
     end
 
+    def test_history_saving_with_exit!
+      write_history ""
+
+      write_ruby <<~'RUBY'
+        binding.irb
+      RUBY
+
+      run_ruby_file do
+        type "'starting session'"
+        type "exit!"
+      end
+
+      assert_equal <<~HISTORY, @history_file.open.read
+        'starting session'
+        exit!
+      HISTORY
+    end
+
     def test_history_saving_with_nested_sessions_and_prior_history
       write_history <<~HISTORY
         old_history_1


### PR DESCRIPTION
# Problem
Currently, `exit!` does not save the history of the console' input like the following example

```console
irb(main):001:0> a = 1
=> 1
irb(main):002:0> b = 2
=> 2
irb(main):003:0> exit
```

Open another session and type up-arrow to check the above history
`irb(main):001:0> b = 2 # (history is saved!)`

If we run the same for `exit!`, the history isn't saved.
Closes [#612](https://github.com/ruby/irb/issues/612)

# Solution

I extended the command `exit!` and used a new class `ExitForcedAction`. Note that we can't use `Exit!` as the class name since `!` isn't allowed.

This will call the `irb_exit!` method, which will throw the same exception as exit (`throw :IRB_EXIT`) and the main method `run` catches it and calls `save_history``.


# Demo

In the following example, I test that the history is saved and `Kernel.exit!` exits the console even when the session is nested.

https://github.com/ruby/irb/assets/11672878/f6993f51-e729-4f4c-9ce4-b40a9137c925


