### PR TITLE
Escape closing square brackets in regexp

### DIFF
--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -543,7 +543,7 @@ module TestIRB
       )
 
       assert_empty err
-      assert_match(/\[#<TestIRB::Workspac...>, #<TestIRB::Workspac...>]\n/, out)
+      assert_match(/\[#<TestIRB::Workspac...>, #<TestIRB::Workspac...>\]\n/, out)
     end
   end
 


### PR DESCRIPTION
Fixes the following warning:

    test/irb/test_command.rb:546: warning: regular expression has ']' without escape

Introduced in #888.

cc. @st0012 