### PR TITLE
Revert "Switch to StdioInputMethod when TERM is 'dumb' (#907)"

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -311,9 +311,7 @@ require_relative "irb/pager"
 # ### Input Method
 #
 # The IRB input method determines how command input is to be read; by default,
-# the input method for a session is IRB::RelineInputMethod. Unless the
-# value of the TERM environment variable is 'dumb', in which case the
-# most simplistic input method is used.
+# the input method for a session is IRB::RelineInputMethod.
 #
 # You can set the input method by:
 #
@@ -331,8 +329,7 @@ require_relative "irb/pager"
 #         IRB::ReadlineInputMethod.
 #     *   `--nosingleline` or `--multiline` sets the input method to
 #         IRB::RelineInputMethod.
-#     *   `--nosingleline` together with `--nomultiline` sets the
-#         input to IRB::StdioInputMethod.
+#
 #
 #
 # Method `conf.use_multiline?` and its synonym `conf.use_reline` return:

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -85,7 +85,7 @@ module IRB
         @io = nil
         case use_multiline?
         when nil
-          if term_interactive? && IRB.conf[:PROMPT_MODE] != :INF_RUBY && !use_singleline?
+          if STDIN.tty? && IRB.conf[:PROMPT_MODE] != :INF_RUBY && !use_singleline?
             # Both of multiline mode and singleline mode aren't specified.
             @io = RelineInputMethod.new(build_completor)
           else
@@ -99,7 +99,7 @@ module IRB
         unless @io
           case use_singleline?
           when nil
-            if (defined?(ReadlineInputMethod) && term_interactive? &&
+            if (defined?(ReadlineInputMethod) && STDIN.tty? &&
                 IRB.conf[:PROMPT_MODE] != :INF_RUBY)
               @io = ReadlineInputMethod.new
             else
@@ -149,11 +149,6 @@ module IRB
 
       @user_aliases = IRB.conf[:COMMAND_ALIASES].dup
       @command_aliases = @user_aliases.merge(KEYWORD_ALIASES)
-    end
-
-    private def term_interactive?
-      return true if ENV['TEST_IRB_FORCE_INTERACTIVE']
-      STDIN.tty? && ENV['TERM'] != 'dumb'
     end
 
     # because all input will eventually be evaluated as Ruby code,

--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -121,9 +121,7 @@ module TestIRB
       @envs["XDG_CONFIG_HOME"] ||= tmp_dir
       @envs["IRBRC"] = nil unless @envs.key?("IRBRC")
 
-      envs_for_spawn = @envs.merge('TERM' => 'dumb', 'TEST_IRB_FORCE_INTERACTIVE' => 'true')
-
-      PTY.spawn(envs_for_spawn, *cmd) do |read, write, pid|
+      PTY.spawn(@envs.merge("TERM" => "dumb"), *cmd) do |read, write, pid|
         Timeout.timeout(TIMEOUT_SEC) do
           while line = safe_gets(read)
             lines << line


### PR DESCRIPTION
Reverts #907 to avoid ruby/ruby CI failure and Debug compatibility test failure
