### PR TITLE
Standardize command related names

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -9,7 +9,7 @@ require "reline"
 
 require_relative "irb/init"
 require_relative "irb/context"
-require_relative "irb/extend-command"
+require_relative "irb/command"
 
 require_relative "irb/ruby-lex"
 require_relative "irb/statement"

--- a/lib/irb/cmd/nop.rb
+++ b/lib/irb/cmd/nop.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# This file is just a placeholder for backward-compatibility.
+# Please require 'irb' and inheirt your command from `IRB::Command::Base` instead.

--- a/lib/irb/command.rb
+++ b/lib/irb/command.rb
@@ -5,6 +5,9 @@
 #
 
 module IRB # :nodoc:
+  module Command; end
+  ExtendCommand = Command
+  deprecate_constant :ExtendCommand
   # Installs the default irb extensions command bundle.
   module ExtendCommandBundle
     EXCB = ExtendCommandBundle # :nodoc:

--- a/lib/irb/command.rb
+++ b/lib/irb/command.rb
@@ -4,6 +4,8 @@
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 
+require_relative "command/base"
+
 module IRB # :nodoc:
   module Command; end
   ExtendCommand = Command

--- a/lib/irb/command.rb
+++ b/lib/irb/command.rb
@@ -9,7 +9,7 @@ require_relative "command/base"
 module IRB # :nodoc:
   module Command; end
   ExtendCommand = Command
-  deprecate_constant :ExtendCommand
+
   # Installs the default irb extensions command bundle.
   module ExtendCommandBundle
     EXCB = ExtendCommandBundle # :nodoc:

--- a/lib/irb/command.rb
+++ b/lib/irb/command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
 #
-#   irb/extend-command.rb - irb extend command
+#   irb/command.rb - irb command
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 
@@ -31,18 +31,18 @@ module IRB # :nodoc:
 
     @EXTEND_COMMANDS = [
       [
-        :irb_exit, :Exit, "cmd/exit",
+        :irb_exit, :Exit, "command/exit",
         [:exit, OVERRIDE_PRIVATE_ONLY],
         [:quit, OVERRIDE_PRIVATE_ONLY],
         [:irb_quit, OVERRIDE_PRIVATE_ONLY],
       ],
       [
-        :irb_exit!, :ForceExit, "cmd/force_exit",
+        :irb_exit!, :ForceExit, "command/force_exit",
         [:exit!, OVERRIDE_PRIVATE_ONLY],
       ],
 
       [
-        :irb_current_working_workspace, :CurrentWorkingWorkspace, "cmd/chws",
+        :irb_current_working_workspace, :CurrentWorkingWorkspace, "command/chws",
         [:cwws, NO_OVERRIDE],
         [:pwws, NO_OVERRIDE],
         [:irb_print_working_workspace, OVERRIDE_ALL],
@@ -54,7 +54,7 @@ module IRB # :nodoc:
         [:irb_pwb, OVERRIDE_ALL],
       ],
       [
-        :irb_change_workspace, :ChangeWorkspace, "cmd/chws",
+        :irb_change_workspace, :ChangeWorkspace, "command/chws",
         [:chws, NO_OVERRIDE],
         [:cws, NO_OVERRIDE],
         [:irb_chws, OVERRIDE_ALL],
@@ -65,13 +65,13 @@ module IRB # :nodoc:
       ],
 
       [
-        :irb_workspaces, :Workspaces, "cmd/pushws",
+        :irb_workspaces, :Workspaces, "command/pushws",
         [:workspaces, NO_OVERRIDE],
         [:irb_bindings, OVERRIDE_ALL],
         [:bindings, NO_OVERRIDE],
       ],
       [
-        :irb_push_workspace, :PushWorkspace, "cmd/pushws",
+        :irb_push_workspace, :PushWorkspace, "command/pushws",
         [:pushws, NO_OVERRIDE],
         [:irb_pushws, OVERRIDE_ALL],
         [:irb_push_binding, OVERRIDE_ALL],
@@ -79,7 +79,7 @@ module IRB # :nodoc:
         [:pushb, NO_OVERRIDE],
       ],
       [
-        :irb_pop_workspace, :PopWorkspace, "cmd/pushws",
+        :irb_pop_workspace, :PopWorkspace, "command/pushws",
         [:popws, NO_OVERRIDE],
         [:irb_popws, OVERRIDE_ALL],
         [:irb_pop_binding, OVERRIDE_ALL],
@@ -88,112 +88,112 @@ module IRB # :nodoc:
       ],
 
       [
-        :irb_load, :Load, "cmd/load"],
+        :irb_load, :Load, "command/load"],
       [
-        :irb_require, :Require, "cmd/load"],
+        :irb_require, :Require, "command/load"],
       [
-        :irb_source, :Source, "cmd/load",
+        :irb_source, :Source, "command/load",
         [:source, NO_OVERRIDE],
       ],
 
       [
-        :irb, :IrbCommand, "cmd/subirb"],
+        :irb, :IrbCommand, "command/subirb"],
       [
-        :irb_jobs, :Jobs, "cmd/subirb",
+        :irb_jobs, :Jobs, "command/subirb",
         [:jobs, NO_OVERRIDE],
       ],
       [
-        :irb_fg, :Foreground, "cmd/subirb",
+        :irb_fg, :Foreground, "command/subirb",
         [:fg, NO_OVERRIDE],
       ],
       [
-        :irb_kill, :Kill, "cmd/subirb",
+        :irb_kill, :Kill, "command/subirb",
         [:kill, OVERRIDE_PRIVATE_ONLY],
       ],
 
       [
-        :irb_debug, :Debug, "cmd/debug",
+        :irb_debug, :Debug, "command/debug",
         [:debug, NO_OVERRIDE],
       ],
       [
-        :irb_edit, :Edit, "cmd/edit",
+        :irb_edit, :Edit, "command/edit",
         [:edit, NO_OVERRIDE],
       ],
       [
-        :irb_break, :Break, "cmd/break",
+        :irb_break, :Break, "command/break",
       ],
       [
-        :irb_catch, :Catch, "cmd/catch",
+        :irb_catch, :Catch, "command/catch",
       ],
       [
-        :irb_next, :Next, "cmd/next"
+        :irb_next, :Next, "command/next"
       ],
       [
-        :irb_delete, :Delete, "cmd/delete",
+        :irb_delete, :Delete, "command/delete",
         [:delete, NO_OVERRIDE],
       ],
       [
-        :irb_step, :Step, "cmd/step",
+        :irb_step, :Step, "command/step",
         [:step, NO_OVERRIDE],
       ],
       [
-        :irb_continue, :Continue, "cmd/continue",
+        :irb_continue, :Continue, "command/continue",
         [:continue, NO_OVERRIDE],
       ],
       [
-        :irb_finish, :Finish, "cmd/finish",
+        :irb_finish, :Finish, "command/finish",
         [:finish, NO_OVERRIDE],
       ],
       [
-        :irb_backtrace, :Backtrace, "cmd/backtrace",
+        :irb_backtrace, :Backtrace, "command/backtrace",
         [:backtrace, NO_OVERRIDE],
         [:bt, NO_OVERRIDE],
       ],
       [
-        :irb_debug_info, :Info, "cmd/info",
+        :irb_debug_info, :Info, "command/info",
         [:info, NO_OVERRIDE],
       ],
 
       [
-        :irb_help, :Help, "cmd/help",
+        :irb_help, :Help, "command/help",
         [:help, NO_OVERRIDE],
       ],
 
       [
-        :irb_show_doc, :ShowDoc, "cmd/show_doc",
+        :irb_show_doc, :ShowDoc, "command/show_doc",
         [:show_doc, NO_OVERRIDE],
       ],
 
       [
-        :irb_info, :IrbInfo, "cmd/irb_info"
+        :irb_info, :IrbInfo, "command/irb_info"
       ],
 
       [
-        :irb_ls, :Ls, "cmd/ls",
+        :irb_ls, :Ls, "command/ls",
         [:ls, NO_OVERRIDE],
       ],
 
       [
-        :irb_measure, :Measure, "cmd/measure",
+        :irb_measure, :Measure, "command/measure",
         [:measure, NO_OVERRIDE],
       ],
 
       [
-        :irb_show_source, :ShowSource, "cmd/show_source",
+        :irb_show_source, :ShowSource, "command/show_source",
         [:show_source, NO_OVERRIDE],
       ],
 
       [
-        :irb_whereami, :Whereami, "cmd/whereami",
+        :irb_whereami, :Whereami, "command/whereami",
         [:whereami, NO_OVERRIDE],
       ],
       [
-        :irb_show_cmds, :ShowCmds, "cmd/show_cmds",
+        :irb_show_cmds, :ShowCmds, "command/show_cmds",
         [:show_cmds, NO_OVERRIDE],
       ],
 
       [
-        :irb_history, :History, "cmd/history",
+        :irb_history, :History, "command/history",
         [:history, NO_OVERRIDE],
         [:hist, NO_OVERRIDE],
       ]
@@ -210,11 +210,11 @@ module IRB # :nodoc:
       end
 
       @EXTEND_COMMANDS.each do |cmd_name, cmd_class, load_file, *aliases|
-        if !defined?(ExtendCommand) || !ExtendCommand.const_defined?(cmd_class, false)
+        if !defined?(Command) || !Command.const_defined?(cmd_class, false)
           require_relative load_file
         end
 
-        klass = ExtendCommand.const_get(cmd_class, false)
+        klass = Command.const_get(cmd_class, false)
         aliases = aliases.map { |a| a.first }
 
         if additional_aliases = user_aliases[cmd_name]
@@ -234,10 +234,10 @@ module IRB # :nodoc:
       @EXTEND_COMMANDS.each do |cmd_name, cmd_class, load_file, *aliases|
         next if cmd_name != command && aliases.all? { |alias_name, _| alias_name != command }
 
-        if !defined?(ExtendCommand) || !ExtendCommand.const_defined?(cmd_class, false)
+        if !defined?(Command) || !Command.const_defined?(cmd_class, false)
           require_relative load_file
         end
-        return ExtendCommand.const_get(cmd_class, false)
+        return Command.const_get(cmd_class, false)
       end
       nil
     end
@@ -267,7 +267,7 @@ module IRB # :nodoc:
       line = __LINE__; eval %[
         def #{cmd_name}(*opts, **kwargs, &b)
           Kernel.require_relative "#{load_file}"
-          ::IRB::ExtendCommand::#{cmd_class}.execute(irb_context, *opts, **kwargs, &b)
+          ::IRB::Command::#{cmd_class}.execute(irb_context, *opts, **kwargs, &b)
         end
       ], nil, __FILE__, line
 

--- a/lib/irb/command/backtrace.rb
+++ b/lib/irb/command/backtrace.rb
@@ -5,14 +5,14 @@ require_relative "debug"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
-    class Info < DebugCommand
+  module Command
+    class Backtrace < DebugCommand
       def self.transform_args(args)
         args&.dump
       end
 
       def execute(*args)
-        super(pre_cmds: ["info", *args].join(" "))
+        super(pre_cmds: ["backtrace", *args].join(" "))
       end
     end
   end

--- a/lib/irb/command/base.rb
+++ b/lib/irb/command/base.rb
@@ -49,7 +49,6 @@ module IRB
     end
 
     Nop = Base
-    deprecate_constant :Nop
   end
 
   # :startdoc:

--- a/lib/irb/command/base.rb
+++ b/lib/irb/command/base.rb
@@ -10,7 +10,7 @@ module IRB
   module Command
     class CommandArgumentError < StandardError; end
 
-    class Nop
+    class Base
       class << self
         def category(category = nil)
           @category = category if category
@@ -47,6 +47,9 @@ module IRB
         #nop
       end
     end
+
+    Nop = Base
+    deprecate_constant :Nop
   end
 
   # :startdoc:

--- a/lib/irb/command/break.rb
+++ b/lib/irb/command/break.rb
@@ -5,14 +5,14 @@ require_relative "debug"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
-    class Backtrace < DebugCommand
+  module Command
+    class Break < DebugCommand
       def self.transform_args(args)
         args&.dump
       end
 
-      def execute(*args)
-        super(pre_cmds: ["backtrace", *args].join(" "))
+      def execute(args = nil)
+        super(pre_cmds: "break #{args}")
       end
     end
   end

--- a/lib/irb/command/catch.rb
+++ b/lib/irb/command/catch.rb
@@ -5,7 +5,7 @@ require_relative "debug"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class Catch < DebugCommand
       def self.transform_args(args)
         args&.dump

--- a/lib/irb/command/chws.rb
+++ b/lib/irb/command/chws.rb
@@ -10,7 +10,7 @@ require_relative "../ext/change-ws"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
 
     class CurrentWorkingWorkspace < Nop
       category "Workspace"

--- a/lib/irb/command/chws.rb
+++ b/lib/irb/command/chws.rb
@@ -3,8 +3,6 @@
 #   change-ws.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-
-require_relative "nop"
 require_relative "../ext/change-ws"
 
 module IRB
@@ -12,7 +10,7 @@ module IRB
 
   module Command
 
-    class CurrentWorkingWorkspace < Nop
+    class CurrentWorkingWorkspace < Base
       category "Workspace"
       description "Show the current workspace."
 
@@ -21,7 +19,7 @@ module IRB
       end
     end
 
-    class ChangeWorkspace < Nop
+    class ChangeWorkspace < Base
       category "Workspace"
       description "Change the current workspace to an object."
 

--- a/lib/irb/command/continue.rb
+++ b/lib/irb/command/continue.rb
@@ -5,7 +5,7 @@ require_relative "debug"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class Continue < DebugCommand
       def execute(*args)
         super(do_cmds: ["continue", *args].join(" "))

--- a/lib/irb/command/debug.rb
+++ b/lib/irb/command/debug.rb
@@ -4,7 +4,7 @@ require_relative "../debug"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class Debug < Nop
       category "Debugging"
       description "Start the debugger of debug.gem."

--- a/lib/irb/command/debug.rb
+++ b/lib/irb/command/debug.rb
@@ -1,11 +1,10 @@
-require_relative "nop"
 require_relative "../debug"
 
 module IRB
   # :stopdoc:
 
   module Command
-    class Debug < Nop
+    class Debug < Base
       category "Debugging"
       description "Start the debugger of debug.gem."
 

--- a/lib/irb/command/delete.rb
+++ b/lib/irb/command/delete.rb
@@ -5,7 +5,7 @@ require_relative "debug"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class Delete < DebugCommand
       def execute(*args)
         super(pre_cmds: ["delete", *args].join(" "))

--- a/lib/irb/command/edit.rb
+++ b/lib/irb/command/edit.rb
@@ -1,12 +1,12 @@
 require 'shellwords'
-require_relative "nop"
+
 require_relative "../source_finder"
 
 module IRB
   # :stopdoc:
 
   module Command
-    class Edit < Nop
+    class Edit < Base
       category "Misc"
       description 'Open a file with the editor command defined with `ENV["VISUAL"]` or `ENV["EDITOR"]`.'
 

--- a/lib/irb/command/edit.rb
+++ b/lib/irb/command/edit.rb
@@ -5,7 +5,7 @@ require_relative "../source_finder"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class Edit < Nop
       category "Misc"
       description 'Open a file with the editor command defined with `ENV["VISUAL"]` or `ENV["EDITOR"]`.'

--- a/lib/irb/command/exit.rb
+++ b/lib/irb/command/exit.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "nop"
-
 module IRB
   # :stopdoc:
 
   module Command
-    class Exit < Nop
+    class Exit < Base
       category "IRB"
       description "Exit the current irb session."
 

--- a/lib/irb/command/exit.rb
+++ b/lib/irb/command/exit.rb
@@ -5,15 +5,15 @@ require_relative "nop"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
-    class ForceExit < Nop
+  module Command
+    class Exit < Nop
       category "IRB"
-      description "Exit the current process."
+      description "Exit the current irb session."
 
       def execute(*)
-        throw :IRB_EXIT, true
+        IRB.irb_exit
       rescue UncaughtThrowError
-        Kernel.exit!
+        Kernel.exit
       end
     end
   end

--- a/lib/irb/command/finish.rb
+++ b/lib/irb/command/finish.rb
@@ -5,7 +5,7 @@ require_relative "debug"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class Finish < DebugCommand
       def execute(*args)
         super(do_cmds: ["finish", *args].join(" "))

--- a/lib/irb/command/force_exit.rb
+++ b/lib/irb/command/force_exit.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "nop"
-
 module IRB
   # :stopdoc:
 
   module Command
-    class ForceExit < Nop
+    class ForceExit < Base
       category "IRB"
       description "Exit the current process."
 

--- a/lib/irb/command/force_exit.rb
+++ b/lib/irb/command/force_exit.rb
@@ -5,15 +5,15 @@ require_relative "nop"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
-    class Exit < Nop
+  module Command
+    class ForceExit < Nop
       category "IRB"
-      description "Exit the current irb session."
+      description "Exit the current process."
 
       def execute(*)
-        IRB.irb_exit
+        throw :IRB_EXIT, true
       rescue UncaughtThrowError
-        Kernel.exit
+        Kernel.exit!
       end
     end
   end

--- a/lib/irb/command/help.rb
+++ b/lib/irb/command/help.rb
@@ -3,7 +3,7 @@
 require_relative "show_cmds"
 
 module IRB
-  module ExtendCommand
+  module Command
     class Help < ShowCmds
       category "IRB"
       description "List all available commands and their description."

--- a/lib/irb/command/history.rb
+++ b/lib/irb/command/history.rb
@@ -7,7 +7,7 @@ require_relative "../pager"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class History < Nop
       category "IRB"
       description "Shows the input history. `-g [query]` or `-G [query]` allows you to filter the output."

--- a/lib/irb/command/history.rb
+++ b/lib/irb/command/history.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 require "stringio"
-require_relative "nop"
+
 require_relative "../pager"
 
 module IRB
   # :stopdoc:
 
   module Command
-    class History < Nop
+    class History < Base
       category "IRB"
       description "Shows the input history. `-g [query]` or `-G [query]` allows you to filter the output."
 

--- a/lib/irb/command/info.rb
+++ b/lib/irb/command/info.rb
@@ -5,14 +5,14 @@ require_relative "debug"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
-    class Break < DebugCommand
+  module Command
+    class Info < DebugCommand
       def self.transform_args(args)
         args&.dump
       end
 
-      def execute(args = nil)
-        super(pre_cmds: "break #{args}")
+      def execute(*args)
+        super(pre_cmds: ["info", *args].join(" "))
       end
     end
   end

--- a/lib/irb/command/irb_info.rb
+++ b/lib/irb/command/irb_info.rb
@@ -5,7 +5,7 @@ require_relative "nop"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class IrbInfo < Nop
       category "IRB"
       description "Show information about IRB."

--- a/lib/irb/command/irb_info.rb
+++ b/lib/irb/command/irb_info.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: false
 
-require_relative "nop"
-
 module IRB
   # :stopdoc:
 
   module Command
-    class IrbInfo < Nop
+    class IrbInfo < Base
       category "IRB"
       description "Show information about IRB."
 

--- a/lib/irb/command/load.rb
+++ b/lib/irb/command/load.rb
@@ -3,15 +3,13 @@
 #   load.rb -
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
-
-require_relative "nop"
 require_relative "../ext/loader"
 
 module IRB
   # :stopdoc:
 
   module Command
-    class LoaderCommand < Nop
+    class LoaderCommand < Base
       include IrbLoader
 
       def raise_cmd_argument_error

--- a/lib/irb/command/load.rb
+++ b/lib/irb/command/load.rb
@@ -10,7 +10,7 @@ require_relative "../ext/loader"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class LoaderCommand < Nop
       include IrbLoader
 

--- a/lib/irb/command/ls.rb
+++ b/lib/irb/command/ls.rb
@@ -9,7 +9,7 @@ require_relative "../color"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class Ls < Nop
       category "Context"
       description "Show methods, constants, and variables. `-g [query]` or `-G [query]` allows you to filter out the output."

--- a/lib/irb/command/ls.rb
+++ b/lib/irb/command/ls.rb
@@ -2,7 +2,7 @@
 
 require "reline"
 require "stringio"
-require_relative "nop"
+
 require_relative "../pager"
 require_relative "../color"
 
@@ -10,7 +10,7 @@ module IRB
   # :stopdoc:
 
   module Command
-    class Ls < Nop
+    class Ls < Base
       category "Context"
       description "Show methods, constants, and variables. `-g [query]` or `-G [query]` allows you to filter out the output."
 

--- a/lib/irb/command/measure.rb
+++ b/lib/irb/command/measure.rb
@@ -1,10 +1,8 @@
-require_relative "nop"
-
 module IRB
   # :stopdoc:
 
   module Command
-    class Measure < Nop
+    class Measure < Base
       category "Misc"
       description "`measure` enables the mode to measure processing time. `measure :off` disables it."
 

--- a/lib/irb/command/measure.rb
+++ b/lib/irb/command/measure.rb
@@ -3,7 +3,7 @@ require_relative "nop"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class Measure < Nop
       category "Misc"
       description "`measure` enables the mode to measure processing time. `measure :off` disables it."

--- a/lib/irb/command/next.rb
+++ b/lib/irb/command/next.rb
@@ -5,10 +5,10 @@ require_relative "debug"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
-    class Step < DebugCommand
+  module Command
+    class Next < DebugCommand
       def execute(*args)
-        super(do_cmds: ["step", *args].join(" "))
+        super(do_cmds: ["next", *args].join(" "))
       end
     end
   end

--- a/lib/irb/command/nop.rb
+++ b/lib/irb/command/nop.rb
@@ -7,7 +7,7 @@
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class CommandArgumentError < StandardError; end
 
     class Nop

--- a/lib/irb/command/pushws.rb
+++ b/lib/irb/command/pushws.rb
@@ -4,14 +4,13 @@
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 
-require_relative "nop"
 require_relative "../ext/workspaces"
 
 module IRB
   # :stopdoc:
 
   module Command
-    class Workspaces < Nop
+    class Workspaces < Base
       category "Workspace"
       description "Show workspaces."
 

--- a/lib/irb/command/pushws.rb
+++ b/lib/irb/command/pushws.rb
@@ -10,7 +10,7 @@ require_relative "../ext/workspaces"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class Workspaces < Nop
       category "Workspace"
       description "Show workspaces."

--- a/lib/irb/command/show_cmds.rb
+++ b/lib/irb/command/show_cmds.rb
@@ -7,7 +7,7 @@ require_relative "../pager"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class ShowCmds < Nop
       category "IRB"
       description "List all available commands and their description."

--- a/lib/irb/command/show_cmds.rb
+++ b/lib/irb/command/show_cmds.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 require "stringio"
-require_relative "nop"
+
 require_relative "../pager"
 
 module IRB
   # :stopdoc:
 
   module Command
-    class ShowCmds < Nop
+    class ShowCmds < Base
       category "IRB"
       description "List all available commands and their description."
 

--- a/lib/irb/command/show_doc.rb
+++ b/lib/irb/command/show_doc.rb
@@ -3,7 +3,7 @@
 require_relative "nop"
 
 module IRB
-  module ExtendCommand
+  module Command
     class ShowDoc < Nop
       class << self
         def transform_args(args)

--- a/lib/irb/command/show_doc.rb
+++ b/lib/irb/command/show_doc.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "nop"
-
 module IRB
   module Command
-    class ShowDoc < Nop
+    class ShowDoc < Base
       class << self
         def transform_args(args)
           # Return a string literal as is for backward compatibility

--- a/lib/irb/command/show_source.rb
+++ b/lib/irb/command/show_source.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
-require_relative "nop"
 require_relative "../source_finder"
 require_relative "../pager"
 require_relative "../color"
 
 module IRB
   module Command
-    class ShowSource < Nop
+    class ShowSource < Base
       category "Context"
       description "Show the source code of a given method or constant."
 

--- a/lib/irb/command/show_source.rb
+++ b/lib/irb/command/show_source.rb
@@ -6,7 +6,7 @@ require_relative "../pager"
 require_relative "../color"
 
 module IRB
-  module ExtendCommand
+  module Command
     class ShowSource < Nop
       category "Context"
       description "Show the source code of a given method or constant."

--- a/lib/irb/command/step.rb
+++ b/lib/irb/command/step.rb
@@ -5,10 +5,10 @@ require_relative "debug"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
-    class Next < DebugCommand
+  module Command
+    class Step < DebugCommand
       def execute(*args)
-        super(do_cmds: ["next", *args].join(" "))
+        super(do_cmds: ["step", *args].join(" "))
       end
     end
   end

--- a/lib/irb/command/subirb.rb
+++ b/lib/irb/command/subirb.rb
@@ -9,7 +9,7 @@ require_relative "nop"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class MultiIRBCommand < Nop
       def execute(*args)
         extend_irb_context

--- a/lib/irb/command/subirb.rb
+++ b/lib/irb/command/subirb.rb
@@ -4,13 +4,11 @@
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 
-require_relative "nop"
-
 module IRB
   # :stopdoc:
 
   module Command
-    class MultiIRBCommand < Nop
+    class MultiIRBCommand < Base
       def execute(*args)
         extend_irb_context
       end

--- a/lib/irb/command/whereami.rb
+++ b/lib/irb/command/whereami.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "nop"
-
 module IRB
   # :stopdoc:
 
   module Command
-    class Whereami < Nop
+    class Whereami < Base
       category "Context"
       description "Show the source code around binding.irb again."
 

--- a/lib/irb/command/whereami.rb
+++ b/lib/irb/command/whereami.rb
@@ -5,7 +5,7 @@ require_relative "nop"
 module IRB
   # :stopdoc:
 
-  module ExtendCommand
+  module Command
     class Whereami < Nop
       category "Context"
       description "Show the source code around binding.irb again."

--- a/lib/irb/ext/use-loader.rb
+++ b/lib/irb/ext/use-loader.rb
@@ -17,12 +17,12 @@ module IRB
     remove_method :irb_load if method_defined?(:irb_load)
     # Loads the given file similarly to Kernel#load, see IrbLoader#irb_load
     def irb_load(*opts, &b)
-      ExtendCommand::Load.execute(irb_context, *opts, &b)
+      Command::Load.execute(irb_context, *opts, &b)
     end
     remove_method :irb_require if method_defined?(:irb_require)
     # Loads the given file similarly to Kernel#require
     def irb_require(*opts, &b)
-      ExtendCommand::Require.execute(irb_context, *opts, &b)
+      Command::Require.execute(irb_context, *opts, &b)
     end
   end
 

--- a/lib/irb/statement.rb
+++ b/lib/irb/statement.rb
@@ -83,9 +83,9 @@ module IRB
       end
 
       def should_be_handled_by_debugger?
-        require_relative 'cmd/help'
-        require_relative 'cmd/debug'
-        IRB::ExtendCommand::DebugCommand > @command_class || IRB::ExtendCommand::Help == @command_class
+        require_relative 'command/help'
+        require_relative 'command/debug'
+        IRB::Command::DebugCommand > @command_class || IRB::Command::Help == @command_class
       end
 
       def evaluable_code

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: false
 require "rubygems"
 require "irb"
-require "irb/extend-command"
 
 require_relative "helper"
 
@@ -797,7 +796,7 @@ module TestIRB
       assert(possible_rdoc_output.any? { |output| output.match?(out) }, "Expect the `show_doc` command to match one of the possible outputs. Got:\n#{out}")
     ensure
       # this is the only way to reset the redefined method without coupling the test with its implementation
-      EnvUtil.suppress_warning { load "irb/cmd/help.rb" }
+      EnvUtil.suppress_warning { load "irb/command/help.rb" }
     end
 
     def test_show_doc_without_rdoc
@@ -813,7 +812,7 @@ module TestIRB
       assert_include(err, "Can't display document because `rdoc` is not installed.\n")
     ensure
       # this is the only way to reset the redefined method without coupling the test with its implementation
-      EnvUtil.suppress_warning { load "irb/cmd/help.rb" }
+      EnvUtil.suppress_warning { load "irb/command/help.rb" }
     end
   end
 


### PR DESCRIPTION
Before we expose command extension APIs, I think it'd be beneficial to first standardize (or even modernize) the names we use for command related concepts. This includes namespace, base class, and folder names:

1. Rename `lib/irb/extend-command.rb` to `lib/irb/command.rb`
2. Rename `lib/irb/cmd/*.rb` to `lib/irb/command/*.rb`
3. Rename `test/irb/test_cmd.rb` to `test/irb/test_command.rb`
4. Rename `ExtendCommand` to `Command` and alias it to `Command`
6. Rename `Nop` to `Base` and alias it to `Base`
