### PR TITLE
Improve help message for no meta commands

### DIFF
--- a/lib/irb/command/base.rb
+++ b/lib/irb/command/base.rb
@@ -18,12 +18,12 @@ module IRB
       class << self
         def category(category = nil)
           @category = category if category
-          @category
+          @category || "No category"
         end
 
         def description(description = nil)
           @description = description if description
-          @description
+          @description || "No description provided."
         end
 
         def help_message(help_message = nil)

--- a/lib/irb/command/help.rb
+++ b/lib/irb/command/help.rb
@@ -12,7 +12,7 @@ module IRB
             help_message
           else
             if command_class = Command.load_command(command_name)
-              command_class.help_message || command_class.description || ""
+              command_class.help_message || command_class.description
             else
               "Can't find command `#{command_name}`. Please check the command name and try again.\n\n"
             end
@@ -28,17 +28,9 @@ module IRB
         commands_grouped_by_categories = commands_info.group_by { |cmd| cmd[:category] }
         commands_grouped_by_categories["Helper methods"] = helper_methods_info
 
-        user_aliases = irb_context.instance_variable_get(:@user_aliases)
-
-        commands_grouped_by_categories["Aliases"] = user_aliases.map do |alias_name, target|
-          { display_name: alias_name, description: "Alias for `#{target}`" }
-        end
-
         if irb_context.with_debugger
           # Remove the original "Debugging" category
           commands_grouped_by_categories.delete("Debugging")
-          # Add an empty "Debugging (from debug.gem)" category at the end
-          commands_grouped_by_categories["Debugging (from debug.gem)"] = []
         end
 
         longest_cmd_name_length = commands_info.map { |c| c[:display_name].length }.max
@@ -46,15 +38,31 @@ module IRB
         output = StringIO.new
 
         help_cmds = commands_grouped_by_categories.delete("Help")
+        no_category_cmds = commands_grouped_by_categories.delete("No category")
+        aliases = irb_context.instance_variable_get(:@user_aliases).map do |alias_name, target|
+          { display_name: alias_name, description: "Alias for `#{target}`" }
+        end
 
+        # Display help commands first
         add_category_to_output("Help", help_cmds, output, longest_cmd_name_length)
 
+        # Display the rest of the commands grouped by categories
         commands_grouped_by_categories.each do |category, cmds|
           add_category_to_output(category, cmds, output, longest_cmd_name_length)
         end
 
+        # Display commands without a category
+        if no_category_cmds
+          add_category_to_output("No category", no_category_cmds, output, longest_cmd_name_length)
+        end
+
+        # Display aliases
+        add_category_to_output("Aliases", aliases, output, longest_cmd_name_length)
+
         # Append the debugger help at the end
         if irb_context.with_debugger
+          # Add "Debugging (from debug.gem)" category as title
+          add_category_to_output("Debugging (from debug.gem)", [], output, longest_cmd_name_length)
           output.puts DEBUGGER__.help
         end
 

--- a/test/irb/command/test_custom_command.rb
+++ b/test/irb/command/test_custom_command.rb
@@ -15,7 +15,6 @@ module TestIRB
           description 'print_command'
           def execute(*)
             puts "Hello from PrintCommand"
-            nil
           end
         end
 
@@ -25,7 +24,7 @@ module TestIRB
       RUBY
 
       output = run_ruby_file do
-        type "print!\n"
+        type "print!"
         type "exit"
       end
 
@@ -41,7 +40,6 @@ module TestIRB
           description 'print_command'
           def execute(*)
             puts "Hello from PrintCommand"
-            nil
           end
         end
 
@@ -51,7 +49,7 @@ module TestIRB
       RUBY
 
       output = run_ruby_file do
-        type "print!\n"
+        type "print!"
         type "exit"
       end
 
@@ -69,7 +67,6 @@ module TestIRB
             $nth_execution ||= 0
             puts "\#{$nth_execution} arg=\#{arg.inspect}"
             $nth_execution += 1
-            nil
           end
         end
 
@@ -79,9 +76,9 @@ module TestIRB
       RUBY
 
       output = run_ruby_file do
-        type "print_arg\n"
+        type "print_arg"
         type "print_arg  \n"
-        type "print_arg a r  g\n"
+        type "print_arg a r  g"
         type "print_arg  a r  g  \n"
         type "exit"
       end
@@ -103,7 +100,6 @@ module TestIRB
             $nth_execution ||= 1
             puts "\#{$nth_execution} FooBar executed"
             $nth_execution += 1
-            nil
           end
         end
 
@@ -131,7 +127,6 @@ module TestIRB
         class NoMetaCommand < IRB::Command::Base
           def execute(*)
             puts "This command does not override meta attributes"
-            nil
           end
         end
 
@@ -141,8 +136,8 @@ module TestIRB
       RUBY
 
       output = run_ruby_file do
-        type "no_meta\n"
-        type "help no_meta\n"
+        type "no_meta"
+        type "help no_meta"
         type "exit"
       end
 

--- a/test/irb/command/test_custom_command.rb
+++ b/test/irb/command/test_custom_command.rb
@@ -142,6 +142,7 @@ module TestIRB
       end
 
       assert_include(output, "This command does not override meta attributes")
+      assert_include(output, "No description provided.")
       assert_not_include(output, "Maybe IRB bug")
     end
   end


### PR DESCRIPTION
1. Add placeholder values for both command category and description
2. Update help command's output to give different types of categories
   more explicit ordering