### PR TITLE
Prompt specifiers: documentation improvements

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -656,8 +656,10 @@ require_relative "irb/pager"
 # *   `%m`: the value of `self.to_s`.
 # *   `%M`: the value of `self.inspect`.
 # *   `%l`: an indication of the type of string; one of `"`, `'`, `/`, `]`.
-# *   `*NN*i`: Indentation level.
-# *   `*NN*n`: Line number.
+# *   `%NNi`: Indentation level. NN is a 2-digit number that specifies the number
+#             of digits of the indentation level (03 will result in 001).
+# *   `%NNn`: Line number. NN is a 2-digit number that specifies the number
+#             of digits of the line number (03 will result in 001).
 # *   `%%`: Literal `%`.
 #
 #


### PR DESCRIPTION
While reading the docs for specifying your own custom prompt, I noticed a few issues.

First, the placeholder for specifying the indentation level and the line number are wrong. `*NN*i` does not work, nor `*NN*n` (replacing NN with digits of course). The right placeholders are actually `%NNi` and `%NNn`.

Additionally, it took me a lot of time to understand that NN meant that I had to use digits and not actual NN in the placeholder 🤣. I have added a brief line for both the placeholders that actually states that you should use digits and not the raw NN.

PR's open for discussion 😃.