### PR TITLE
Avoid raising errors while running help for custom commands

### DIFF
--- a/lib/irb/command/help.rb
+++ b/lib/irb/command/help.rb
@@ -12,7 +12,7 @@ module IRB
             help_message
           else
             if command_class = Command.load_command(command_name)
-              command_class.help_message || command_class.description
+              command_class.help_message || command_class.description || ""
             else
               "Can't find command `#{command_name}`. Please check the command name and try again.\n\n"
             end

--- a/test/irb/command/test_custom_command.rb
+++ b/test/irb/command/test_custom_command.rb
@@ -123,5 +123,32 @@ module TestIRB
       assert_include(output, "2 FooBar executed")
       assert_include(output, "foobar_description")
     end
+
+    def test_no_meta_command_also_works
+      write_ruby <<~RUBY
+        require "irb"
+        require "irb/command"
+
+        class NoMetaCommand < IRB::Command::Base
+          def execute(*)
+            puts "This command does not override meta attributes"
+            nil
+          end
+        end
+
+        IRB::Command.register(:no_meta, NoMetaCommand)
+
+        binding.irb
+      RUBY
+
+      output = run_ruby_file do
+        type "no_meta\n"
+        type "help no_meta\n"
+        type "exit"
+      end
+
+      assert_include(output, "This command does not override meta attributes")
+      assert_not_include(output, "Maybe IRB bug")
+    end
   end
 end


### PR DESCRIPTION
When I updating my custom command with irb 1.13.0, I have faced this error

```
irb(main):001> help my_command
/home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb/pager.rb:57:in `content_exceeds_screen_height?': undefined method `lines' for nil (NoMethodError)

        content.lines.count > pageable_height ||
               ^^^^^^
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb/pager.rb:11:in `page_content'
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb/command/help.rb:20:in `execute'
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb/command/base.rb:42:in `execute'
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb/context.rb:598:in `evaluate'
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb.rb:1043:in `block (2 levels) in eval_input'
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb.rb:1374:in `signal_status'
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb.rb:1035:in `block in eval_input'
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb.rb:1114:in `block in each_top_level_statement'
        from <internal:kernel>:187:in `loop'
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb.rb:1111:in `each_top_level_statement'
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb.rb:1034:in `eval_input'
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb.rb:1015:in `block in run'
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb.rb:1014:in `catch'
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb.rb:1014:in `run'
        from /home/kachick/.local/share/gem/ruby/3.3.0/gems/irb-1.13.0/lib/irb.rb:901:in `start'
        from ./bin/console:5:in `<main>'
Maybe IRB bug!
```

The output from the `my_command` does not define meta attributes, but displaying `Maybe IRB bug!` is not correct even in this case.