### PR TITLE
Repurpose the help command to display the help message

### DIFF
--- a/lib/irb/cmd/help.rb
+++ b/lib/irb/cmd/help.rb
@@ -1,23 +1,12 @@
 # frozen_string_literal: true
 
-require_relative "show_doc"
+require_relative "show_cmds"
 
 module IRB
   module ExtendCommand
-    class Help < ShowDoc
-      category "Context"
-      description "[DEPRECATED] Enter the mode to look up RI documents."
-
-      DEPRECATION_MESSAGE = <<~MSG
-        [Deprecation] The `help` command will be repurposed to display command help in the future.
-        For RI document lookup, please use the `show_doc` command instead.
-        For command help, please use `show_cmds` for now.
-      MSG
-
-      def execute(*names)
-        warn DEPRECATION_MESSAGE
-        super
-      end
+    class Help < ShowCmds
+      category "IRB"
+      description "List all available commands and their description."
     end
   end
 end

--- a/test/irb/test_cmd.rb
+++ b/test/irb/test_cmd.rb
@@ -603,6 +603,16 @@ module TestIRB
 
 
   class ShowCmdsTest < CommandTestCase
+    def test_help
+      out, err = execute_lines(
+        "help\n",
+      )
+
+      assert_empty err
+      assert_match(/List all available commands and their description/, out)
+      assert_match(/Start the debugger of debug\.gem/, out)
+    end
+
     def test_show_cmds
       out, err = execute_lines(
         "show_cmds\n"
@@ -774,22 +784,6 @@ module TestIRB
   end
 
   class ShowDocTest < CommandTestCase
-    def test_help
-      out, err = execute_lines(
-        "help String#gsub\n",
-        "\n",
-      )
-
-      # the former is what we'd get without document content installed, like on CI
-      # the latter is what we may get locally
-      possible_rdoc_output = [/Nothing known about String#gsub/, /gsub\(pattern\)/]
-      assert_include err, "[Deprecation] The `help` command will be repurposed to display command help in the future.\n"
-      assert(possible_rdoc_output.any? { |output| output.match?(out) }, "Expect the `help` command to match one of the possible outputs. Got:\n#{out}")
-    ensure
-      # this is the only way to reset the redefined method without coupling the test with its implementation
-      EnvUtil.suppress_warning { load "irb/cmd/help.rb" }
-    end
-
     def test_show_doc
       out, err = execute_lines(
         "show_doc String#gsub\n",


### PR DESCRIPTION
See #787 for more details.

Closes #787 