### PR TITLE
Remove workaround for empty lines in dynamic_prompt

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1138,7 +1138,6 @@ module IRB
       end
       if @context.io.respond_to?(:dynamic_prompt)
         @context.io.dynamic_prompt do |lines|
-          lines << '' if lines.empty?
           tokens = RubyLex.ripper_lex_without_warning(lines.map{ |l| l + "\n" }.join, local_variables: @context.local_variables)
           line_results = IRB::NestingParser.parse_by_line(tokens)
           tokens_until_line = []


### PR DESCRIPTION
This guard clause looks like a workaround of Reline's bug. I think this bug is already fixed or perhaps never existed.
```ruby
@context.io.dynamic_prompt do |lines|
  lines << '' if lines.empty?
  ...
end
```
Also, modifying given value (might be Reline's internal value) is not good. Fortunately, this code is never executed.

Reline calls prompt proc with `check_multiline_prompt(whole_buffer)` or `check_multiline_prompt(@buffer_of_lines)`
`@buffer_of_lines` is always non-empty because Reline would crash when it becomes empty.