### PR TITLE
Support `IRB.conf[:BACKTRACE_FILTER]`

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -196,7 +196,7 @@ module TestIRB
     end
 
     def write_ruby(program)
-      @ruby_file = Tempfile.create(%w{irb- .rb})
+      @ruby_file = Tempfile.create(%w{irbtest- .rb})
       @tmpfiles << @ruby_file
       @ruby_file.write(program)
       @ruby_file.close

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -823,4 +823,95 @@ module TestIRB
       IRB::Irb.new(workspace, TestInputMethod.new)
     end
   end
+
+  class BacktraceFilteringTest < TestIRB::IntegrationTestCase
+    def test_backtrace_filtering
+      write_ruby <<~'RUBY'
+        def foo
+          raise "error"
+        end
+
+        def bar
+          foo
+        end
+
+        binding.irb
+      RUBY
+
+      output = run_ruby_file do
+        type "bar"
+        type "exit"
+      end
+
+      assert_match(/irbtest-.*\.rb:2:in (`|'Object#)foo': error \(RuntimeError\)/, output)
+      frame_traces = output.split("\n").select { |line| line.strip.match?(/from /) }.map(&:strip)
+
+      expected_traces = if RUBY_VERSION >= "3.3.0"
+        [
+          /from .*\/irbtest-.*.rb:6:in (`|'Object#)bar'/,
+          /from .*\/irbtest-.*.rb\(irb\):1:in [`']<main>'/,
+          /from <internal:kernel>:\d+:in (`|'Kernel#)loop'/,
+          /from <internal:prelude>:\d+:in (`|'Binding#)irb'/,
+          /from .*\/irbtest-.*.rb:9:in [`']<main>'/
+        ]
+      else
+        [
+          /from .*\/irbtest-.*.rb:6:in (`|'Object#)bar'/,
+          /from .*\/irbtest-.*.rb\(irb\):1:in [`']<main>'/,
+          /from <internal:prelude>:\d+:in (`|'Binding#)irb'/,
+          /from .*\/irbtest-.*.rb:9:in [`']<main>'/
+        ]
+      end
+
+      expected_traces.reverse! if RUBY_VERSION < "3.0.0"
+
+      expected_traces.each_with_index do |expected_trace, index|
+        assert_match(expected_trace, frame_traces[index])
+      end
+    end
+
+    def test_backtrace_filtering_with_backtrace_filter
+      write_rc <<~'RUBY'
+        class TestBacktraceFilter
+          def self.call(backtrace)
+            backtrace.reject { |line| line.include?("internal") }
+          end
+        end
+
+        IRB.conf[:BACKTRACE_FILTER] = TestBacktraceFilter
+      RUBY
+
+      write_ruby <<~'RUBY'
+        def foo
+          raise "error"
+        end
+
+        def bar
+          foo
+        end
+
+        binding.irb
+      RUBY
+
+      output = run_ruby_file do
+        type "bar"
+        type "exit"
+      end
+
+      assert_match(/irbtest-.*\.rb:2:in (`|'Object#)foo': error \(RuntimeError\)/, output)
+      frame_traces = output.split("\n").select { |line| line.strip.match?(/from /) }.map(&:strip)
+
+      expected_traces = [
+        /from .*\/irbtest-.*.rb:6:in (`|'Object#)bar'/,
+        /from .*\/irbtest-.*.rb\(irb\):1:in [`']<main>'/,
+        /from .*\/irbtest-.*.rb:9:in [`']<main>'/
+      ]
+
+      expected_traces.reverse! if RUBY_VERSION < "3.0.0"
+
+      expected_traces.each_with_index do |expected_trace, index|
+        assert_match(expected_trace, frame_traces[index])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This config allows users to customize the backtrace of exceptions raised and displayed in IRB sessions. This is useful for filtering out library frames from the backtrace.

IRB expects the given value to response to `filter` method and return the filtered backtrace.

Closes #914 

### Notes

- Ideally backtrace filters should be chainable, like Rack middlewares, to allow multiple sources to inject their own filters. However, I haven't seen much use cases for backtrace filtering outside of [Rails'](https://github.com/rails/rails/blob/bad7ff1664fb05cc227d0386ee3cbe4c292efe05/railties/lib/rails/commands/console/console_command.rb), so I'm not sure if that'll actually be necessary.
- To make IRB compatible with older Rails versions, we need to keep `WorkSpace#filter_backtrace`'s behaviour the same at least for a few years.