### PR TITLE
Suppress command return values

### DIFF
--- a/lib/irb/command/chws.rb
+++ b/lib/irb/command/chws.rb
@@ -15,7 +15,7 @@ module IRB
       description "Show the current workspace."
 
       def execute(_arg)
-        irb_context.main
+        puts "Current workspace: #{irb_context.main}"
       end
     end
 
@@ -30,7 +30,8 @@ module IRB
           obj = eval(arg, irb_context.workspace.binding)
           irb_context.change_workspace(obj)
         end
-        irb_context.main
+
+        puts "Current workspace: #{irb_context.main}"
       end
     end
   end

--- a/lib/irb/command/subirb.rb
+++ b/lib/irb/command/subirb.rb
@@ -49,6 +49,7 @@ module IRB
 
         extend_irb_context
         IRB.irb(nil, *obj)
+        puts IRB.JobManager.inspect
       end
     end
 
@@ -65,7 +66,7 @@ module IRB
         end
 
         extend_irb_context
-        IRB.JobManager
+        puts IRB.JobManager.inspect
       end
     end
 
@@ -90,6 +91,7 @@ module IRB
 
         raise CommandArgumentError.new("Please specify the id of target IRB job (listed in the `jobs` command).") unless key
         IRB.JobManager.switch(key)
+        puts IRB.JobManager.inspect
       end
     end
 
@@ -112,6 +114,7 @@ module IRB
 
         extend_irb_context
         IRB.JobManager.kill(*keys)
+        puts IRB.JobManager.inspect
       end
     end
   end

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -587,18 +587,19 @@ module IRB
 
     def evaluate(statement, line_no) # :nodoc:
       @line_no = line_no
-      result = nil
 
       case statement
       when Statement::EmptyInput
         return
       when Statement::Expression
         result = evaluate_expression(statement.code, line_no)
+        set_last_value(result)
       when Statement::Command
-        result = statement.command_class.execute(self, statement.arg)
+        statement.command_class.execute(self, statement.arg)
+        set_last_value(nil)
       end
 
-      set_last_value(result)
+      nil
     end
 
     def evaluate_expression(code, line_no) # :nodoc:

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -485,12 +485,11 @@ module TestIRB
   class CwwsTest < WorkspaceCommandTestCase
     def test_cwws_returns_the_current_workspace_object
       out, err = execute_lines(
-        "cwws",
-        "self.class"
+        "cwws"
       )
 
       assert_empty err
-      assert_include(out, self.class.name)
+      assert_include(out, "Current workspace: #{self}")
     end
   end
 
@@ -556,7 +555,7 @@ module TestIRB
         "pushws Foo.new\n",
         "popws\n",
         "cwws\n",
-        "_.class",
+        "self.class",
       )
       assert_empty err
       assert_include(out, "=> #{self.class}")
@@ -576,20 +575,19 @@ module TestIRB
       out, err = execute_lines(
         "chws #{self.class}::Foo.new\n",
         "cwws\n",
-        "_.class",
+        "self.class\n"
       )
       assert_empty err
+      assert_include(out, "Current workspace: #<#{self.class.name}::Foo")
       assert_include(out, "=> #{self.class}::Foo")
     end
 
     def test_chws_does_nothing_when_receiving_no_argument
       out, err = execute_lines(
         "chws\n",
-        "cwws\n",
-        "_.class",
       )
       assert_empty err
-      assert_include(out, "=> #{self.class}")
+      assert_include(out, "Current workspace: #{self}")
     end
   end
 


### PR DESCRIPTION
Since commands can't be chained with methods, their return values are not intended to be used. But if IRB keeps storing command return values as the last value, and print them, users may rely on such implicit behaviour.

So to avoid such confusion, this commit suppresses command's return values. It also updates some commands that currently rely on this implicit behaviour.