### PR TITLE
Clean up tmpdir

### DIFF
--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -273,7 +273,7 @@ module TestIRB
       @original_home = ENV["HOME"]
       @original_irbrc = ENV["IRBRC"]
       # To prevent the test from using the user's .irbrc file
-      ENV["HOME"] = Dir.mktmpdir
+      ENV["HOME"] = @home = Dir.mktmpdir
       IRB.instance_variable_set(:@existing_rc_name_generators, nil)
       super
     end
@@ -283,6 +283,7 @@ module TestIRB
       ENV["IRBRC"] = @original_irbrc
       ENV["HOME"] = @original_home
       File.unlink(@irbrc)
+      Dir.rmdir(@home)
     end
 
     def test_irb_name_converts_non_string_values_to_string


### PR DESCRIPTION
Fix up af8ef2948b49ef8169a1f079b84a2e998948df7c.

https://github.com/ruby/irb/actions/runs/9031681394/job/24818383515#step:10:57
>   Children under /tmp/rubytest.80e8wl:
>   * drwx------ 2 4096 2024-05-10 11:45:14 +0000 d20240510-16364-25ihyj/
>   * drwx------ 2 4096 2024-05-10 11:45:14 +0000 d20240510-16364-wbjs41/
>   * drwx------ 2 4096 2024-05-10 11:45:14 +0000 d20240510-16364-93clx6/
>   * drwx------ 2 4096 2024-05-10 11:45:14 +0000 d20240510-16364-tlh18h/
>   * drwx------ 2 4096 2024-05-10 11:45:14 +0000 d20240510-16364-spmw1m/
