### PR TITLE
Fix indent test and output sequence test for new reline

### DIFF
--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -70,11 +70,8 @@ module TestIRB
         type "exit"
       end
 
-      # Input cramped together due to how Reline's Reline::GeneralIO works
-      assert_include(
-        output,
-        "irb(main):001> irb(main):002> irb(main):002>  irb(main):002>   => nil\r\n"
-      )
+      assert_not_match(/irb\(main\):001> (\r*\n)?=> nil/, output)
+      assert_match(/irb\(main\):002>   (\r*\n)?=> nil/, output)
     end
   end
 

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -137,6 +137,7 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       a
        .a
        .b
+      .itself
     EOC
     close
     assert_screen(<<~EOC)
@@ -153,9 +154,10 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       irb(main):008>
       irb(main):009> a
       irb(main):010>  .a
-      irb(main):011> .b
+      irb(main):011>  .b
+      irb(main):012> .itself
       => true
-      irb(main):012>
+      irb(main):013>
     EOC
   end
 
@@ -181,7 +183,6 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       (a)
         &.b()
 
-
       class A def b; self; end; def c; true; end; end;
       a = A.new
       a
@@ -190,6 +191,7 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
         .c
       (a)
         &.b()
+      .itself
     EOC
     close
     assert_screen(<<~EOC)
@@ -214,17 +216,17 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       irb(main):015>   &.b()
       => #<A>
       irb(main):016>
-      irb(main):017>
-      irb(main):018> class A def b; self; end; def c; true; end; end;
-      irb(main):019> a = A.new
+      irb(main):017> class A def b; self; end; def c; true; end; end;
+      irb(main):018> a = A.new
       => #<A>
-      irb(main):020> a
-      irb(main):021>   .b
-      irb(main):022>   # aaa
-      irb(main):023>   .c
+      irb(main):019> a
+      irb(main):020>   .b
+      irb(main):021>   # aaa
+      irb(main):022>   .c
       => true
-      irb(main):024> (a)
-      irb(main):025> &.b()
+      irb(main):023> (a)
+      irb(main):024>   &.b()
+      irb(main):025> .itself
       => #<A>
       irb(main):026>
     EOC


### PR DESCRIPTION
CI is failing after https://github.com/ruby/reline/pull/614 is merged.


### Indent is changed/fixed
For example, pasting `"a\n .b\n  .c"`:
```
Reline 0.4.2
> a
>   .b
> .c█

Reline 0.5.0.pre.1
> a
>   .b
>   .c█
```
This pull request changes the test to pass with both version by using `"a\n  .b\n  .c\n.d"`.

