### PR TITLE
Allow loading multiple irb files

### DIFF
--- a/lib/irb/command/irb_info.rb
+++ b/lib/irb/command/irb_info.rb
@@ -13,7 +13,8 @@ module IRB
         str += "IRB version: #{IRB.version}\n"
         str += "InputMethod: #{IRB.CurrentContext.io.inspect}\n"
         str += "Completion: #{IRB.CurrentContext.io.respond_to?(:completion_info) ? IRB.CurrentContext.io.completion_info : 'off'}\n"
-        str += ".irbrc path: #{IRB.rc_file}\n" if File.exist?(IRB.rc_file)
+        rc_files = IRB.rc_files.select { |rc| File.exist?(rc) }
+        str += ".irbrc paths: #{rc_files.join(", ")}\n" if rc_files.any?
         str += "RUBY_PLATFORM: #{RUBY_PLATFORM}\n"
         str += "LANG env: #{ENV["LANG"]}\n" if ENV["LANG"] && !ENV["LANG"].empty?
         str += "LC_ALL env: #{ENV["LC_ALL"]}\n" if ENV["LC_ALL"] && !ENV["LC_ALL"].empty?

--- a/lib/irb/history.rb
+++ b/lib/irb/history.rb
@@ -16,7 +16,7 @@ module IRB
       if history_file = IRB.conf[:HISTORY_FILE]
         history_file = File.expand_path(history_file)
       end
-      history_file = IRB.rc_file("_history") unless history_file
+      history_file = IRB.rc_files("_history").first unless history_file
       if File.exist?(history_file)
         File.open(history_file, "r:#{IRB.conf[:LC_MESSAGES].encoding}") do |f|
           f.each { |l|
@@ -41,7 +41,7 @@ module IRB
         if history_file = IRB.conf[:HISTORY_FILE]
           history_file = File.expand_path(history_file)
         end
-        history_file = IRB.rc_file("_history") unless history_file
+        history_file = IRB.rc_files("_history").first unless history_file
 
         # Change the permission of a file that already exists[BUG #7694]
         begin

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -75,6 +75,7 @@ module TestIRB
     def test_irb_info_multiline
       FileUtils.touch("#{@tmpdir}/.inputrc")
       FileUtils.touch("#{@tmpdir}/.irbrc")
+      FileUtils.touch("#{@tmpdir}/_irbrc")
 
       out, err = execute_lines(
         "irb_info",
@@ -86,7 +87,7 @@ module TestIRB
         IRB\sversion:\sirb\s.+\n
         InputMethod:\sAbstract\sInputMethod\n
         Completion: .+\n
-        \.irbrc\spath:\s.+\n
+        \.irbrc\spaths:.*\.irbrc.*_irbrc\n
         RUBY_PLATFORM:\s.+\n
         East\sAsian\sAmbiguous\sWidth:\s\d\n
         #{@is_win ? 'Code\spage:\s\d+\n' : ''}
@@ -110,7 +111,7 @@ module TestIRB
         IRB\sversion:\sirb\s.+\n
         InputMethod:\sAbstract\sInputMethod\n
         Completion: .+\n
-        \.irbrc\spath:\s.+\n
+        \.irbrc\spaths:\s.+\n
         RUBY_PLATFORM:\s.+\n
         East\sAsian\sAmbiguous\sWidth:\s\d\n
         #{@is_win ? 'Code\spage:\s\d+\n' : ''}
@@ -196,7 +197,7 @@ module TestIRB
         IRB\sversion:\sirb .+\n
         InputMethod:\sAbstract\sInputMethod\n
         Completion: .+\n
-        \.irbrc\spath: .+\n
+        \.irbrc\spaths: .+\n
         RUBY_PLATFORM: .+\n
         LANG\senv:\sja_JP\.UTF-8\n
         LC_ALL\senv:\sen_US\.UTF-8\n

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -136,7 +136,7 @@ module TestIRB
         io.class::HISTORY << 'line1'
         io.class::HISTORY << 'line2'
 
-        history_file = IRB.rc_file("_history")
+        history_file = IRB.rc_files("_history").first
         assert_not_send [File, :file?, history_file]
         File.write(history_file, "line0\n")
         io.save_history
@@ -217,9 +217,10 @@ module TestIRB
       backup_xdg_config_home = ENV.delete("XDG_CONFIG_HOME")
       IRB.conf[:LC_MESSAGES] = locale
       actual_history = nil
+      history_file = IRB.rc_files("_history").first
       Dir.mktmpdir("test_irb_history_") do |tmpdir|
         ENV["HOME"] = tmpdir
-        File.open(IRB.rc_file("_history"), "w") do |f|
+        File.open(history_file, "w") do |f|
           f.write(initial_irb_history)
         end
 
@@ -229,7 +230,7 @@ module TestIRB
         if block_given?
           previous_history = []
           io.class::HISTORY.each { |line| previous_history << line }
-          yield IRB.rc_file("_history")
+          yield history_file
           io.class::HISTORY.clear
           previous_history.each { |line| io.class::HISTORY << line }
         end
@@ -237,7 +238,7 @@ module TestIRB
         io.save_history
 
         io.load_history
-        File.open(IRB.rc_file("_history"), "r") do |f|
+        File.open(history_file, "r") do |f|
           actual_history = f.read
         end
       end

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -11,7 +11,7 @@ module TestIRB
       @backup_env = %w[HOME XDG_CONFIG_HOME IRBRC].each_with_object({}) do |env, hash|
         hash[env] = ENV.delete(env)
       end
-      ENV["HOME"] = @tmpdir = Dir.mktmpdir("test_irb_init_#{$$}")
+      ENV["HOME"] = @tmpdir = File.realpath(Dir.mktmpdir("test_irb_init_#{$$}"))
     end
 
     def teardown
@@ -35,34 +35,132 @@ module TestIRB
     end
 
     def test_rc_file
+      verbose, $VERBOSE = $VERBOSE, nil
       tmpdir = @tmpdir
       Dir.chdir(tmpdir) do
         ENV["XDG_CONFIG_HOME"] = "#{tmpdir}/xdg"
         IRB.conf[:RC_NAME_GENERATOR] = nil
-        assert_equal(tmpdir+"/.irb#{IRB::IRBRC_EXT}", IRB.rc_file)
+        assert_equal(tmpdir+"/.irbrc", IRB.rc_file)
         assert_equal(tmpdir+"/.irb_history", IRB.rc_file("_history"))
         assert_file.not_exist?(tmpdir+"/xdg")
         IRB.conf[:RC_NAME_GENERATOR] = nil
-        FileUtils.touch(tmpdir+"/.irb#{IRB::IRBRC_EXT}")
-        assert_equal(tmpdir+"/.irb#{IRB::IRBRC_EXT}", IRB.rc_file)
+        FileUtils.touch(tmpdir+"/.irbrc")
+        assert_equal(tmpdir+"/.irbrc", IRB.rc_file)
         assert_equal(tmpdir+"/.irb_history", IRB.rc_file("_history"))
         assert_file.not_exist?(tmpdir+"/xdg")
       end
+    ensure
+      $VERBOSE = verbose
     end
 
     def test_rc_file_in_subdir
+      verbose, $VERBOSE = $VERBOSE, nil
       tmpdir = @tmpdir
       Dir.chdir(tmpdir) do
         FileUtils.mkdir_p("#{tmpdir}/mydir")
         Dir.chdir("#{tmpdir}/mydir") do
           IRB.conf[:RC_NAME_GENERATOR] = nil
-          assert_equal(tmpdir+"/.irb#{IRB::IRBRC_EXT}", IRB.rc_file)
+          assert_equal(tmpdir+"/.irbrc", IRB.rc_file)
           assert_equal(tmpdir+"/.irb_history", IRB.rc_file("_history"))
           IRB.conf[:RC_NAME_GENERATOR] = nil
-          FileUtils.touch(tmpdir+"/.irb#{IRB::IRBRC_EXT}")
-          assert_equal(tmpdir+"/.irb#{IRB::IRBRC_EXT}", IRB.rc_file)
+          FileUtils.touch(tmpdir+"/.irbrc")
+          assert_equal(tmpdir+"/.irbrc", IRB.rc_file)
           assert_equal(tmpdir+"/.irb_history", IRB.rc_file("_history"))
         end
+      end
+    ensure
+      $VERBOSE = verbose
+    end
+
+    def test_rc_files
+      tmpdir = @tmpdir
+      Dir.chdir(tmpdir) do
+        ENV["XDG_CONFIG_HOME"] = "#{tmpdir}/xdg"
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        assert_includes IRB.rc_files, tmpdir+"/.irbrc"
+        assert_includes IRB.rc_files("_history"), tmpdir+"/.irb_history"
+        assert_file.not_exist?(tmpdir+"/xdg")
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        FileUtils.touch(tmpdir+"/.irbrc")
+        assert_includes IRB.rc_files, tmpdir+"/.irbrc"
+        assert_includes IRB.rc_files("_history"), tmpdir+"/.irb_history"
+        assert_file.not_exist?(tmpdir+"/xdg")
+      end
+    end
+
+    def test_rc_files_in_subdir
+      tmpdir = @tmpdir
+      Dir.chdir(tmpdir) do
+        FileUtils.mkdir_p("#{tmpdir}/mydir")
+        Dir.chdir("#{tmpdir}/mydir") do
+          IRB.conf[:RC_NAME_GENERATOR] = nil
+          assert_includes IRB.rc_files, tmpdir+"/.irbrc"
+          assert_includes IRB.rc_files("_history"), tmpdir+"/.irb_history"
+          IRB.conf[:RC_NAME_GENERATOR] = nil
+          FileUtils.touch(tmpdir+"/.irbrc")
+          assert_includes IRB.rc_files, tmpdir+"/.irbrc"
+          assert_includes IRB.rc_files("_history"), tmpdir+"/.irb_history"
+        end
+      end
+    end
+
+    def test_rc_files_has_file_from_xdg_env
+      tmpdir = @tmpdir
+      ENV["XDG_CONFIG_HOME"] = "#{tmpdir}/xdg"
+      xdg_config = ENV["XDG_CONFIG_HOME"]+"/irb/irbrc"
+
+      FileUtils.mkdir_p(xdg_config)
+
+      Dir.chdir(tmpdir) do
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        assert_includes IRB.rc_files, xdg_config
+      end
+    ensure
+      ENV["XDG_CONFIG_HOME"] = nil
+    end
+
+    def test_rc_files_has_file_from_irbrc_env
+      tmpdir = @tmpdir
+      ENV["IRBRC"] = "#{tmpdir}/irb"
+
+      FileUtils.mkdir_p(ENV["IRBRC"])
+
+      Dir.chdir(tmpdir) do
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        assert_includes IRB.rc_files, ENV["IRBRC"]
+      end
+    ensure
+      ENV["IRBRC"] = nil
+    end
+
+    def test_rc_files_has_file_from_home_env
+      tmpdir = @tmpdir
+      ENV["HOME"] = "#{tmpdir}/home"
+
+      FileUtils.mkdir_p(ENV["HOME"])
+
+      Dir.chdir(tmpdir) do
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        assert_includes IRB.rc_files, ENV["HOME"]+"/.irbrc"
+        assert_includes IRB.rc_files, ENV["HOME"]+"/.config/irb/irbrc"
+      end
+    ensure
+      ENV["HOME"] = nil
+    end
+
+    def test_rc_files_contains_non_env_files
+      tmpdir = @tmpdir
+      FileUtils.mkdir_p("#{tmpdir}/.irbrc")
+      FileUtils.mkdir_p("#{tmpdir}/_irbrc")
+      FileUtils.mkdir_p("#{tmpdir}/irb.rc")
+      FileUtils.mkdir_p("#{tmpdir}/$irbrc")
+
+      Dir.chdir(tmpdir) do
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        assert_includes IRB.rc_files, tmpdir+"/.irbrc"
+        assert_includes IRB.rc_files, tmpdir+"/_irbrc"
+        assert_includes IRB.rc_files, tmpdir+"/irb.rc"
+        assert_includes IRB.rc_files, tmpdir+"/$irbrc"
       end
     end
 


### PR DESCRIPTION
Opening this PR for early feedback, issue: https://github.com/ruby/irb/issues/674

Add the ability to load multiple irb files. 

e.g. if user defines an irb file in `"/Users/user_name/.irbrc"` and inside the project `"/Users/user_name/projects/ruby/irb/.irbrc"` both configs are loaded.

- The existing method `rc_file` is deprecated with a deprecation notice, informing about a new method called `rc_files` to use instead.
- In the tests the deprecation notice is displayed for the existing tests `test_rc_file` and `test_rc_file_in_subdir`, not sure what we want to do with that, silence?

todo
- [x] figure out what to do with _history files, do we only want the first one?
- [x] Add a test for history, EDIT: since we are only getting the first file I did not add a test as there will be no change in behaviour
- [x] Add a test for rbinfo -- also, do we want to display a comma separated list of rc_files?, EDIT: updated existing test that checks for .irbrc and _irbrc


