### PR TITLE
Invalid encoding symbols now raise SyntaxError in 3.4

### DIFF
--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -43,6 +43,10 @@ module TestIRB
         omit "Remove me after https://github.com/ruby/prism/issues/2129 is addressed and adopted in TruffleRuby"
       end
 
+      if RUBY_VERSION >= "3.4."
+        omit "Now raises SyntaxError"
+      end
+
       assert_raise_with_message(EncodingError, /invalid symbol/) {
         @context.evaluate(%q[:"\xAE"], 1)
         # The backtrace of this invalid encoding hash doesn't contain lineno.


### PR DESCRIPTION
Port from ruby/ruby@d9b61e228ff86f00c195abb6c3e0e6f4525385e0