### PR TITLE
Improve constant lookup in SourceFinder

### DIFF
--- a/test/irb/cmd/test_show_source.rb
+++ b/test/irb/cmd/test_show_source.rb
@@ -362,5 +362,36 @@ module TestIRB
       refute_match(/NameError/, out)
       assert_match(%r[Defined in binary file:.+io/console], out)
     end
+
+    def test_show_source_with_constant_lookup
+      write_ruby <<~RUBY
+        X = 1
+        module M
+          Y = 1
+          Z = 2
+        end
+        class A
+          Z = 1
+          Array = 1
+          class B
+            include M
+            Object.new.instance_eval { binding.irb }
+          end
+        end
+      RUBY
+
+      out = run_ruby_file do
+        type "show_source X"
+        type "show_source Y"
+        type "show_source Z"
+        type "show_source Array"
+        type "exit"
+      end
+
+      assert_match(%r[#{@ruby_file.to_path}:1\s+X = 1], out)
+      assert_match(%r[#{@ruby_file.to_path}:3\s+Y = 1], out)
+      assert_match(%r[#{@ruby_file.to_path}:7\s+Z = 1], out)
+      assert_match(%r[#{@ruby_file.to_path}:8\s+Array = 1], out)
+    end
   end
 end


### PR DESCRIPTION
Improve show_source of constant to find const owner more precise.


Constant lookup does not depend on `self`, but on `Module.nesting`
```ruby
X = 1
class A
  Y = 1
  class B
    Z = 1
    [X, Y, Z] # these are visible here. Module.nesting #=> [A::B, A]
  end
end

class A::B
  # [X, Z] # Y is not visible here. Module.nesting #=> [A::B]
end
```

In this test code I added, `X`, `Y`, `Z`, `Array` are all visible with value == 1
```ruby
X = 1
module M
  Y = 1
  Z = 2
end
class A
  Z = 1
  Array = 1
  class B
    include M
    Object.new.instance_eval { binding.irb }
  end
end
```
`Module.nesting` is `[A::B, A]` and lookup order seems `A::B → A → A::B.ancestors → A.ancestors → TOPLEVEL(Object)`
