### PR TITLE
Remove useless loaded file check

### DIFF
--- a/lib/irb/ext/use-loader.rb
+++ b/lib/irb/ext/use-loader.rb
@@ -49,8 +49,6 @@ module IRB
       if IRB.conf[:USE_LOADER] != opt
         IRB.conf[:USE_LOADER] = opt
         if opt
-          if !$".include?("irb/command/load")
-          end
           (class<<@workspace.main;self;end).instance_eval {
             alias_method :load, :irb_load
             alias_method :require, :irb_require


### PR DESCRIPTION
It was doing nothing from the beginning
`$"` never includes `"irb/command/load"` but always includes `"absolute/path/to/irb/command/load.rb"`

https://github.com/ruby/irb/pull/882#discussion_r1500555041
