### PR TITLE
Remove IRB::NotImplementedError

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -20,7 +20,7 @@ module IRB
     #
     # See IO#gets for more information.
     def gets
-      fail NotImplementedError, "gets"
+      fail NotImplementedError
     end
     public :gets
 

--- a/lib/irb/lc/error.rb
+++ b/lib/irb/lc/error.rb
@@ -12,11 +12,6 @@ module IRB
       super("Unrecognized switch: #{val}")
     end
   end
-  class NotImplementedError < StandardError
-    def initialize(val)
-      super("Need to define `#{val}'")
-    end
-  end
   class CantReturnToNormalMode < StandardError
     def initialize
       super("Can't return to normal mode.")

--- a/lib/irb/lc/ja/error.rb
+++ b/lib/irb/lc/ja/error.rb
@@ -12,11 +12,6 @@ module IRB
       super("スイッチ(#{val})が分りません")
     end
   end
-  class NotImplementedError < StandardError
-    def initialize(val)
-      super("`#{val}'の定義が必要です")
-    end
-  end
   class CantReturnToNormalMode < StandardError
     def initialize
       super("Normalモードに戻れません.")

--- a/lib/irb/output-method.rb
+++ b/lib/irb/output-method.rb
@@ -9,16 +9,10 @@ module IRB
   # IRB::Notifier. You can define your own output method to use with Irb.new,
   # or Context.new
   class OutputMethod
-    class NotImplementedError < StandardError
-      def initialize(val)
-        super("Need to define `#{val}'")
-      end
-    end
-
     # Open this method to implement your own output method, raises a
     # NotImplementedError if you don't define #print in your own class.
     def print(*opts)
-      raise NotImplementedError, "print"
+      raise NotImplementedError
     end
 
     # Prints the given +opts+, with a newline delimiter.


### PR DESCRIPTION
`NotImplementedError` is defined globally, and can be used as `raise NotImplementedError`
But inside IRB module, `raise NotImplementedError` raises ArgumentError.
```
irb(main):001* module IRB
irb(main):002*   raise NotImplementedError
irb(main):003> end
gems/irb-1.11.2/lib/irb/lc/ja/error.rb:16:in `initialize': wrong number of arguments (given 0, expected 1) (ArgumentError)
```

Remove `IRB::NotImplementedError` and `IRB::OutputMethod::NotImplementedError` because we don't need it.