### PR TITLE
Change debug test workaround only enabled when output is tty

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -67,7 +67,7 @@ module IRB
     #
     # See IO#gets for more information.
     def gets
-      puts
+      puts if @stdout.tty? # workaround for debug compatibility test
       print @prompt
       line = @stdin.gets
       @line[@line_no += 1] = line


### PR DESCRIPTION
In https://github.com/ruby/irb/pull/943, we add a workaround `puts` but it caused IRB binding spec failure in https://github.com/ruby/ruby/pull/10712.

To minimize the impact and to avoid test failure in other project, I think it is better to restrict this workaround only to tty environment.
For other projects that runs integration test using `IO.popen` in other projects won't be affected by the workaround.
The workaround still works for debug because debug uses `PTY.open`, not `IO.popen`.
