### PR TITLE
Explicitly show `--echo-on-assignment` is default on help

### DIFF
--- a/lib/irb/lc/help-message
+++ b/lib/irb/lc/help-message
@@ -15,7 +15,7 @@ Usage:  irb.rb [options] [programfile] [arguments]
   --echo            Show result (default).
   --noecho          Don't show result.
   --echo-on-assignment
-                    Show result on assignment.
+                    Show result on assignment (default).
   --noecho-on-assignment
                     Don't show result on assignment.
   --truncate-echo-on-assignment


### PR DESCRIPTION
Other options with `no` version (boolean flags) display with `(default)` but `--echo-on-assignment` doesn't have that.