### PR TITLE
Memoize helper method instances with Singleton module

### DIFF
--- a/lib/irb/helper_method/base.rb
+++ b/lib/irb/helper_method/base.rb
@@ -1,6 +1,10 @@
+require "singleton"
+
 module IRB
   module HelperMethod
     class Base
+      include Singleton
+
       class << self
         def description(description = nil)
           @description = description if description

--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -179,7 +179,7 @@ EOF
     def self.install_helper_methods
       HelperMethod.helper_methods.each do |name, helper_method_class|
         define_method name do |*args, **opts, &block|
-          helper_method_class.new.execute(*args, **opts, &block)
+          helper_method_class.instance.execute(*args, **opts, &block)
         end unless method_defined?(name)
       end
     end


### PR DESCRIPTION
Some helpers, like Rails console's [`app`](https://github.com/rails/rails/blob/main/railties/lib/rails/console/app.rb#L10-L13), requires memoization of the helper's ivars. To support it IRB needs to memoize helper method instances as well.