### PR TITLE
rdoc version lock is required

### DIFF
--- a/irb.gemspec
+++ b/irb.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.7")
 
   spec.add_dependency "reline", ">= 0.4.2"
-  spec.add_dependency "rdoc"
+  spec.add_dependency "rdoc", ">= 4.0.0"
 end


### PR DESCRIPTION
Some features of irb do not work properly when using the old rdoc. I have compared several major versions and found that it works as intended from 4.0.0.

This problem occurs when there is a Gemfile.lock is installed with the old rdoc. I don't know why this Gemfile.lock installs an older rdoc than the ruby bundled rdoc, but specifying the version in the gemspec will at least prevent the problem.

NOTE: ruby/irb#704 problem does not occur with this change.

The following is test code.

```
 ### Usage: ruby __FILE__.rb
 # # input RDoc and Tab
 # >> RDoc<Tab>
 #
 ### Expect: Display document of RDoc
 ### Actual: <internal:marshal>:34:in `load': instance of RDoc::Constant needs to have method `marshal_load' (TypeError)
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
  gem 'irb'
  # gem 'rdoc', '~> 4.0.0'
  gem 'rdoc', '~> 3.12.0'
end

require 'rdoc'
require 'irb'

IRB.start
```

---

Simply updating the version of rdoc specified in Gemfile.lock will solve the problem, so if there is a problem with this PR, it is ok to close it.