### PR TITLE
The _history file should not appear in the project directory

### DIFF
--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -412,21 +412,21 @@ module IRB # :nodoc:
   end
 
   def IRB.rc_files(ext = IRBRC_EXT)
-    if !@CONF[:RC_NAME_GENERATOR]
-      @CONF[:RC_NAME_GENERATOR] ||= []
+    unless @CONF[:RC_NAME_GENERATOR] && @CONF[:RC_NAME_GENERATOR][ext]
+      @CONF[:RC_NAME_GENERATOR] ||= Hash.new([])
       existing_rc_file_generators = []
 
       rc_file_generators do |rcgen|
-        @CONF[:RC_NAME_GENERATOR] << rcgen
+        @CONF[:RC_NAME_GENERATOR][ext] << rcgen
         existing_rc_file_generators << rcgen if File.exist?(rcgen.call(ext))
       end
 
       if existing_rc_file_generators.any?
-        @CONF[:RC_NAME_GENERATOR] = existing_rc_file_generators
+        @CONF[:RC_NAME_GENERATOR][ext] = existing_rc_file_generators
       end
     end
 
-    @CONF[:RC_NAME_GENERATOR].map do |rc|
+    @CONF[:RC_NAME_GENERATOR][ext].map do |rc|
       rc_file = rc.call(ext)
       fail IllegalRCNameGenerator unless rc_file.is_a?(String)
       rc_file

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -164,6 +164,21 @@ module TestIRB
       end
     end
 
+    def test_rc_file_in_project_dir_does_not_have_history_in_project_dir
+      tmpdir = @tmpdir
+      ENV["HOME"] = "#{tmpdir}/home"
+
+      FileUtils.mkdir_p("#{tmpdir}/.irbrc")
+      FileUtils.mkdir_p(ENV["HOME"])
+
+      Dir.chdir(tmpdir) do
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        assert_includes IRB.rc_files, tmpdir+"/.irbrc"
+        assert_not_include IRB.rc_files("_history").first, tmpdir+"/.irb_history"
+        assert_includes IRB.rc_files("_history").first, ENV["HOME"]+"/.irb_history"
+      end
+    end
+
     def test_sigint_restore_default
       pend "This test gets stuck on Solaris for unknown reason; contribution is welcome" if RUBY_PLATFORM =~ /solaris/
       bundle_exec = ENV.key?('BUNDLE_GEMFILE') ? ['-rbundler/setup'] : []


### PR DESCRIPTION
Issue https://github.com/ruby/irb/issues/674 (second part of that issue)

The _history file should not appear in the project directory, it should always appear in the IRBRC or HOME or XDG_CONFIG_HOME dir.

By keeping a reference to the extension and using that for the generators, the history file will appear in the HOME, IRBRC, XDG_CONFIG_HOME. If neither of those ENV vars are set, then the history file will appear in the same dir as the irbrc file. Might need to think about that last use case, not sure what we want to do there.

To repro the issue: first create the proj irbrc file, then create the history file, because the `existing_rc_file_generators` will have a value and point to the current proj irbrc file, when you create the history file later, it will create it in the same folder.

cc/ @st0012 