### PR TITLE
 Update error message assertions for Ruby 3.4

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -17,6 +17,7 @@ module IRB
 end
 
 module TestIRB
+  RUBY_3_4 = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0.dev")
   class TestCase < Test::Unit::TestCase
     class TestInputMethod < ::IRB::InputMethod
       attr_reader :list, :line_no

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -68,11 +68,27 @@ module TestIRB
         irb.eval_input
       end
       assert_empty err
-      assert_pattern_list([:*, /\(irb\):1:in `<main>': Foo \(RuntimeError\)\n/,
-                           :*, /#<RuntimeError: Foo>\n/,
-                           :*, /0$/,
-                           :*, /0$/,
-                           /\s*/], out)
+
+      expected_output =
+        if RUBY_3_4
+          [
+            :*, /\(irb\):1:in '<top \(required\)>': Foo \(RuntimeError\)\n/,
+            :*, /#<RuntimeError: Foo>\n/,
+            :*, /0$/,
+            :*, /0$/,
+            /\s*/
+          ]
+        else
+          [
+            :*, /\(irb\):1:in `<main>': Foo \(RuntimeError\)\n/,
+            :*, /#<RuntimeError: Foo>\n/,
+            :*, /0$/,
+            :*, /0$/,
+            /\s*/
+          ]
+        end
+
+      assert_pattern_list(expected_output, out)
     ensure
       $VERBOSE = verbose
     end
@@ -88,11 +104,21 @@ module TestIRB
         irb.eval_input
       end
       assert_empty err
-      assert_pattern_list([
-          :*, /\(irb\):1:in `<main>': Foo \(RuntimeError\)\n/,
-          :*, /\(irb\):2:in `<main>': Bar \(RuntimeError\)\n/,
-          :*, /#<RuntimeError: Bar>\n/,
-        ], out)
+      expected_output =
+        if RUBY_3_4
+          [
+            :*, /\(irb\):1:in '<top \(required\)>': Foo \(RuntimeError\)\n/,
+            :*, /\(irb\):2:in '<top \(required\)>': Bar \(RuntimeError\)\n/,
+            :*, /#<RuntimeError: Bar>\n/,
+          ]
+        else
+          [
+            :*, /\(irb\):1:in `<main>': Foo \(RuntimeError\)\n/,
+            :*, /\(irb\):2:in `<main>': Bar \(RuntimeError\)\n/,
+            :*, /#<RuntimeError: Bar>\n/,
+          ]
+        end
+      assert_pattern_list(expected_output, out)
     end
 
     def test_prompt_n_deprecation
@@ -130,9 +156,9 @@ module TestIRB
         [:marshal, "123", Marshal.dump(123)],
       ],
       failed: [
-        [false, "BasicObject.new", /#<NoMethodError: undefined method `to_s' for/],
-        [:p, "class Foo; undef inspect ;end; Foo.new", /#<NoMethodError: undefined method `inspect' for/],
-        [:yaml, "BasicObject.new", /#<NoMethodError: undefined method `inspect' for/],
+        [false, "BasicObject.new", /#<NoMethodError: undefined method (`|')to_s' for/],
+        [:p, "class Foo; undef inspect ;end; Foo.new", /#<NoMethodError: undefined method (`|')inspect' for/],
+        [:yaml, "BasicObject.new", /#<NoMethodError: undefined method (`|')inspect' for/],
         [:marshal, "[Object.new, Class.new]", /#<TypeError: can't dump anonymous class #<Class:/]
       ]
     }.each do |scenario, cases|
@@ -210,7 +236,7 @@ module TestIRB
       end
       assert_empty err
       assert_match(/An error occurred when inspecting the object: #<RuntimeError: foo>/, out)
-      assert_match(/An error occurred when running Kernel#inspect: #<NoMethodError: undefined method `inspect' for/, out)
+      assert_match(/An error occurred when running Kernel#inspect: #<NoMethodError: undefined method (`|')inspect' for/, out)
     ensure
       $VERBOSE = verbose
     end
@@ -500,22 +526,30 @@ module TestIRB
         irb.eval_input
       end
       assert_empty err
-      if RUBY_VERSION < '3.0.0' && STDOUT.tty?
-        expected = [
-          :*, /Traceback \(most recent call last\):\n/,
-          :*, /\t 2: from \(irb\):1:in `<main>'\n/,
-          :*, /\t 1: from \(irb\):1:in `hoge'\n/,
-          :*, /\(irb\):1:in `fuga': unhandled exception\n/,
-        ]
-      else
-        expected = [
-          :*, /\(irb\):1:in `fuga': unhandled exception\n/,
-          :*, /\tfrom \(irb\):1:in `hoge'\n/,
-          :*, /\tfrom \(irb\):1:in `<main>'\n/,
-          :*
-        ]
-      end
-      assert_pattern_list(expected, out)
+      expected_output =
+        if RUBY_3_4
+          [
+            :*, /\(irb\):1:in 'fuga': unhandled exception\n/,
+            :*, /\tfrom \(irb\):1:in 'hoge'\n/,
+            :*, /\tfrom \(irb\):1:in '<top \(required\)>'\n/,
+            :*
+          ]
+        elsif RUBY_VERSION < '3.0.0' && STDOUT.tty?
+          [
+            :*, /Traceback \(most recent call last\):\n/,
+            :*, /\t 2: from \(irb\):1:in `<main>'\n/,
+            :*, /\t 1: from \(irb\):1:in `hoge'\n/,
+            :*, /\(irb\):1:in `fuga': unhandled exception\n/,
+          ]
+        else
+          [
+            :*, /\(irb\):1:in `fuga': unhandled exception\n/,
+            :*, /\tfrom \(irb\):1:in `hoge'\n/,
+            :*, /\tfrom \(irb\):1:in `<main>'\n/,
+            :*
+          ]
+        end
+      assert_pattern_list(expected_output, out)
     ensure
       $VERBOSE = verbose
     end
@@ -530,22 +564,31 @@ module TestIRB
         irb.eval_input
       end
       assert_empty err
-      if RUBY_VERSION < '3.0.0' && STDOUT.tty?
-        expected = [
-          :*, /Traceback \(most recent call last\):\n/,
-          :*, /\t 2: from \(irb\):1:in `<main>'\n/,
-          :*, /\t 1: from \(irb\):1:in `hoge'\n/,
-          :*, /\(irb\):1:in `fuga': A\\xF3B \(RuntimeError\)\n/,
-        ]
-      else
-        expected = [
-          :*, /\(irb\):1:in `fuga': A\\xF3B \(RuntimeError\)\n/,
-          :*, /\tfrom \(irb\):1:in `hoge'\n/,
-          :*, /\tfrom \(irb\):1:in `<main>'\n/,
-          :*
-        ]
-      end
-      assert_pattern_list(expected, out)
+      expected_output =
+        if RUBY_3_4
+          [
+            :*, /\(irb\):1:in 'fuga': A\\xF3B \(RuntimeError\)\n/,
+            :*, /\tfrom \(irb\):1:in 'hoge'\n/,
+            :*, /\tfrom \(irb\):1:in '<top \(required\)>'\n/,
+            :*
+          ]
+        elsif RUBY_VERSION < '3.0.0' && STDOUT.tty?
+          [
+            :*, /Traceback \(most recent call last\):\n/,
+            :*, /\t 2: from \(irb\):1:in `<main>'\n/,
+            :*, /\t 1: from \(irb\):1:in `hoge'\n/,
+            :*, /\(irb\):1:in `fuga': A\\xF3B \(RuntimeError\)\n/,
+          ]
+        else
+          [
+            :*, /\(irb\):1:in `fuga': A\\xF3B \(RuntimeError\)\n/,
+            :*, /\tfrom \(irb\):1:in `hoge'\n/,
+            :*, /\tfrom \(irb\):1:in `<main>'\n/,
+            :*
+          ]
+        end
+
+      assert_pattern_list(expected_output, out)
     ensure
       $VERBOSE = verbose
     end
@@ -571,43 +614,43 @@ module TestIRB
         expected = [
           :*, /Traceback \(most recent call last\):\n/,
           :*, /\t... \d+ levels...\n/,
-          :*, /\t16: from \(irb\):1:in `a4'\n/,
-          :*, /\t15: from \(irb\):1:in `a5'\n/,
-          :*, /\t14: from \(irb\):1:in `a6'\n/,
-          :*, /\t13: from \(irb\):1:in `a7'\n/,
-          :*, /\t12: from \(irb\):1:in `a8'\n/,
-          :*, /\t11: from \(irb\):1:in `a9'\n/,
-          :*, /\t10: from \(irb\):1:in `a10'\n/,
-          :*, /\t 9: from \(irb\):1:in `a11'\n/,
-          :*, /\t 8: from \(irb\):1:in `a12'\n/,
-          :*, /\t 7: from \(irb\):1:in `a13'\n/,
-          :*, /\t 6: from \(irb\):1:in `a14'\n/,
-          :*, /\t 5: from \(irb\):1:in `a15'\n/,
-          :*, /\t 4: from \(irb\):1:in `a16'\n/,
-          :*, /\t 3: from \(irb\):1:in `a17'\n/,
-          :*, /\t 2: from \(irb\):1:in `a18'\n/,
-          :*, /\t 1: from \(irb\):1:in `a19'\n/,
-          :*, /\(irb\):1:in `a20': unhandled exception\n/,
+          :*, /\t16: from \(irb\):1:in (`|')a4'\n/,
+          :*, /\t15: from \(irb\):1:in (`|')a5'\n/,
+          :*, /\t14: from \(irb\):1:in (`|')a6'\n/,
+          :*, /\t13: from \(irb\):1:in (`|')a7'\n/,
+          :*, /\t12: from \(irb\):1:in (`|')a8'\n/,
+          :*, /\t11: from \(irb\):1:in (`|')a9'\n/,
+          :*, /\t10: from \(irb\):1:in (`|')a10'\n/,
+          :*, /\t 9: from \(irb\):1:in (`|')a11'\n/,
+          :*, /\t 8: from \(irb\):1:in (`|')a12'\n/,
+          :*, /\t 7: from \(irb\):1:in (`|')a13'\n/,
+          :*, /\t 6: from \(irb\):1:in (`|')a14'\n/,
+          :*, /\t 5: from \(irb\):1:in (`|')a15'\n/,
+          :*, /\t 4: from \(irb\):1:in (`|')a16'\n/,
+          :*, /\t 3: from \(irb\):1:in (`|')a17'\n/,
+          :*, /\t 2: from \(irb\):1:in (`|')a18'\n/,
+          :*, /\t 1: from \(irb\):1:in (`|')a19'\n/,
+          :*, /\(irb\):1:in (`|')a20': unhandled exception\n/,
         ]
       else
         expected = [
-          :*, /\(irb\):1:in `a20': unhandled exception\n/,
-          :*, /\tfrom \(irb\):1:in `a19'\n/,
-          :*, /\tfrom \(irb\):1:in `a18'\n/,
-          :*, /\tfrom \(irb\):1:in `a17'\n/,
-          :*, /\tfrom \(irb\):1:in `a16'\n/,
-          :*, /\tfrom \(irb\):1:in `a15'\n/,
-          :*, /\tfrom \(irb\):1:in `a14'\n/,
-          :*, /\tfrom \(irb\):1:in `a13'\n/,
-          :*, /\tfrom \(irb\):1:in `a12'\n/,
-          :*, /\tfrom \(irb\):1:in `a11'\n/,
-          :*, /\tfrom \(irb\):1:in `a10'\n/,
-          :*, /\tfrom \(irb\):1:in `a9'\n/,
-          :*, /\tfrom \(irb\):1:in `a8'\n/,
-          :*, /\tfrom \(irb\):1:in `a7'\n/,
-          :*, /\tfrom \(irb\):1:in `a6'\n/,
-          :*, /\tfrom \(irb\):1:in `a5'\n/,
-          :*, /\tfrom \(irb\):1:in `a4'\n/,
+          :*, /\(irb\):1:in (`|')a20': unhandled exception\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a19'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a18'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a17'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a16'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a15'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a14'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a13'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a12'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a11'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a10'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a9'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a8'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a7'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a6'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a5'\n/,
+          :*, /\tfrom \(irb\):1:in (`|')a4'\n/,
           :*, /\t... \d+ levels...\n/,
         ]
       end

--- a/test/irb/test_eval_history.rb
+++ b/test/irb/test_eval_history.rb
@@ -37,7 +37,7 @@ module TestIRB
       )
 
       assert_empty(err)
-      assert_match(/undefined local variable or method `__'/, out)
+      assert_match(/undefined local variable or method (`|')__'/, out)
     end
 
     def test_eval_history_can_be_retrieved_with_double_underscore

--- a/test/irb/test_raise_exception.rb
+++ b/test/irb/test_raise_exception.rb
@@ -61,7 +61,7 @@ IRB
         # TruffleRuby warns when the locale does not exist
         env['TRUFFLERUBYOPT'] = "#{ENV['TRUFFLERUBYOPT']} --log.level=SEVERE" if RUBY_ENGINE == 'truffleruby'
         args = [env] + bundle_exec + %W[-rirb -C #{tmpdir} -W0 -e IRB.start(__FILE__) -- -f --]
-        error = /`raise_euc_with_invalid_byte_sequence': あ\\xFF \(RuntimeError\)/
+        error = /raise_euc_with_invalid_byte_sequence': あ\\xFF \(RuntimeError\)/
         assert_in_out_err(args, <<~IRB, error, [], encoding: "UTF-8")
           require_relative 'euc'
           raise_euc_with_invalid_byte_sequence


### PR DESCRIPTION
 https://github.com/ruby/ruby/pull/9605 changes both quotes and format for exception messages. So we need to update the assertions in the tests.