### PR TITLE
Omit 2 encoding error related tests for TruffleRuby

### DIFF
--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -39,6 +39,10 @@ module TestIRB
     end
 
     def test_evaluate_with_encoding_error_without_lineno
+      if RUBY_ENGINE == 'truffleruby'
+        omit "Remove me after https://github.com/ruby/prism/issues/2129 is addressed and adopted in TruffleRuby"
+      end
+
       assert_raise_with_message(EncodingError, /invalid symbol/) {
         @context.evaluate(%q[:"\xAE"], 1)
         # The backtrace of this invalid encoding hash doesn't contain lineno.

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -221,6 +221,10 @@ module TestIRB
     end
 
     def assert_code_block_open(lines, expected, local_variables: [])
+      if RUBY_ENGINE == 'truffleruby'
+        omit "Remove me after https://github.com/ruby/prism/issues/2129 is addressed and adopted in TruffleRuby"
+      end
+
       _indent_level, _continue, code_block_open = check_state(lines, local_variables: local_variables)
       error_message = "Wrong result of code_block_open for:\n #{lines.join("\n")}"
       assert_equal(expected, code_block_open, error_message)


### PR DESCRIPTION
They're failing due to an issue in Prism: https://github.com/ruby/prism/issues/2129

So we need to skip them until:
- The issue is fixed in Prism
- TruffleRuby is updated to a version of Prism that includes the fix