### PR TITLE
Prevent `irb_history`'s creation during HistoryTest

### DIFF
--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -10,11 +10,23 @@ return if RUBY_PLATFORM.match?(/solaris|mswin|mingw/i)
 module TestIRB
   class HistoryTest < TestCase
     def setup
+      @original_verbose, $VERBOSE = $VERBOSE, nil
+      @tmpdir = Dir.mktmpdir("test_irb_history_")
+      @backup_home = ENV["HOME"]
+      @backup_xdg_config_home = ENV.delete("XDG_CONFIG_HOME")
+      @backup_irbrc = ENV.delete("IRBRC")
+      @backup_default_external = Encoding.default_external
+      ENV["HOME"] = @tmpdir
       IRB.conf[:RC_NAME_GENERATOR] = nil
     end
 
     def teardown
       IRB.conf[:RC_NAME_GENERATOR] = nil
+      ENV["HOME"] = @backup_home
+      ENV["XDG_CONFIG_HOME"] = @backup_xdg_config_home
+      ENV["IRBRC"] = @backup_irbrc
+      Encoding.default_external = @backup_default_external
+      $VERBOSE = @original_verbose
     end
 
     class TestInputMethodWithRelineHistory < TestInputMethod
@@ -123,35 +135,23 @@ module TestIRB
     end
 
     def test_history_concurrent_use_not_present
-      backup_home = ENV["HOME"]
-      backup_xdg_config_home = ENV.delete("XDG_CONFIG_HOME")
-      backup_irbrc = ENV.delete("IRBRC")
       IRB.conf[:LC_MESSAGES] = IRB::Locale.new
       IRB.conf[:SAVE_HISTORY] = 1
-      Dir.mktmpdir("test_irb_history_") do |tmpdir|
-        ENV["HOME"] = tmpdir
-        io = TestInputMethodWithRelineHistory.new
-        io.class::HISTORY.clear
-        io.load_history
-        io.class::HISTORY << 'line1'
-        io.class::HISTORY << 'line2'
+      io = TestInputMethodWithRelineHistory.new
+      io.class::HISTORY.clear
+      io.load_history
+      io.class::HISTORY << 'line1'
+      io.class::HISTORY << 'line2'
 
-        history_file = IRB.rc_files("_history").first
-        assert_not_send [File, :file?, history_file]
-        File.write(history_file, "line0\n")
-        io.save_history
-        assert_equal(%w"line0 line1 line2", File.read(history_file).split)
-      end
-    ensure
-      ENV["HOME"] = backup_home
-      ENV["XDG_CONFIG_HOME"] = backup_xdg_config_home
-      ENV["IRBRC"] = backup_irbrc
+      history_file = IRB.rc_files("_history").first
+      assert_not_send [File, :file?, history_file]
+      File.write(history_file, "line0\n")
+      io.save_history
+      assert_equal(%w"line0 line1 line2", File.read(history_file).split)
     end
 
     def test_history_different_encodings
-      backup_default_external = Encoding.default_external
       IRB.conf[:SAVE_HISTORY] = 2
-      verbose_bak, $VERBOSE = $VERBOSE, nil
       Encoding.default_external = Encoding::US_ASCII
       locale = IRB::Locale.new("C")
       assert_history(<<~EXPECTED_HISTORY.encode(Encoding::US_ASCII), <<~INITIAL_HISTORY.encode(Encoding::UTF_8), <<~INPUT, locale: locale)
@@ -162,9 +162,6 @@ module TestIRB
       INITIAL_HISTORY
         exit
       INPUT
-    ensure
-      Encoding.default_external = backup_default_external
-      $VERBOSE = verbose_bak
     end
 
     def test_history_does_not_raise_when_history_file_directory_does_not_exist
@@ -176,6 +173,11 @@ module TestIRB
       assert_warn(/history file does not exist/) do
         io.save_history
       end
+
+      # assert_warn reverts $VERBOSE to EnvUtil.original_verbose, which is true in some cases
+      # We want to keep $VERBOSE as nil until teardown is called
+      # TODO: check if this is an assert_warn issue
+      $VERBOSE = nil
     ensure
       IRB.conf[:HISTORY_FILE] = backup_history_file
     end
@@ -212,35 +214,30 @@ module TestIRB
     end
 
     def assert_history(expected_history, initial_irb_history, input, input_method = TestInputMethodWithRelineHistory, locale: IRB::Locale.new)
-      backup_verbose, $VERBOSE = $VERBOSE, nil
-      backup_home = ENV["HOME"]
-      backup_xdg_config_home = ENV.delete("XDG_CONFIG_HOME")
       IRB.conf[:LC_MESSAGES] = locale
       actual_history = nil
       history_file = IRB.rc_files("_history").first
-      Dir.mktmpdir("test_irb_history_") do |tmpdir|
-        ENV["HOME"] = tmpdir
-        File.open(history_file, "w") do |f|
-          f.write(initial_irb_history)
-        end
+      ENV["HOME"] = @tmpdir
+      File.open(history_file, "w") do |f|
+        f.write(initial_irb_history)
+      end
 
-        io = input_method.new
+      io = input_method.new
+      io.class::HISTORY.clear
+      io.load_history
+      if block_given?
+        previous_history = []
+        io.class::HISTORY.each { |line| previous_history << line }
+        yield history_file
         io.class::HISTORY.clear
-        io.load_history
-        if block_given?
-          previous_history = []
-          io.class::HISTORY.each { |line| previous_history << line }
-          yield history_file
-          io.class::HISTORY.clear
-          previous_history.each { |line| io.class::HISTORY << line }
-        end
-        input.split.each { |line| io.class::HISTORY << line }
-        io.save_history
+        previous_history.each { |line| io.class::HISTORY << line }
+      end
+      input.split.each { |line| io.class::HISTORY << line }
+      io.save_history
 
-        io.load_history
-        File.open(history_file, "r") do |f|
-          actual_history = f.read
-        end
+      io.load_history
+      File.open(history_file, "r") do |f|
+        actual_history = f.read
       end
       assert_equal(expected_history, actual_history, <<~MESSAGE)
         expected:
@@ -248,10 +245,6 @@ module TestIRB
         but actual:
         #{actual_history}
       MESSAGE
-    ensure
-      $VERBOSE = backup_verbose
-      ENV["HOME"] = backup_home
-      ENV["XDG_CONFIG_HOME"] = backup_xdg_config_home
     end
 
     def with_temp_stdio


### PR DESCRIPTION
Some cases of it currently create `~/.irb_history` files unintentionally while others don't. This is caused by the varying levels of setup/cleanup between them. This commit fixes the issue by wrapping every single test inside a consistent test setup and teardown callbacks.