### PR TITLE
Cache RDoc::RI::Driver.new

### DIFF
--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -88,17 +88,18 @@ module TestIRB
       @driver = RDoc::RI::Driver.new(use_stdout: true)
     end
 
-    def display_document(target, bind)
+    def display_document(target, bind, driver = nil)
       input_method = IRB::RelineInputMethod.new(IRB::RegexpCompletor.new)
+      input_method.instance_variable_set(:@rdoc_ri_driver, driver) if driver
       input_method.instance_variable_set(:@completion_params, ['', target, '', bind])
-      input_method.display_document(target, driver: @driver)
+      input_method.display_document(target)
     end
 
     def test_perfectly_matched_namespace_triggers_document_display
       omit unless has_rdoc_content?
 
       out, err = capture_output do
-        display_document("String", binding)
+        display_document("String", binding, @driver)
       end
 
       assert_empty(err)
@@ -109,7 +110,7 @@ module TestIRB
     def test_perfectly_matched_multiple_namespaces_triggers_document_display
       result = nil
       out, err = capture_output do
-        result = display_document("{}.nil?", binding)
+        result = display_document("{}.nil?", binding, @driver)
       end
 
       assert_empty(err)
@@ -131,7 +132,7 @@ module TestIRB
     def test_not_matched_namespace_triggers_nothing
       result = nil
       out, err = capture_output do
-        result = display_document("Stri", binding)
+        result = display_document("Stri", binding, @driver)
       end
 
       assert_empty(err)
@@ -156,7 +157,7 @@ module TestIRB
     def test_perfect_matching_handles_nil_namespace
       out, err = capture_output do
         # symbol literal has `nil` doc namespace so it's a good test subject
-        assert_nil(display_document(":aiueo", binding))
+        assert_nil(display_document(":aiueo", binding, @driver))
       end
 
       assert_empty(err)

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -256,9 +256,9 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     start_terminal(3, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
     write("{}.__id_")
     write("\C-i")
+    sleep 0.2
     close
     screen = result.join("\n").sub(/\n*\z/, "\n")
-    # This assertion passes whether showdoc dialog completed or not.
     assert_match(/start\ IRB\nirb\(main\):001> {}\.__id__\n                }\.__id__(?:Press )?/, screen)
   end
 
@@ -278,6 +278,7 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     start_terminal(4, 19, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
     write("IR")
     write("\C-i")
+    sleep 0.2
     close
 
     # This is because on macOS we display different shortcut for displaying the full doc
@@ -315,6 +316,7 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     start_terminal(4, 12, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
     write("IR")
     write("\C-i")
+    sleep 0.2
     close
     assert_screen(<<~EOC)
       start IRB


### PR DESCRIPTION
This will improve performance and fixes flaky test.

The first call of RDoc::RI::Driver.new takes time, and after second call, it does not take so much time.
```
RDoc::RI::Driver.new #=> 0.131312s first call
RDoc::RI::Driver.new #=> 0.022779s second call
```
However, the time is not super fast. Depend on environment. (0.15sec in docker, different platform).
This will cause usability problem and test failure.

### sleep 0.2
Caching should improve the problem, but test still failed, so I added sleep.
Failed runs
https://github.com/tompng/irb/actions/runs/8418696431/job/23049722164
https://github.com/tompng/irb/actions/runs/8418949008/job/23050530042

### Background of test failure
Test with reline latest is failing recently. These are the reasons
- RDoc::RI::Driver.new get slower in latest rdoc (Marshal.load with filter, perhaps CVE fix)
- Reline's rendering output changed. This change made test_yamatanooroti reduce `sleep 0.1` call. Less sleep for time-consuming test will make test more likely to fail.