### PR TITLE
Add workaround for ruby/debug/test/console/irb_test failing with StdioInputMethod

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -67,6 +67,7 @@ module IRB
     #
     # See IO#gets for more information.
     def gets
+      puts
       print @prompt
       line = @stdin.gets
       @line[@line_no += 1] = line


### PR DESCRIPTION
Debug compatibility test is failing now.
Adding this `puts` makes ruby/debug's irb_test pass.

![puts_inserts_newline.png](https://github.com/ruby/irb/assets/1780201/c39e88ee-81e4-4d1d-9fa0-eec2396b5aa5)
input:
```
M-x shell[ENTER]
irb[ENTER]
123456[ENTER]
puts 'hello'[ENTER]
```


I'll investigate why test was failing before. After fixing something, we may be able to remove this `puts`.