### PR TITLE
Rescue from exceptions raised by #name

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -388,7 +388,7 @@ module IRB
 
         if doc_namespace
           rec_class = rec.is_a?(Module) ? rec : rec.class
-          "#{rec_class.name}#{sep}#{candidates.find{ |i| i == message }}"
+          "#{rec_class.name}#{sep}#{candidates.find{ |i| i == message }}" rescue nil
         else
           select_message(receiver, message, candidates, sep)
         end

--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -418,7 +418,7 @@ module IRB
           vars = (bind.local_variables | bind.eval_instance_variables).collect{|m| m.to_s}
           perfect_match_var = vars.find{|m| m.to_s == input}
           if perfect_match_var
-            eval("#{perfect_match_var}.class.name", bind)
+            eval("#{perfect_match_var}.class.name", bind) rescue nil
           else
             candidates = (bind.eval_methods | bind.eval_private_methods | bind.local_variables | bind.eval_instance_variables | bind.eval_class_constants).collect{|m| m.to_s}
             candidates |= ReservedWords


### PR DESCRIPTION
Hi there!

When using autocompletion, irb might terminate after pressing tab if the class overwrites `name` and makes it raise errors for some reason. This commit rescue irb from termination.

```ruby
class Foo
  def self.name
    raise StandardError, 'Abort!'
  end
  def self.bar
    'bar'
  end
end
```

In irb, `Foo.ba[press tab]` will terminate the session.

```shell
irb(main):001> IRB.version
=> "irb 1.12.0 (2024-03-06)"
irb(main):002* class Foo
irb(main):003*   def self.name
irb(main):004*     raise StandardError, 'Abort!'
irb(main):005*   end
irb(main):006*   def self.bar
irb(main):007*     'bar'
irb(main):008*   end
irb(main):009> end
=> :bar
irb(main):010> Foo.bar(irb):4:in `name': Abort! (StandardError)
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb/completion.rb:391:in `retrieve_completion_data'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb/completion.rb:188:in `doc_namespace'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb/input-method.rb:308:in `retrieve_doc_namespace'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb/input-method.rb:328:in `block in show_doc_dialog_proc'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline/line_editor.rb:588:in `instance_exec'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline/line_editor.rb:588:in `call'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline/line_editor.rb:623:in `call'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline/line_editor.rb:776:in `update_each_dialog'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline/line_editor.rb:652:in `block in render_dialog'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline/line_editor.rb:650:in `map'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline/line_editor.rb:650:in `render_dialog'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline/line_editor.rb:500:in `rerender'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline.rb:351:in `block (3 levels) in inner_readline'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline.rb:349:in `each'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline.rb:349:in `block (2 levels) in inner_readline'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline.rb:424:in `block in read_io'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline.rb:394:in `loop'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline.rb:394:in `read_io'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline.rb:347:in `block in inner_readline'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline.rb:345:in `loop'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline.rb:345:in `inner_readline'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline.rb:273:in `block in readmultiline'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline/ansi.rb:152:in `block in with_raw_input'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline/ansi.rb:152:in `raw'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline/ansi.rb:152:in `with_raw_input'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.4.3/lib/reline.rb:269:in `readmultiline'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/3.2.0/forwardable.rb:240:in `readmultiline'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb/input-method.rb:465:in `gets'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb.rb:1036:in `block in read_input'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb.rb:1323:in `signal_status'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb.rb:1034:in `read_input'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb.rb:1056:in `readmultiline'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb.rb:1083:in `block in each_top_level_statement'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb.rb:1082:in `loop'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb.rb:1082:in `each_top_level_statement'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb.rb:1004:in `eval_input'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb.rb:988:in `block in run'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb.rb:987:in `catch'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb.rb:987:in `run'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/lib/irb.rb:884:in `start'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.12.0/exe/irb:9:in `<top (required)>'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/bin/irb:25:in `load'
        from /Users/monkeywzr/.rbenv/versions/3.2.2/bin/irb:25:in `<main>'
➜

```

In rails 7.0, `ActiveSupport::TimeWithZone.name` will raise `ActiveSupport::DeprecationException` if we set `config.active_support.deprecation = :raise`, which should be common for development environment.

```
Rails.version # => "7.0.8"
IRB.version # => "irb 1.12.0 (2024-03-06)"
Rails.application.config.active_support.deprecation # => :raise
foo = Time.current
foo.[press_tab] # => BOOM! Irb terminates!
```

This pr rescue irb from termination.
