### PR TITLE
Remove exit command workaround, handle IRB_EXIT in debug_readline

### DIFF
--- a/lib/irb/command/exit.rb
+++ b/lib/irb/command/exit.rb
@@ -8,10 +8,8 @@ module IRB
       category "IRB"
       description "Exit the current irb session."
 
-      def execute(*)
+      def execute(_arg)
         IRB.irb_exit
-      rescue UncaughtThrowError
-        Kernel.exit
       end
     end
   end

--- a/lib/irb/command/force_exit.rb
+++ b/lib/irb/command/force_exit.rb
@@ -8,10 +8,8 @@ module IRB
       category "IRB"
       description "Exit the current process."
 
-      def execute(*)
+      def execute(_arg)
         throw :IRB_EXIT, true
-      rescue UncaughtThrowError
-        Kernel.exit!
       end
     end
   end

--- a/test/irb/command/test_force_exit.rb
+++ b/test/irb/command/test_force_exit.rb
@@ -47,17 +47,5 @@ module TestIRB
 
       assert_match(/irb\(main\):001> 123/, output)
     end
-
-    def test_forced_exit_out_of_irb_session
-      write_ruby <<~'ruby'
-        at_exit { puts 'un' + 'reachable' }
-        binding.irb
-        exit! # this will call exit! method overrided by command
-      ruby
-      output = run_ruby_file do
-        type "exit"
-      end
-      assert_not_include(output, 'unreachable')
-    end
   end
 end

--- a/test/irb/test_debugger_integration.rb
+++ b/test/irb/test_debugger_integration.rb
@@ -244,28 +244,46 @@ module TestIRB
     def test_exit
       write_ruby <<~'RUBY'
         binding.irb
-        puts "hello"
+        puts "he" + "llo"
       RUBY
 
       output = run_ruby_file do
-        type "next"
+        type "debug"
         type "exit"
       end
 
-      assert_match(/irb\(main\):001> next/, output)
+      assert_match(/irb:rdbg\(main\):002>/, output)
+      assert_match(/hello/, output)
+    end
+
+    def test_force_exit
+      write_ruby <<~'RUBY'
+        binding.irb
+        puts "he" + "llo"
+      RUBY
+
+      output = run_ruby_file do
+        type "debug"
+        type "exit!"
+      end
+
+      assert_match(/irb:rdbg\(main\):002>/, output)
+      assert_not_match(/hello/, output)
     end
 
     def test_quit
       write_ruby <<~'RUBY'
         binding.irb
+        puts "he" + "llo"
       RUBY
 
       output = run_ruby_file do
-        type "next"
+        type "debug"
         type "quit!"
       end
 
-      assert_match(/irb\(main\):001> next/, output)
+      assert_match(/irb:rdbg\(main\):002>/, output)
+      assert_not_match(/hello/, output)
     end
 
     def test_prompt_line_number_continues


### PR DESCRIPTION
## Removing workaround
Command was a method.
```ruby
binding.irb # self.exit was overridden
exit # this was executing exit command. Need workaround to avoid `uncaught throw :IRB_EXIT` error
```
Now, it's not a method. Workaround for `exit` and `exit!` is not needed anymore.

## Debug and exit
`catch(:IRB_EXIT)` was missing in handling debug command. It was working because the workaround was luckily triggered.
Added catch because the workaround is removed.

## Behavior change
With this ruby file
```ruby
binding.irb
puts 'hello'
binding.irb
```
In this pull request, `debug` `exit` prints 'hello' and moves to the next breakpoint, (just like CTRL-d input).
Before this change, it was exiting process without printing 'hello'.
