### PR TITLE
Support repeating debugger input by passing empty input to it

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1082,16 +1082,17 @@ module IRB
       loop do
         code = readmultiline
         break unless code
-
-        if code != "\n"
-          yield build_statement(code), @line_no
-        end
+        yield build_statement(code), @line_no
         @line_no += code.count("\n")
       rescue RubyLex::TerminateLineInput
       end
     end
 
     def build_statement(code)
+      if code.match?(/\A\n*\z/)
+        return Statement::EmptyInput.new
+      end
+
       code.force_encoding(@context.io.encoding)
       command_or_alias, arg = code.split(/\s/, 2)
       # Transform a non-identifier alias (@, $) or keywords (next, break)

--- a/lib/irb/statement.rb
+++ b/lib/irb/statement.rb
@@ -20,6 +20,29 @@ module IRB
       raise NotImplementedError
     end
 
+    class EmptyInput < Statement
+      def is_assignment?
+        false
+      end
+
+      def suppresses_echo?
+        true
+      end
+
+      # Debugger takes empty input to repeat the last command
+      def should_be_handled_by_debugger?
+        true
+      end
+
+      def code
+        ""
+      end
+
+      def evaluable_code
+        code
+      end
+    end
+
     class Expression < Statement
       def initialize(code, is_assignment)
         @code = code

--- a/test/irb/test_debugger_integration.rb
+++ b/test/irb/test_debugger_integration.rb
@@ -6,7 +6,7 @@ require "tmpdir"
 require_relative "helper"
 
 module TestIRB
-  class DebugCommandTest < IntegrationTestCase
+  class DebuggerIntegrationTest < IntegrationTestCase
     def setup
       super
 
@@ -433,6 +433,30 @@ module TestIRB
 
       assert_match(/irb\(main\):001> next/, output)
       assert_include(output, "Multi-IRB commands are not available when the debugger is enabled.")
+    end
+
+    def test_irb_passes_empty_input_to_debugger_to_repeat_the_last_command
+      write_ruby <<~'ruby'
+        binding.irb
+        puts "foo"
+        puts "bar"
+        puts "baz"
+      ruby
+
+      output = run_ruby_file do
+        type "next"
+        type ""
+        # Test that empty input doesn't repeat expressions
+        type "123"
+        type ""
+        type "next"
+        type ""
+        type ""
+      end
+
+      assert_include(output, "=>   2\| puts \"foo\"")
+      assert_include(output, "=>   3\| puts \"bar\"")
+      assert_include(output, "=>   4\| puts \"baz\"")
     end
   end
 end

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -58,6 +58,24 @@ module TestIRB
       assert_include output, "=> \"It's a foo\""
       assert_include output, "=> \"It's a bar\""
     end
+
+    def test_empty_input_echoing_behaviour
+      write_ruby <<~'RUBY'
+        binding.irb
+      RUBY
+
+      output = run_ruby_file do
+        type ""
+        type "  "
+        type "exit"
+      end
+
+      # Input cramped together due to how Reline's Reline::GeneralIO works
+      assert_include(
+        output,
+        "irb(main):001> irb(main):002> irb(main):002>  irb(main):002>   => nil\r\n"
+      )
+    end
   end
 
   class IrbIOConfigurationTest < TestCase


### PR DESCRIPTION
When typing empty input in `rdbg` sessions, `debug` repeats the last repeatable input so users don't need to type `step` or `next` repeatedly. But currently `irb:rdbg` session doesn't support this as IRB ignores empty input completely.

This PR supports the behaviour by adding representation for empty input, and pass it to the debugger when in the `irb:rdbg` session. I also added a test to check the current empty input behaviour in normal IRB sessions is not changed.

Closes https://github.com/ruby/debug/issues/1063