### PR TITLE
Unroll extension method generation

### DIFF
--- a/lib/irb/command.rb
+++ b/lib/irb/command.rb
@@ -315,44 +315,4 @@ module IRB # :nodoc:
 
     install_extend_commands
   end
-
-  # Extends methods for the Context module
-  module ContextExtender
-    CE = ContextExtender # :nodoc:
-
-    @EXTEND_COMMANDS = [
-      [:eval_history=, "ext/eval_history.rb"],
-      [:use_loader=, "ext/use-loader.rb"],
-    ]
-
-    # Installs the default context extensions as irb commands:
-    #
-    # Context#eval_history=::   +irb/ext/history.rb+
-    # Context#use_tracer=::     +irb/ext/tracer.rb+
-    # Context#use_loader=::     +irb/ext/use-loader.rb+
-    def self.install_extend_commands
-      for args in @EXTEND_COMMANDS
-        def_extend_command(*args)
-      end
-    end
-
-    # Evaluate the given +command+ from the given +load_file+ on the Context
-    # module.
-    #
-    # Will also define any given +aliases+ for the method.
-    def self.def_extend_command(cmd_name, load_file, *aliases)
-      line = __LINE__; Context.module_eval %[
-        def #{cmd_name}(*opts, &b)
-          Context.module_eval {remove_method(:#{cmd_name})}
-          require_relative "#{load_file}"
-          __send__ :#{cmd_name}, *opts, &b
-        end
-        for ali in aliases
-          alias_method ali, cmd_name
-        end
-      ], __FILE__, line
-    end
-
-    CE.install_extend_commands
-  end
 end

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -166,6 +166,18 @@ module IRB
       IRB.conf[:USE_TRACER] = val
     end
 
+    def eval_history=(val)
+      self.class.remove_method(__method__)
+      require_relative "ext/eval_history"
+      __send__(__method__, val)
+    end
+
+    def use_loader=(val)
+      self.class.remove_method(__method__)
+      require_relative "ext/use-loader"
+      __send__(__method__, val)
+    end
+
     private def build_completor
       completor_type = IRB.conf[:COMPLETOR]
       case completor_type

--- a/lib/irb/ext/use-loader.rb
+++ b/lib/irb/ext/use-loader.rb
@@ -4,7 +4,7 @@
 #   	by Keiju ISHITSUKA(keiju@ruby-lang.org)
 #
 
-require_relative "../cmd/load"
+require_relative "../command/load"
 require_relative "loader"
 
 class Object
@@ -49,7 +49,7 @@ module IRB
       if IRB.conf[:USE_LOADER] != opt
         IRB.conf[:USE_LOADER] = opt
         if opt
-          if !$".include?("irb/cmd/load")
+          if !$".include?("irb/command/load")
           end
           (class<<@workspace.main;self;end).instance_eval {
             alias_method :load, :irb_load


### PR DESCRIPTION
Given we only have 2 remaining extension setter methods, both of which only take 1 argument and don't have any alias, the current method generation logic is overly complicated.

This PR simplifies the method generation logic by simply defining the methods directly in the `IRB::Context` class.

I also found that `use_loader` is broken and fixed it in a separate commit.