### PR TITLE
Load RubyGems explicitly for tests of test/irb

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -1,5 +1,6 @@
 require "test/unit"
 require "pathname"
+require "rubygems"
 
 begin
   require_relative "../lib/helper"

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: false
 require 'irb/color'
-require 'rubygems'
 require 'stringio'
 
 require_relative "helper"

--- a/test/irb/test_color_printer.rb
+++ b/test/irb/test_color_printer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: false
 require 'irb/color_printer'
-require 'rubygems'
 require 'stringio'
 
 require_relative "helper"

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: false
-require "rubygems"
 require "irb"
 
 require_relative "helper"

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: false
 require 'tempfile'
 require 'irb'
-require 'rubygems'
 
 require_relative "helper"
 

--- a/test/irb/test_tracer.rb
+++ b/test/irb/test_tracer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: false
 require 'tempfile'
 require 'irb'
-require 'rubygems'
 
 require_relative "helper"
 

--- a/test/irb/test_workspace.rb
+++ b/test/irb/test_workspace.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: false
 require 'tempfile'
-require 'rubygems'
 require 'irb'
 require 'irb/workspace'
 require 'irb/color'


### PR DESCRIPTION
The current test helper failed with some environments at `ruby/ruby`.

* https://github.com/ruby/ruby/actions/runs/7953591320/job/21709784902
* http://ci.rvm.jp/results/trunk-random0@ruby-sp2-docker/4954021

We should load `rubygems` at test helper. 