### PR TITLE
[Feature #16495] Do not include a backtick in error messages and backtraces

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1235,7 +1235,7 @@ module IRB
         lines.map{ |l| l + "\n" }.join
       }
       # The "<top (required)>" in "(irb)" may be the top level of IRB so imitate the main object.
-      message = message.gsub(/\(irb\):(?<num>\d+):in `<(?<frame>top \(required\))>'/) { "(irb):#{$~[:num]}:in `<main>'" }
+      message = message.gsub(/\(irb\):(?<num>\d+):in (?<open_quote>[`'])<(?<frame>top \(required\))>'/) { "(irb):#{$~[:num]}:in #{$~[:open_quote]}<main>'" }
       puts message
       puts 'Maybe IRB bug!' if irb_bug
     rescue Exception => handler_exc


### PR DESCRIPTION
This is backport commit from https://github.com/ruby/ruby/pull/9605

@mame also fixes some tests on `test/irb`. But It's better to pick upstream changes from https://github.com/ruby/irb/pull/874. I'll merge it to `ruby/ruby`.