### PR TITLE
Let IRB::Color.colorable? always return true|false

### DIFF
--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -79,12 +79,12 @@ module IRB # :nodoc:
 
     class << self
       def colorable?
-        supported = $stdout.tty? && (/mswin|mingw/ =~ RUBY_PLATFORM || (ENV.key?('TERM') && ENV['TERM'] != 'dumb'))
+        supported = $stdout.tty? && (/mswin|mingw/.match?(RUBY_PLATFORM) || (ENV.key?('TERM') && ENV['TERM'] != 'dumb'))
 
         # because ruby/debug also uses irb's color module selectively,
         # irb won't be activated in that case.
         if IRB.respond_to?(:conf)
-          supported && IRB.conf.fetch(:USE_COLORIZE, true)
+          supported && !!IRB.conf.fetch(:USE_COLORIZE, true)
         else
           supported
         end


### PR DESCRIPTION
`IRB::Color.colorable?` is used in `exc.full_message(order:, highlight: HERE)` and `hightlight` requires boolean or nil value.

When it is used for full_message, `IRB::Color.colorable?` always returns boolean value, but looking at the code, it was not obvious. It looks like there is a chance to return an integer value.