### PR TITLE
Restore IRB.CurrentContext when binding.irb is nested

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -898,7 +898,7 @@ module IRB
     else
       irb = Irb.new
     end
-    irb.run(@CONF)
+    irb.run
   end
 
   # Quits irb
@@ -989,10 +989,10 @@ module IRB
       input
     end
 
-    def run(conf = IRB.conf)
+    def run
+      conf = IRB.conf
       in_nested_session = !!conf[:MAIN_CONTEXT]
       conf[:IRB_RC].call(context) if conf[:IRB_RC]
-      conf[:MAIN_CONTEXT] = context
 
       save_history = !in_nested_session && conf[:SAVE_HISTORY] && context.io.support_history_saving?
 
@@ -1025,6 +1025,8 @@ module IRB
 
     # Evaluates input for this session.
     def eval_input
+      prev_context = IRB.conf[:MAIN_CONTEXT]
+      IRB.conf[:MAIN_CONTEXT] = @context
       configure_io
 
       each_top_level_statement do |statement, line_no|
@@ -1055,6 +1057,8 @@ module IRB
           end
         end
       end
+    ensure
+      IRB.conf[:MAIN_CONTEXT] = prev_context
     end
 
     def read_input(prompt)
@@ -1585,7 +1589,7 @@ class Binding
       # workspace
       binding_irb = IRB::Irb.new(workspace)
       binding_irb.context.irb_path = irb_path
-      binding_irb.run(IRB.conf)
+      binding_irb.run
       binding_irb.debug_break
     end
   end

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1109,6 +1109,7 @@ module IRB
 
     def each_top_level_statement
       loop do
+        IRB.conf[:MAIN_CONTEXT] = @context
         code = readmultiline
         break unless code
         yield build_statement(code), @line_no

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -125,6 +125,26 @@ module TestIRB
     end
   end
 
+  class NestedBindingIrbTest < IntegrationTestCase
+    def test_current_context_restore
+      write_ruby <<~'RUBY'
+        binding.irb
+      RUBY
+
+      output = run_ruby_file do
+        type '$ctx = IRB.CurrentContext'
+        type 'binding.irb'
+        type 'p context_changed: IRB.CurrentContext != $ctx'
+        type 'exit'
+        type 'p context_restored: IRB.CurrentContext == $ctx'
+        type 'exit'
+      end
+
+      assert_include output, '{:context_changed=>true}'
+      assert_include output, '{:context_restored=>true}'
+    end
+  end
+
   class IrbIOConfigurationTest < TestCase
     Row = Struct.new(:content, :current_line_spaces, :new_line_spaces, :indent_level)
 


### PR DESCRIPTION
Fix #650

```
$ irb
irb(main):001> 123.instance_eval{binding.irb}
irb(123):001> exit
=> nil
irb(main):002> IRB.CurrentContext.main
=> 123 # Should be `main`. `IRB.CurrentContext` is not restored
```

# Changes
Moved preparation of `conf[:MAIN_CONTEXT]` to `eval_input`.
Every `eval_input` was working before because we forgot to restore MAIN_CONTEXT, so MAIN_CONTEXT was always present.

Delete `conf` parameter from `def run` which is always identical to `IRB.conf`, so we don't have to pass that param to `eval_input`.
