### PR TITLE
Fix % escape in prompt format

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1457,7 +1457,7 @@ module IRB
     end
 
     def format_prompt(format, ltype, indent, line_no) # :nodoc:
-      format.gsub(/%([0-9]+)?([a-zA-Z])/) do
+      format.gsub(/%([0-9]+)?([a-zA-Z%])/) do
         case $2
         when "N"
           @context.irb_name
@@ -1490,7 +1490,7 @@ module IRB
             line_no.to_s
           end
         when "%"
-          "%"
+          "%" unless $1
         end
       end
     end

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -662,6 +662,14 @@ module TestIRB
       assert_equal("irb(!ArgumentError)>", irb.send(:format_prompt, 'irb(%M)>', nil, 1, 1))
     end
 
+    def test_prompt_format
+      main = 'main'
+      irb = IRB::Irb.new(IRB::WorkSpace.new(main), TestInputMethod.new)
+      assert_equal('%% main %m %main %%m >', irb.send(:format_prompt, '%%%% %m %%m %%%m %%%%m %l', '>', 1, 1))
+      assert_equal('42,%i, 42,%3i,042,%03i', irb.send(:format_prompt, '%i,%%i,%3i,%%3i,%03i,%%03i', nil, 42, 1))
+      assert_equal('42,%n, 42,%3n,042,%03n', irb.send(:format_prompt, '%n,%%n,%3n,%%3n,%03n,%%03n', nil, 1, 42))
+    end
+
     def test_lineno
       input = TestInputMethod.new([
         "\n",


### PR DESCRIPTION
Escaping % in prompt fromatting was not correctly implemented.

```ruby
# Wrong formatting
IRB::Irb.new.send(:format_prompt, '%% %02i', nil, 1, 1)
=> "%% 01" # should be "% 01"

# Reference
format '%% %02d', 1
=> "% 01"
```
This pull request fixes it.