### PR TITLE
Enhance regexp to account for prism error messages

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -230,7 +230,7 @@ module IRB
           #   example:
           #     '
           return :recoverable_error
-        when /syntax error, unexpected end-of-input/
+        when /unexpected end-of-input/
           # "syntax error, unexpected end-of-input, expecting keyword_end"
           #
           #   example:
@@ -240,7 +240,7 @@ module IRB
           #         fuga
           #       end
           return :recoverable_error
-        when /syntax error, unexpected keyword_end/
+        when /unexpected keyword_end/
           # "syntax error, unexpected keyword_end"
           #
           #   example:
@@ -250,7 +250,7 @@ module IRB
           #   example:
           #     end
           return :unrecoverable_error
-        when /syntax error, unexpected '\.'/
+        when /unexpected '\.'/
           # "syntax error, unexpected '.'"
           #
           #   example:


### PR DESCRIPTION
Prism changes this error message slightly to provide more information. Currently:

```
$ ./ruby -c -e 'foo.;'
-e:1: syntax error, unexpected ';'
foo.;
./ruby: compile error (SyntaxError)
$ ./ruby --parser=prism -c -e 'foo.;'
./ruby: warning: The compiler based on the Prism parser is currently experimental and compatibility with the compiler based on parse.y is not yet complete. Please report any issues you find on the `ruby/prism` issue tracker.
./ruby: -e:1: syntax error found (SyntaxError)
> 1 | foo.;
    |     ^ unexpected ';'; expecting a message to send to the receiver
  2 | 
```

This is the only regexp that needs to change to get all of the CRuby/IRB tests passing with `--parser=prism`.