### PR TITLE
Add a warning for when the history path doesn't exist

### DIFF
--- a/lib/irb/history.rb
+++ b/lib/irb/history.rb
@@ -61,7 +61,7 @@ module IRB
 
         pathname = Pathname.new(history_file)
         unless Dir.exist?(pathname.dirname)
-          warn "Warning: The path to save IRB history does not exist. Please, set the env var IRB.conf[:HISTORY_FILE] with a valid path."
+          warn "Warning: The directory to save IRB's history file does not exist. Please double check `IRB.conf[:HISTORY_FILE]`'s value."
           return
         end
 

--- a/lib/irb/history.rb
+++ b/lib/irb/history.rb
@@ -53,6 +53,10 @@ module IRB
           raise
         end
 
+        if !File.exist?(history_file)
+          warn "Warning: The path for the HISTORY_FILE does not exist."
+        end
+
         if File.exist?(history_file) &&
            File.mtime(history_file) != @loaded_history_mtime
           history = history[@loaded_history_lines..-1] if @loaded_history_lines

--- a/lib/irb/history.rb
+++ b/lib/irb/history.rb
@@ -53,14 +53,16 @@ module IRB
           raise
         end
 
-        if !File.exist?(history_file)
-          warn "Warning: The path for the HISTORY_FILE does not exist."
-        end
-
         if File.exist?(history_file) &&
            File.mtime(history_file) != @loaded_history_mtime
           history = history[@loaded_history_lines..-1] if @loaded_history_lines
           append_history = true
+        end
+
+        pathname = Pathname.new(history_file)
+        unless Dir.exist?(pathname.dirname)
+          warn "Warning: The path to save IRB history does not exist. Please, set the env var IRB.conf[:HISTORY_FILE] with a valid path."
+          return
         end
 
         File.open(history_file, (append_history ? 'a' : 'w'), 0o600, encoding: IRB.conf[:LC_MESSAGES]&.encoding) do |f|

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -167,6 +167,19 @@ module TestIRB
       $VERBOSE = verbose_bak
     end
 
+    def test_history_does_not_raise_when_history_file_directory_does_not_exist
+      backup_history_file = IRB.conf[:HISTORY_FILE]
+      IRB.conf[:SAVE_HISTORY] = 1
+      IRB.conf[:HISTORY_FILE] = "fake/fake/fake/history_file"
+      io = TestInputMethodWithRelineHistory.new
+
+      assert_nothing_raised do
+        io.save_history
+      end
+    ensure
+      IRB.conf[:HISTORY_FILE] = backup_history_file
+    end
+
     private
 
     def history_concurrent_use_for_input_method(input_method)


### PR DESCRIPTION
When using a file path that doesn't exist in the `IRB.conf[:HISTORY_FILE]` env variable, `IRB` creates a new file with that directory without warning the developer. 

This PR prints a warning when that happens. 

```console
➜  irb git:(add-warning) ✗ echo 'IRB.conf[:HISTORY_FILE] = "/Users/ignaciochiazzo/irb/test/irb/fake-folder/fake/testing.rb"' > ~/.irbrc

➜  irb git:(add-warning) ✗ bundle exec irb
irb(main):001> a = 1
=> 1
irb(main):002> exit
Warning: The path to save IRB history does not exist. Please, set the env var IRB.conf[:HISTORY_FILE] with a valid path. 
```

https://github.com/ruby/irb/issues/830

### Demo

https://github.com/ruby/irb/assets/11672878/58831fdd-cd44-4f68-b1ff-1eb03680da02

