### PR TITLE
Remove internal-only methods from Command::Base

### DIFF
--- a/lib/irb/command/base.rb
+++ b/lib/irb/command/base.rb
@@ -50,25 +50,6 @@ module IRB
 
       attr_reader :irb_context
 
-      def unwrap_string_literal(str)
-        return if str.empty?
-
-        sexp = Ripper.sexp(str)
-        if sexp && sexp.size == 2 && sexp.last&.first&.first == :string_literal
-          @irb_context.workspace.binding.eval(str).to_s
-        else
-          str
-        end
-      end
-
-      def ruby_args(arg)
-        # Use throw and catch to handle arg that includes `;`
-        # For example: "1, kw: (2; 3); 4" will be parsed to [[1], { kw: 3 }]
-        catch(:EXTRACT_RUBY_ARGS) do
-          @irb_context.workspace.binding.eval "IRB::Command.extract_ruby_args #{arg}"
-        end || [[], {}]
-      end
-
       def execute(arg)
         #nop
       end

--- a/lib/irb/command/edit.rb
+++ b/lib/irb/command/edit.rb
@@ -8,6 +8,8 @@ module IRB
 
   module Command
     class Edit < Base
+      include IRB::Command::RubyArgsExtractor
+
       category "Misc"
       description 'Open a file or source location.'
       help_message <<~HELP_MESSAGE

--- a/lib/irb/command/edit.rb
+++ b/lib/irb/command/edit.rb
@@ -8,7 +8,7 @@ module IRB
 
   module Command
     class Edit < Base
-      include IRB::Command::RubyArgsExtractor
+      include RubyArgsExtractor
 
       category "Misc"
       description 'Open a file or source location.'

--- a/lib/irb/command/internal_helpers.rb
+++ b/lib/irb/command/internal_helpers.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module IRB
+  module Command
+    # Internal use only, for default command's backward compatibility.
+    module RubyArgsExtractor # :nodoc:
+      def unwrap_string_literal(str)
+        return if str.empty?
+
+        sexp = Ripper.sexp(str)
+        if sexp && sexp.size == 2 && sexp.last&.first&.first == :string_literal
+          @irb_context.workspace.binding.eval(str).to_s
+        else
+          str
+        end
+      end
+
+      def ruby_args(arg)
+        # Use throw and catch to handle arg that includes `;`
+        # For example: "1, kw: (2; 3); 4" will be parsed to [[1], { kw: 3 }]
+        catch(:EXTRACT_RUBY_ARGS) do
+          @irb_context.workspace.binding.eval "IRB::Command.extract_ruby_args #{arg}"
+        end || [[], {}]
+      end
+    end
+  end
+end

--- a/lib/irb/command/load.rb
+++ b/lib/irb/command/load.rb
@@ -10,6 +10,7 @@ module IRB
 
   module Command
     class LoaderCommand < Base
+      include RubyArgsExtractor
       include IrbLoader
 
       def raise_cmd_argument_error

--- a/lib/irb/command/ls.rb
+++ b/lib/irb/command/ls.rb
@@ -11,6 +11,8 @@ module IRB
 
   module Command
     class Ls < Base
+      include RubyArgsExtractor
+
       category "Context"
       description "Show methods, constants, and variables."
 

--- a/lib/irb/command/measure.rb
+++ b/lib/irb/command/measure.rb
@@ -3,6 +3,8 @@ module IRB
 
   module Command
     class Measure < Base
+      include RubyArgsExtractor
+
       category "Misc"
       description "`measure` enables the mode to measure processing time. `measure :off` disables it."
 

--- a/lib/irb/command/show_doc.rb
+++ b/lib/irb/command/show_doc.rb
@@ -3,6 +3,8 @@
 module IRB
   module Command
     class ShowDoc < Base
+      include RubyArgsExtractor
+
       category "Context"
       description "Look up documentation with RI."
 

--- a/lib/irb/command/show_source.rb
+++ b/lib/irb/command/show_source.rb
@@ -7,6 +7,8 @@ require_relative "../color"
 module IRB
   module Command
     class ShowSource < Base
+      include RubyArgsExtractor
+
       category "Context"
       description "Show the source code of a given method, class/module, or constant."
 

--- a/lib/irb/command/subirb.rb
+++ b/lib/irb/command/subirb.rb
@@ -9,6 +9,8 @@ module IRB
 
   module Command
     class MultiIRBCommand < Base
+      include RubyArgsExtractor
+
       private
 
       def print_deprecated_warning

--- a/lib/irb/default_commands.rb
+++ b/lib/irb/default_commands.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "command"
+require_relative "command/internal_helpers"
 require_relative "command/context"
 require_relative "command/exit"
 require_relative "command/force_exit"


### PR DESCRIPTION
I think we should hide `Command#ruby_args` and `Command#unwrap_string_literal` from custom command definition, (at least for now).

We can reduce the use of these methods. Most of the case these methods are used for backward compatibility in default commands. Hiding it, we can remove these methods in any time.
