### PR TITLE
Add disable_irb command to disable debug of binding.irb

### DIFF
--- a/lib/irb/command.rb
+++ b/lib/irb/command.rb
@@ -196,7 +196,12 @@ module IRB # :nodoc:
         :irb_history, :History, "command/history",
         [:history, NO_OVERRIDE],
         [:hist, NO_OVERRIDE],
-      ]
+      ],
+
+      [
+        :irb_disable_irb, :DisableIrb, "command/disable_irb",
+        [:disable_irb, NO_OVERRIDE],
+      ],
     ]
 
 

--- a/lib/irb/command/disable_irb.rb
+++ b/lib/irb/command/disable_irb.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module IRB
+  # :stopdoc:
+
+  module Command
+    class DisableIrb < Base
+      category "IRB"
+      description "Disable binding.irb."
+
+      def execute(*)
+        ::Binding.define_method(:irb) {}
+        IRB.irb_exit
+      rescue UncaughtThrowError
+        Kernel.exit
+      end
+    end
+  end
+
+  # :startdoc:
+end


### PR DESCRIPTION
This PR is a proposal to add the command `disable_irb`, which is equivalent to the command `disble-pry` in pry.

## Background
I often debug my programs with lots of `binding.irb`. Then, after I have finished debugging, the `binding.irb` I have planted sometimes makes it difficult to terminate the process normally.

Here is an extreme example.

```console
$ ruby -e '100.times{ binding.irb }'
irb(main):001> exit
irb(main):001> exit
irb(main):001> exit
... # 100 times exit required!
```

I often use the following workaround.

```console
$ ruby -e '1000.times{ binding.irb }'
irb(main):001> class ::Binding; def irb; end; end
=> :irb
irb(main):002> exit
```

## Proposal
With `disable_irb` to be added in this PR, it is easy to skip `binding.irb` called in a large number of loops, as shown below.

```console
$ ruby -e '1000.times{ binding.irb }'
irb(main):001> disable_irb
```
