### PR TITLE
Accept "  " for colorizing "\t" test

### DIFF
--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -99,7 +99,7 @@ module TestIRB
         "foo %i[bar]" => "foo #{YELLOW}%i[#{CLEAR}#{YELLOW}bar#{CLEAR}#{YELLOW}]#{CLEAR}",
         "foo :@bar, baz, :@@qux, :$quux" => "foo #{YELLOW}:#{CLEAR}#{YELLOW}@bar#{CLEAR}, baz, #{YELLOW}:#{CLEAR}#{YELLOW}@@qux#{CLEAR}, #{YELLOW}:#{CLEAR}#{YELLOW}$quux#{CLEAR}",
         "`echo`" => "#{RED}#{BOLD}`#{CLEAR}#{RED}echo#{CLEAR}#{RED}#{BOLD}`#{CLEAR}",
-        "\t" => "\t", # not ^I
+        "\t" => Reline::Unicode.escape_for_print("\t") == '  ' ? '  ' : "\t", # not ^I
         "foo(*%W(bar))" => "foo(*#{RED}#{BOLD}%W(#{CLEAR}#{RED}bar#{CLEAR}#{RED}#{BOLD})#{CLEAR})",
         "$stdout" => "#{GREEN}#{BOLD}$stdout#{CLEAR}",
         "__END__" => "#{GREEN}__END__#{CLEAR}",


### PR DESCRIPTION
Need for https://github.com/ruby/reline/pull/655

After Reline implements bracketed paste, text containing `"\t"` can be inserted to IRB.
Reline can't render `"\t"` because the rendered width of `"\t"` is unknown and flexible, (and I think Reline only supports width within 0..2 now).
There are two options.
- `"\t"` can be inserted into IRB, and colorized as two spaces. `irb> p '	'.bytes` will print `[9]`
- `"\t"` will be converted to two spaces when pasted. `irb> p '	'.bytes` will print `[32, 32]`

https://github.com/ruby/reline/pull/655 is doing the former one, need to fix IRB's tab colorizing test.