### PR TITLE
Require pathname

### DIFF
--- a/lib/irb/history.rb
+++ b/lib/irb/history.rb
@@ -1,3 +1,5 @@
+require "pathname"
+
 module IRB
   module HistorySavingAbility # :nodoc:
     def support_history_saving?


### PR DESCRIPTION
#852 added usage of `Pathname` but missed requiring it, which is breaking `ruby/ruby`'s CI. This PR addresses the issue.