### PR TITLE
Add a new initialization step to validate IRB.conf's values

### DIFF
--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -73,11 +73,12 @@ module IRB
 
       self.prompt_mode = IRB.conf[:PROMPT_MODE]
 
-      if IRB.conf[:SINGLE_IRB] or !defined?(IRB::JobManager)
-        @irb_name = IRB.conf[:IRB_NAME]
-      else
-        @irb_name = IRB.conf[:IRB_NAME]+"#"+IRB.JobManager.n_jobs.to_s
+      @irb_name = IRB.conf[:IRB_NAME]
+
+      unless IRB.conf[:SINGLE_IRB] or !defined?(IRB::JobManager)
+        @irb_name = @irb_name + "#" + IRB.JobManager.n_jobs.to_s
       end
+
       self.irb_path = "(" + @irb_name + ")"
 
       case input_method

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -268,15 +268,94 @@ module TestIRB
     end
   end
 
+  class ConfigValidationTest < TestCase
+    def setup
+      @original_home = ENV["HOME"]
+      @original_irbrc = ENV["IRBRC"]
+      # To prevent the test from using the user's .irbrc file
+      ENV["HOME"] = Dir.mktmpdir
+      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
+      super
+    end
+
+    def teardown
+      super
+      ENV["IRBRC"] = @original_irbrc
+      ENV["HOME"] = @original_home
+      File.unlink(@irbrc)
+    end
+
+    def test_irb_name_converts_non_string_values_to_string
+      assert_no_irb_validation_error(<<~'RUBY')
+        IRB.conf[:IRB_NAME] = :foo
+      RUBY
+
+      assert_equal "foo", IRB.conf[:IRB_NAME]
+    end
+
+    def test_irb_rc_name_only_takes_callable_objects
+      assert_irb_validation_error(<<~'RUBY', "IRB.conf[:IRB_RC] should be a callable object. Got :foo.")
+        IRB.conf[:IRB_RC] = :foo
+      RUBY
+    end
+
+    def test_back_trace_limit_only_accepts_integers
+      assert_irb_validation_error(<<~'RUBY', "IRB.conf[:BACK_TRACE_LIMIT] should be an integer. Got \"foo\".")
+        IRB.conf[:BACK_TRACE_LIMIT] = "foo"
+      RUBY
+    end
+
+    def test_prompt_only_accepts_hash
+      assert_irb_validation_error(<<~'RUBY', "IRB.conf[:PROMPT] should be a Hash. Got \"foo\".")
+        IRB.conf[:PROMPT] = "foo"
+      RUBY
+    end
+
+    def test_eval_history_only_accepts_integers
+      assert_irb_validation_error(<<~'RUBY', "IRB.conf[:EVAL_HISTORY] should be an integer. Got \"foo\".")
+        IRB.conf[:EVAL_HISTORY] = "foo"
+      RUBY
+    end
+
+    private
+
+    def assert_irb_validation_error(rc_content, error_message)
+      write_rc rc_content
+
+      assert_raise_with_message(TypeError, error_message) do
+        IRB.setup(__FILE__)
+      end
+    end
+
+    def assert_no_irb_validation_error(rc_content)
+      write_rc rc_content
+
+      assert_nothing_raised do
+        IRB.setup(__FILE__)
+      end
+    end
+
+    def write_rc(content)
+      @irbrc = Tempfile.new('irbrc')
+      @irbrc.write(content)
+      @irbrc.close
+      ENV['IRBRC'] = @irbrc.path
+    end
+  end
+
   class InitIntegrationTest < IntegrationTestCase
-    def test_load_error_in_rc_file_is_warned
-      write_rc <<~'IRBRC'
-        require "file_that_does_not_exist"
-      IRBRC
+    def setup
+      super
 
       write_ruby <<~'RUBY'
         binding.irb
       RUBY
+    end
+
+    def test_load_error_in_rc_file_is_warned
+      write_rc <<~'IRBRC'
+        require "file_that_does_not_exist"
+      IRBRC
 
       output = run_ruby_file do
         type "'foobar'"
@@ -292,10 +371,6 @@ module TestIRB
       write_rc <<~'IRBRC'
         raise "I'm an error"
       IRBRC
-
-      write_ruby <<~'RUBY'
-        binding.irb
-      RUBY
 
       output = run_ruby_file do
         type "'foobar'"


### PR DESCRIPTION
Currently, users can only find out that they have set a wrong value for IRB configs when the value is used, with opaque error messages like "comparison of Integer with true failed (TypeError)".

This commit adds a new initialization step to validate the values of some IRB configs, so that users can find out about the wrong values during the initialization of IRB.

Closes #774