### PR TITLE
Powerup show_source by enabling RubyVM.keep_script_lines

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1531,8 +1531,6 @@ class Binding
     debugger_irb = IRB.instance_variable_get(:@debugger_irb)
 
     irb_path = File.expand_path(source_location[0])
-    # We need to change the irb_path to distinguish source_location of method defined in the actual file and method defined in irb session.
-    irb_path = "#{irb_path}(#{IRB.conf[:IRB_NAME]})" if File.exist?(irb_path)
 
     if debugger_irb
       # If we're already in a debugger session, set the workspace and irb_path for the original IRB instance

--- a/lib/irb/cmd/edit.rb
+++ b/lib/irb/cmd/edit.rb
@@ -37,7 +37,8 @@ module IRB
               # in this case, we should just ignore the error
             end
 
-          if source
+          # Ignore `source.file == "(irb)"` and `source.first_line == nil` (binary file)
+          if source && File.exist?(source.file) && source.first_line
             path = source.file
           else
             puts "Can not find file: #{path}"

--- a/lib/irb/cmd/edit.rb
+++ b/lib/irb/cmd/edit.rb
@@ -37,8 +37,7 @@ module IRB
               # in this case, we should just ignore the error
             end
 
-          # Ignore `source.file == "(irb)"` and `source.first_line == nil` (binary file)
-          if source && File.exist?(source.file) && source.first_line
+          if source&.file_exist? && !source.binary_file?
             path = source.file
           else
             puts "Can not find file: #{path}"

--- a/lib/irb/cmd/edit.rb
+++ b/lib/irb/cmd/edit.rb
@@ -24,11 +24,9 @@ module IRB
       def execute(*args)
         path = args.first
 
-        if path.nil? && (irb_path = @irb_context.irb_path)
-          path = irb_path
-        end
-
-        if !File.exist?(path)
+        if path.nil?
+          path = @irb_context.irb_path
+        elsif !File.exist?(path)
           source =
             begin
               SourceFinder.new(@irb_context).find_source(path)
@@ -39,10 +37,12 @@ module IRB
 
           if source&.file_exist? && !source.binary_file?
             path = source.file
-          else
-            puts "Can not find file: #{path}"
-            return
           end
+        end
+
+        unless File.exist?(path)
+          puts "Can not find file: #{path}"
+          return
         end
 
         if editor = (ENV['VISUAL'] || ENV['EDITOR'])

--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -45,13 +45,22 @@ module IRB
       private
 
       def show_source(source)
-        file_content = IRB::Color.colorize_code(File.read(source.file))
-        code = file_content.lines[(source.first_line - 1)...source.last_line].join
-        content = <<~CONTENT
+        if source.content
+          code = IRB::Color.colorize_code(source.content)
+        elsif source.first_line && source.last_line
+          file_content = IRB::Color.colorize_code(File.read(source.file))
+          code = file_content.lines[(source.first_line - 1)...source.last_line].join
+        elsif source.first_line
+          code = 'Source not available'
+        else
+          content = "\n#{bold('Defined in binary file')}: #{source.file}\n\n"
+        end
+        content ||= <<~CONTENT
 
           #{bold("From")}: #{source.file}:#{source.first_line}
 
-          #{code}
+          #{code.chomp}
+
         CONTENT
 
         Pager.page_content(content)

--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -45,26 +45,18 @@ module IRB
       private
 
       def show_source(source)
-        if source.file_content
-          # Colorizing partial code `source.content` sometimes fails.
-          # Instead, we need to colorize `source.file_content` and extract the relevant lines.
-          file_content = IRB::Color.colorize_code(source.file_content)
-          code = file_content.lines[(source.first_line - 1)...source.last_line].join
-        elsif source.content
-          code = IRB::Color.colorize_code(source.content)
-        elsif source.first_line
-          code = 'Source not available'
-        else
+        if source.binary_file?
           content = "\n#{bold('Defined in binary file')}: #{source.file}\n\n"
+        else
+          code = source.colorized_content || 'Source not available'
+          content = <<~CONTENT
+
+            #{bold("From")}: #{source.file}:#{source.line}
+
+            #{code.chomp}
+
+          CONTENT
         end
-        content ||= <<~CONTENT
-
-          #{bold("From")}: #{source.file}:#{source.first_line}
-
-          #{code.chomp}
-
-        CONTENT
-
         Pager.page_content(content)
       end
 

--- a/lib/irb/cmd/show_source.rb
+++ b/lib/irb/cmd/show_source.rb
@@ -45,11 +45,13 @@ module IRB
       private
 
       def show_source(source)
-        if source.content
-          code = IRB::Color.colorize_code(source.content)
-        elsif source.first_line && source.last_line
-          file_content = IRB::Color.colorize_code(File.read(source.file))
+        if source.file_content
+          # Colorizing partial code `source.content` sometimes fails.
+          # Instead, we need to colorize `source.file_content` and extract the relevant lines.
+          file_content = IRB::Color.colorize_code(source.file_content)
           code = file_content.lines[(source.first_line - 1)...source.last_line].join
+        elsif source.content
+          code = IRB::Color.colorize_code(source.content)
         elsif source.first_line
           code = 'Source not available'
         else

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -555,9 +555,12 @@ module IRB
         IRB.set_measure_callback
       end
 
+      # We need to use differente path to distinguish source_location of method defined in the actual file and method defined in irb session.
+      eval_path = File.exist?(irb_path) ? "#{irb_path}(#{IRB.conf[:IRB_NAME]})" : irb_path
+
       if IRB.conf[:MEASURE] && !IRB.conf[:MEASURE_CALLBACKS].empty?
         last_proc = proc do
-          result = @workspace.evaluate(line, irb_path, line_no)
+          result = @workspace.evaluate(line, eval_path, line_no)
         end
         IRB.conf[:MEASURE_CALLBACKS].inject(last_proc) do |chain, item|
           _name, callback, arg = item
@@ -568,7 +571,7 @@ module IRB
           end
         end.call
       else
-        result = @workspace.evaluate(line, irb_path, line_no)
+        result = @workspace.evaluate(line, eval_path, line_no)
       end
 
       set_last_value(result)

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -555,9 +555,6 @@ module IRB
         IRB.set_measure_callback
       end
 
-      # We need to use differente path to distinguish source_location of method defined in the actual file and method defined in irb session.
-      eval_path = File.exist?(irb_path) ? "#{irb_path}(#{IRB.conf[:IRB_NAME]})" : irb_path
-
       if IRB.conf[:MEASURE] && !IRB.conf[:MEASURE_CALLBACKS].empty?
         last_proc = proc do
           result = @workspace.evaluate(line, eval_path, line_no)
@@ -575,6 +572,14 @@ module IRB
       end
 
       set_last_value(result)
+    end
+
+    private def eval_path
+      # We need to use differente path to distinguish source_location of method defined in the actual file and method defined in irb session.
+      if !defined?(@irb_path_existence) || @irb_path_existence[0] != irb_path
+        @irb_path_existence = [irb_path, File.exist?(irb_path)]
+      end
+      @irb_path_existence[1] ? "#{irb_path}(#{IRB.conf[:IRB_NAME]})" : irb_path
     end
 
     def inspect_last_value # :nodoc:

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -848,6 +848,16 @@ module TestIRB
       assert_match("command: ': code'", out)
     end
 
+    def test_edit_without_arg_and_non_existing_irb_path
+      out, err = execute_lines(
+        "edit",
+        irb_path: '/path/to/file.rb(irb)'
+      )
+
+      assert_empty err
+      assert_match(/Can not find file: \/path\/to\/file\.rb\(irb\)/, out)
+    end
+
     def test_edit_with_path
       out, err = execute_lines(
         "edit #{__FILE__}"

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -666,6 +666,15 @@ module TestIRB
         ], out)
     end
 
+    def test_eval_path
+      @context.irb_path = __FILE__
+      assert_equal("#{__FILE__}(irb)", @context.send(:eval_path))
+      @context.irb_path = 'file/does/not/exist'
+      assert_equal('file/does/not/exist', @context.send(:eval_path))
+      @context.irb_path = "#{__FILE__}(irb)"
+      assert_equal("#{__FILE__}(irb)", @context.send(:eval_path))
+    end
+
     def test_build_completor
       verbose, $VERBOSE = $VERBOSE, nil
       original_completor = IRB.conf[:COMPLETOR]


### PR DESCRIPTION
With `RubyVM.keep_script_lines = true`, we can show method source defined in IRB.

```ruby
% irb
irb(main):001> def foo; end
=> :foo
irb(main):002> $ foo

From: (irb):1

def foo; end

=> nil
```

```ruby
% ruby -Ilib a.rb
From: a.rb @ line 1 :

 => 1: binding.irb

irb(main):001> def foo; end
=> :foo
irb(main):002> $ foo

From: /path/to/a.rb(irb):1

def foo; end

=> nil
```

## Other changes
```ruby
irb(main):003> $ StringIO

Defined in binary file: /path/to/lib/stringio.bundle

=> nil
irb(main):004> $ Object#tap

From: <internal:kernel>:89

Source not available

=> nil
```

## SourceFinder#find_source
> Error: Couldn't locate a definition for ...

Even if the file is a binary file or does not exist, I think find_source can return a value.
We actually located the definition, but the content of the source is just not available.

```ruby
find_source('StringIO') #=> { file: 'lib/stringio.bundle', first_line: nil, last_line: nil }
find_source('foobar') #=> { file: '(irb)', first_line: 1, last_line: nil, content: 'def foobar; end' }
find_source('tap') #=> { file: '<internal:kernel>', first_line: 89, last_line: nil }
```
