### PR TITLE
Fix irb_history saved to current directory

### DIFF
--- a/doc/irb/indexes.md
+++ b/doc/irb/indexes.md
@@ -165,9 +165,6 @@ for each entry that is pre-defined, the initial value is given:
 - `:RC`: Whether a {configuration file}[rdoc-ref:IRB@Configuration+File]
   was found and interpreted;
   initial value: `true` if a configuration file was found, `false` otherwise.
-- `:RC_NAME_GENERATOR`: \Proc to generate paths of potential
-  {configuration files}[rdoc-ref:IRB@Configuration+File];
-  initial value: `=> #<Proc:0x000055f9bebfed80 /var/lib/gems/3.0.0/gems/irb-1.8.3/lib/irb/init.rb:401>`.
 - `:SAVE_HISTORY`: Number of commands to save in
   {input command history}[rdoc-ref:IRB@Input+Command+History];
   initial value: `1000`.

--- a/lib/irb/command/irb_info.rb
+++ b/lib/irb/command/irb_info.rb
@@ -13,7 +13,7 @@ module IRB
         str += "IRB version: #{IRB.version}\n"
         str += "InputMethod: #{IRB.CurrentContext.io.inspect}\n"
         str += "Completion: #{IRB.CurrentContext.io.respond_to?(:completion_info) ? IRB.CurrentContext.io.completion_info : 'off'}\n"
-        rc_files = IRB.rc_files.select { |rc| File.exist?(rc) }
+        rc_files = IRB.irbrc_files
         str += ".irbrc paths: #{rc_files.join(", ")}\n" if rc_files.any?
         str += "RUBY_PLATFORM: #{RUBY_PLATFORM}\n"
         str += "LANG env: #{ENV["LANG"]}\n" if ENV["LANG"] && !ENV["LANG"].empty?

--- a/lib/irb/history.rb
+++ b/lib/irb/history.rb
@@ -16,8 +16,8 @@ module IRB
       if history_file = IRB.conf[:HISTORY_FILE]
         history_file = File.expand_path(history_file)
       end
-      history_file = IRB.rc_files("_history").first unless history_file
-      if File.exist?(history_file)
+      history_file = IRB.rc_file("_history") unless history_file
+      if history_file && File.exist?(history_file)
         File.open(history_file, "r:#{IRB.conf[:LC_MESSAGES].encoding}") do |f|
           f.each { |l|
             l = l.chomp
@@ -41,7 +41,10 @@ module IRB
         if history_file = IRB.conf[:HISTORY_FILE]
           history_file = File.expand_path(history_file)
         end
-        history_file = IRB.rc_files("_history").first unless history_file
+        history_file = IRB.rc_file("_history") unless history_file
+
+        # When HOME and XDG_CONFIG_HOME are not available, history_file might be nil
+        return unless history_file
 
         # Change the permission of a file that already exists[BUG #7694]
         begin

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -395,10 +395,8 @@ module IRB # :nodoc:
   # Run the config file
   def IRB.run_config
     if @CONF[:RC]
-      rc_files.each do |rc|
-        # Because rc_file always returns `HOME/.irbrc` even if no rc file is present, we can't warn users about missing rc files.
-        # Otherwise, it'd be very noisy.
-        load rc if File.exist?(rc)
+      irbrc_files.each do |rc|
+        load rc
       rescue StandardError, ScriptError => e
         warn "Error loading RC file '#{rc}':\n#{e.full_message(highlight: false)}"
       end
@@ -406,31 +404,44 @@ module IRB # :nodoc:
   end
 
   IRBRC_EXT = "rc"
-  def IRB.rc_file(ext = IRBRC_EXT)
-    warn "rc_file is deprecated, please use rc_files instead."
-    rc_files(ext).first
+
+  def IRB.prepare_rc_name_generator
+    return if @CONF[:RC_NAME_GENERATOR]
+
+    @CONF[:RC_NAME_GENERATOR] = []
+    rc_file_generators do |rcgen|
+      @CONF[:RC_NAME_GENERATOR] << rcgen if File.exist?(rcgen.call(IRBRC_EXT))
+    end
+    @current_dir_irbrc_files = generate_current_dir_irbrc_files
   end
 
-  def IRB.rc_files(ext = IRBRC_EXT)
-    if !@CONF[:RC_NAME_GENERATOR]
-      @CONF[:RC_NAME_GENERATOR] ||= []
-      existing_rc_file_generators = []
+  def IRB.rc_file(ext)
+    prepare_rc_name_generator
 
-      rc_file_generators do |rcgen|
-        @CONF[:RC_NAME_GENERATOR] << rcgen
-        existing_rc_file_generators << rcgen if File.exist?(rcgen.call(ext))
-      end
-
-      if existing_rc_file_generators.any?
-        @CONF[:RC_NAME_GENERATOR] = existing_rc_file_generators
-      end
+    # When irbrc exist in default location
+    if (rcgen = @CONF[:RC_NAME_GENERATOR].first)
+      file = rcgen.call(ext)
+      fail IllegalRCNameGenerator unless file.is_a?(String)
+      return file
     end
 
-    @CONF[:RC_NAME_GENERATOR].map do |rc|
-      rc_file = rc.call(ext)
-      fail IllegalRCNameGenerator unless rc_file.is_a?(String)
-      rc_file
+    # When irbrc does not exist in default location
+    rc_file_generators do |rcgen|
+      return rcgen.call(ext)
     end
+
+    # When HOME and XDG_CONFIG_HOME are not available
+    nil
+  end
+
+  def IRB.irbrc_files
+    prepare_rc_name_generator
+    files = @CONF[:RC_NAME_GENERATOR].filter_map do |rc|
+      file = rc.call(IRBRC_EXT)
+      fail IllegalRCNameGenerator unless file.is_a?(String)
+      file if File.exist?(file)
+    end + @current_dir_irbrc_files
+    files.uniq
   end
 
   # enumerate possible rc-file base name generators
@@ -446,13 +457,17 @@ module IRB # :nodoc:
     end
     if home = ENV["HOME"]
       yield proc{|rc| home+"/.irb#{rc}"}
-      yield proc{|rc| home+"/.config/irb/irb#{rc}"}
+      if xdg_config_home.nil? || xdg_config_home.empty?
+        yield proc{|rc| home+"/.config/irb/irb#{rc}"}
+      end
     end
+  end
+
+  # possible irbrc files in current directory
+  def IRB.generate_current_dir_irbrc_files
     current_dir = Dir.pwd
-    yield proc{|rc| current_dir+"/.irb#{rc}"}
-    yield proc{|rc| current_dir+"/irb#{rc.sub(/\A_?/, '.')}"}
-    yield proc{|rc| current_dir+"/_irb#{rc}"}
-    yield proc{|rc| current_dir+"/$irb#{rc}"}
+    files = %w[.irbrc irbrc _irbrc $irbrc].map { |file| "#{current_dir}/#{file}" }
+    files.select { |file| File.exist?(file) }
   end
 
   # loading modules

--- a/lib/irb/lc/error.rb
+++ b/lib/irb/lc/error.rb
@@ -47,11 +47,6 @@ module IRB
       super("Undefined prompt mode(#{val}).")
     end
   end
-  class IllegalRCGenerator < StandardError
-    def initialize
-      super("Define illegal RC_NAME_GENERATOR.")
-    end
-  end
 
   # :startdoc:
 end

--- a/lib/irb/lc/ja/error.rb
+++ b/lib/irb/lc/ja/error.rb
@@ -47,11 +47,6 @@ module IRB
       super("プロンプトモード(#{val})は定義されていません.")
     end
   end
-  class IllegalRCGenerator < StandardError
-    def initialize
-      super("RC_NAME_GENERATORが正しく定義されていません.")
-    end
-  end
 
   # :startdoc:
 end

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -20,6 +20,7 @@ module TestIRB
       @xdg_config_home_backup = ENV.delete("XDG_CONFIG_HOME")
       save_encodings
       IRB.instance_variable_get(:@CONF).clear
+      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
       @is_win = (RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/)
     end
 

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -17,11 +17,11 @@ module TestIRB
       @backup_irbrc = ENV.delete("IRBRC")
       @backup_default_external = Encoding.default_external
       ENV["HOME"] = @tmpdir
-      IRB.conf[:RC_NAME_GENERATOR] = nil
+      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
     end
 
     def teardown
-      IRB.conf[:RC_NAME_GENERATOR] = nil
+      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
       ENV["HOME"] = @backup_home
       ENV["XDG_CONFIG_HOME"] = @backup_xdg_config_home
       ENV["IRBRC"] = @backup_irbrc

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -144,7 +144,7 @@ module TestIRB
       io.class::HISTORY << 'line1'
       io.class::HISTORY << 'line2'
 
-      history_file = IRB.rc_files("_history").first
+      history_file = IRB.rc_file("_history")
       assert_not_send [File, :file?, history_file]
       File.write(history_file, "line0\n")
       io.save_history
@@ -183,6 +183,16 @@ module TestIRB
       IRB.conf[:HISTORY_FILE] = backup_history_file
     end
 
+    def test_no_home_no_history_file_does_not_raise_history_save
+      ENV['HOME'] = nil
+      io = TestInputMethodWithRelineHistory.new
+      assert_nil(IRB.rc_file('_history'))
+      assert_nothing_raised do
+        io.load_history
+        io.save_history
+      end
+    end
+
     private
 
     def history_concurrent_use_for_input_method(input_method)
@@ -217,7 +227,7 @@ module TestIRB
     def assert_history(expected_history, initial_irb_history, input, input_method = TestInputMethodWithRelineHistory, locale: IRB::Locale.new)
       IRB.conf[:LC_MESSAGES] = locale
       actual_history = nil
-      history_file = IRB.rc_files("_history").first
+      history_file = IRB.rc_file("_history")
       ENV["HOME"] = @tmpdir
       File.open(history_file, "w") do |f|
         f.write(initial_irb_history)

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -39,22 +39,6 @@ module TestIRB
       assert_equal orig, $0
     end
 
-    def test_rc_file
-      tmpdir = @tmpdir
-      Dir.chdir(tmpdir) do
-        ENV["XDG_CONFIG_HOME"] = "#{tmpdir}/xdg"
-        reset_rc_name_generators
-        assert_empty(IRB.irbrc_files)
-        assert_equal("#{ENV["HOME"]}/.irb_history", IRB.rc_file("_history"))
-        assert_file.not_exist?(tmpdir+"/xdg")
-        reset_rc_name_generators
-        FileUtils.touch(tmpdir+"/.irbrc")
-        assert_equal(tmpdir+"/.irbrc", IRB.irbrc_files.first)
-        assert_equal(tmpdir+"/.irb_history", IRB.rc_file("_history"))
-        assert_file.not_exist?(tmpdir+"/xdg")
-      end
-    end
-
     def test_rc_files
       tmpdir = @tmpdir
       Dir.chdir(tmpdir) do
@@ -103,9 +87,7 @@ module TestIRB
     def test_duplicated_rc_files
       tmpdir = @tmpdir
       Dir.chdir(tmpdir) do
-        ENV['HOME'] = tmpdir
         ENV['XDG_CONFIG_HOME'] = "#{ENV['HOME']}/.config"
-        FileUtils.mkdir_p(ENV['HOME'])
         FileUtils.mkdir_p("#{ENV['XDG_CONFIG_HOME']}/irb")
         env_irbrc = ENV['IRBRC'] = "#{tmpdir}/_irbrc"
         xdg_config_irbrc = "#{ENV['XDG_CONFIG_HOME']}/irb/irbrc"

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -18,6 +18,7 @@ module TestIRB
       ENV.update(@backup_env)
       FileUtils.rm_rf(@tmpdir)
       IRB.conf.delete(:SCRIPT)
+      IRB.conf[:RC_NAME_GENERATOR] = nil
     end
 
     def test_setup_with_argv_preserves_global_argv
@@ -35,132 +36,82 @@ module TestIRB
     end
 
     def test_rc_file
-      verbose, $VERBOSE = $VERBOSE, nil
       tmpdir = @tmpdir
       Dir.chdir(tmpdir) do
         ENV["XDG_CONFIG_HOME"] = "#{tmpdir}/xdg"
         IRB.conf[:RC_NAME_GENERATOR] = nil
-        assert_equal(tmpdir+"/.irbrc", IRB.rc_file)
-        assert_equal(tmpdir+"/.irb_history", IRB.rc_file("_history"))
+        assert_empty(IRB.irbrc_files)
+        assert_equal("#{ENV["HOME"]}/.irb_history", IRB.rc_file("_history"))
         assert_file.not_exist?(tmpdir+"/xdg")
         IRB.conf[:RC_NAME_GENERATOR] = nil
         FileUtils.touch(tmpdir+"/.irbrc")
-        assert_equal(tmpdir+"/.irbrc", IRB.rc_file)
+        assert_equal(tmpdir+"/.irbrc", IRB.irbrc_files.first)
         assert_equal(tmpdir+"/.irb_history", IRB.rc_file("_history"))
         assert_file.not_exist?(tmpdir+"/xdg")
       end
-    ensure
-      $VERBOSE = verbose
-    end
-
-    def test_rc_file_in_subdir
-      verbose, $VERBOSE = $VERBOSE, nil
-      tmpdir = @tmpdir
-      Dir.chdir(tmpdir) do
-        FileUtils.mkdir_p("#{tmpdir}/mydir")
-        Dir.chdir("#{tmpdir}/mydir") do
-          IRB.conf[:RC_NAME_GENERATOR] = nil
-          assert_equal(tmpdir+"/.irbrc", IRB.rc_file)
-          assert_equal(tmpdir+"/.irb_history", IRB.rc_file("_history"))
-          IRB.conf[:RC_NAME_GENERATOR] = nil
-          FileUtils.touch(tmpdir+"/.irbrc")
-          assert_equal(tmpdir+"/.irbrc", IRB.rc_file)
-          assert_equal(tmpdir+"/.irb_history", IRB.rc_file("_history"))
-        end
-      end
-    ensure
-      $VERBOSE = verbose
     end
 
     def test_rc_files
       tmpdir = @tmpdir
       Dir.chdir(tmpdir) do
-        ENV["XDG_CONFIG_HOME"] = "#{tmpdir}/xdg"
+        home = ENV['HOME'] = "#{tmpdir}/home"
+        xdg_config_home = ENV['XDG_CONFIG_HOME'] = "#{tmpdir}/xdg"
         IRB.conf[:RC_NAME_GENERATOR] = nil
-        assert_includes IRB.rc_files, tmpdir+"/.irbrc"
-        assert_includes IRB.rc_files("_history"), tmpdir+"/.irb_history"
-        assert_file.not_exist?(tmpdir+"/xdg")
+        assert_empty(IRB.irbrc_files)
+        assert_equal("#{home}/.irb_history", IRB.rc_file('_history'))
+        FileUtils.mkdir_p(home)
+        FileUtils.mkdir_p("#{xdg_config_home}/irb")
+        FileUtils.mkdir_p("#{home}/.config/irb")
         IRB.conf[:RC_NAME_GENERATOR] = nil
-        FileUtils.touch(tmpdir+"/.irbrc")
-        assert_includes IRB.rc_files, tmpdir+"/.irbrc"
-        assert_includes IRB.rc_files("_history"), tmpdir+"/.irb_history"
-        assert_file.not_exist?(tmpdir+"/xdg")
-      end
-    end
-
-    def test_rc_files_in_subdir
-      tmpdir = @tmpdir
-      Dir.chdir(tmpdir) do
-        FileUtils.mkdir_p("#{tmpdir}/mydir")
-        Dir.chdir("#{tmpdir}/mydir") do
-          IRB.conf[:RC_NAME_GENERATOR] = nil
-          assert_includes IRB.rc_files, tmpdir+"/.irbrc"
-          assert_includes IRB.rc_files("_history"), tmpdir+"/.irb_history"
-          IRB.conf[:RC_NAME_GENERATOR] = nil
-          FileUtils.touch(tmpdir+"/.irbrc")
-          assert_includes IRB.rc_files, tmpdir+"/.irbrc"
-          assert_includes IRB.rc_files("_history"), tmpdir+"/.irb_history"
+        assert_empty(IRB.irbrc_files)
+        assert_equal("#{xdg_config_home}/irb/irb_history", IRB.rc_file('_history'))
+        home_irbrc = "#{home}/.irbrc"
+        config_irbrc = "#{home}/.config/irb/irbrc"
+        xdg_config_irbrc = "#{xdg_config_home}/irb/irbrc"
+        [home_irbrc, config_irbrc, xdg_config_irbrc].each do |file|
+          FileUtils.touch(file)
         end
+        current_dir_irbrcs = %w[.irbrc irbrc _irbrc $irbrc].map { |file| "#{tmpdir}/#{file}" }
+        current_dir_irbrcs.each { |file| FileUtils.touch(file) }
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        assert_equal([xdg_config_irbrc, home_irbrc, *current_dir_irbrcs], IRB.irbrc_files)
+        assert_equal(xdg_config_irbrc.sub(/rc$/, '_history'), IRB.rc_file('_history'))
+        ENV['XDG_CONFIG_HOME'] = nil
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        assert_equal([home_irbrc, config_irbrc, *current_dir_irbrcs], IRB.irbrc_files)
+        assert_equal(home_irbrc.sub(/rc$/, '_history'), IRB.rc_file('_history'))
+        ENV['XDG_CONFIG_HOME'] = ''
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        assert_equal([home_irbrc, config_irbrc] + current_dir_irbrcs, IRB.irbrc_files)
+        assert_equal(home_irbrc.sub(/rc$/, '_history'), IRB.rc_file('_history'))
+        ENV['XDG_CONFIG_HOME'] = xdg_config_home
+        ENV['IRBRC'] = "#{tmpdir}/.irbrc"
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        assert_equal([ENV['IRBRC'], xdg_config_irbrc, home_irbrc] + (current_dir_irbrcs - [ENV['IRBRC']]), IRB.irbrc_files)
+        assert_equal(ENV['IRBRC'] + '_history', IRB.rc_file('_history'))
+        ENV['IRBRC'] = ENV['HOME'] = ENV['XDG_CONFIG_HOME'] = nil
+        IRB.conf[:RC_NAME_GENERATOR] = nil
+        assert_equal(current_dir_irbrcs, IRB.irbrc_files)
+        assert_nil(IRB.rc_file('_history'))
       end
     end
 
-    def test_rc_files_has_file_from_xdg_env
+    def test_duplicated_rc_files
       tmpdir = @tmpdir
-      ENV["XDG_CONFIG_HOME"] = "#{tmpdir}/xdg"
-      xdg_config = ENV["XDG_CONFIG_HOME"]+"/irb/irbrc"
-
-      FileUtils.mkdir_p(xdg_config)
-
       Dir.chdir(tmpdir) do
+        ENV['HOME'] = tmpdir
+        ENV['XDG_CONFIG_HOME'] = "#{ENV['HOME']}/.config"
+        FileUtils.mkdir_p(ENV['HOME'])
+        FileUtils.mkdir_p("#{ENV['XDG_CONFIG_HOME']}/irb")
+        env_irbrc = ENV['IRBRC'] = "#{tmpdir}/_irbrc"
+        xdg_config_irbrc = "#{ENV['XDG_CONFIG_HOME']}/irb/irbrc"
+        home_irbrc = "#{ENV['HOME']}/.irbrc"
+        current_dir_irbrc = "#{tmpdir}/irbrc"
+        [env_irbrc, xdg_config_irbrc, home_irbrc, current_dir_irbrc].each do |file|
+          FileUtils.touch(file)
+        end
         IRB.conf[:RC_NAME_GENERATOR] = nil
-        assert_includes IRB.rc_files, xdg_config
-      end
-    ensure
-      ENV["XDG_CONFIG_HOME"] = nil
-    end
-
-    def test_rc_files_has_file_from_irbrc_env
-      tmpdir = @tmpdir
-      ENV["IRBRC"] = "#{tmpdir}/irb"
-
-      FileUtils.mkdir_p(ENV["IRBRC"])
-
-      Dir.chdir(tmpdir) do
-        IRB.conf[:RC_NAME_GENERATOR] = nil
-        assert_includes IRB.rc_files, ENV["IRBRC"]
-      end
-    ensure
-      ENV["IRBRC"] = nil
-    end
-
-    def test_rc_files_has_file_from_home_env
-      tmpdir = @tmpdir
-      ENV["HOME"] = "#{tmpdir}/home"
-
-      FileUtils.mkdir_p(ENV["HOME"])
-
-      Dir.chdir(tmpdir) do
-        IRB.conf[:RC_NAME_GENERATOR] = nil
-        assert_includes IRB.rc_files, ENV["HOME"]+"/.irbrc"
-        assert_includes IRB.rc_files, ENV["HOME"]+"/.config/irb/irbrc"
-      end
-    ensure
-      ENV["HOME"] = nil
-    end
-
-    def test_rc_files_contains_non_env_files
-      tmpdir = @tmpdir
-      FileUtils.mkdir_p("#{tmpdir}/.irbrc")
-      FileUtils.mkdir_p("#{tmpdir}/_irbrc")
-      FileUtils.mkdir_p("#{tmpdir}/irb.rc")
-      FileUtils.mkdir_p("#{tmpdir}/$irbrc")
-
-      Dir.chdir(tmpdir) do
-        IRB.conf[:RC_NAME_GENERATOR] = nil
-        assert_includes IRB.rc_files, tmpdir+"/.irbrc"
-        assert_includes IRB.rc_files, tmpdir+"/_irbrc"
-        assert_includes IRB.rc_files, tmpdir+"/irb.rc"
-        assert_includes IRB.rc_files, tmpdir+"/$irbrc"
+        assert_equal([env_irbrc, xdg_config_irbrc, home_irbrc, current_dir_irbrc], IRB.irbrc_files)
       end
     end
 

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -11,6 +11,8 @@ end
 class IRB::RenderingTest < Yamatanooroti::TestCase
   def setup
     @original_term = ENV['TERM']
+    @home_backup = ENV['HOME']
+    @xdg_config_home_backup = ENV['XDG_CONFIG_HOME']
     ENV['TERM'] = "xterm-256color"
     @pwd = Dir.pwd
     suffix = '%010d' % Random.rand(0..65535)
@@ -24,12 +26,16 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     @irbrc_backup = ENV['IRBRC']
     @irbrc_file = ENV['IRBRC'] = File.join(@tmpdir, 'temporaty_irbrc')
     File.unlink(@irbrc_file) if File.exist?(@irbrc_file)
+    ENV['HOME'] = File.join(@tmpdir, 'home')
+    ENV['XDG_CONFIG_HOME'] = File.join(@tmpdir, 'xdg_config_home')
   end
 
   def teardown
     FileUtils.rm_rf(@tmpdir)
     ENV['IRBRC'] = @irbrc_backup
     ENV['TERM'] = @original_term
+    ENV['HOME'] = @home_backup
+    ENV['XDG_CONFIG_HOME'] = @xdg_config_home_backup
   end
 
   def test_launch


### PR DESCRIPTION
Fixes #674 with refactoring

IRB.rc_files is used for irbrc searching and irb_history searching. I think two separate logic is combined into one and making the code complicated.

### Changes
- Split `IRB.rc_files(ext)` to `IRB.irb_files` and `IRB.rc_file(ext)`
- history will be saved to `dirname(ENV['IRBRC'])`, `ENV['XDG_CONFIG_HOME']` or `ENV['HOME']`
- `IRB.conf[:RC_NAME_GENERATOR]` is removed because it's impossible to configure before loading irbrc
- Fix irbrc loaded twice bug mentioned in https://github.com/ruby/irb/issues/674#issuecomment-1994482350