### PR TITLE
Suppress 'Maybe IRB bug!' message in extract_ruby_args

### DIFF
--- a/lib/irb/command/internal_helpers.rb
+++ b/lib/irb/command/internal_helpers.rb
@@ -4,6 +4,8 @@ module IRB
   module Command
     # Internal use only, for default command's backward compatibility.
     module RubyArgsExtractor # :nodoc:
+      class Error < StandardError; end
+
       def unwrap_string_literal(str)
         return if str.empty?
 
@@ -16,10 +18,15 @@ module IRB
       end
 
       def ruby_args(arg)
+        if arg =~ /\A([<=>]|([-+*\/%^&|!]|\*\*|\|\||&&)=)/
+          raise Error, "Invalid IRB::Command argument: #{arg.inspect}"
+        end
         # Use throw and catch to handle arg that includes `;`
         # For example: "1, kw: (2; 3); 4" will be parsed to [[1], { kw: 3 }]
         catch(:EXTRACT_RUBY_ARGS) do
           @irb_context.workspace.binding.eval "IRB::Command.extract_ruby_args #{arg}"
+        rescue
+          raise Error
         end || [[], {}]
       end
     end

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -413,6 +413,18 @@ module TestIRB
       assert_match(/\A=> 3\n=> nil\n=> 3\n/, out)
       assert_empty(c.class_variables)
     end
+
+    def test_error_call
+      out, err = execute_lines("measure raise 'foo'+'bar'+'error'\n")
+      assert_empty err
+      assert_include(out, 'foobarerror')
+      assert_not_include(out, 'Maybe IRB bug')
+
+      out, err = execute_lines("measure = 1\n")
+      assert_empty err
+      assert_include(out, 'Invalid IRB::Command argument: "= 1"')
+      assert_not_include(out, 'Maybe IRB bug')
+    end
   end
 
   class IrbSourceTest < CommandTestCase


### PR DESCRIPTION
Improve error message of #958

```
irb(main):001> measure = 1
undefined method `extract_ruby_args=' for module IRB::Command (NoMethodError)
IRB::Command.extract_ruby_args = 1
            ^^^^^^^^^^^^^^^^^^^^
Maybe IRB bug!
```
This is not a bug. `"= 1"` is an invalid argument for `measure` command.

```
irb(main):002> measure a + b
undefined local variable or method `a' for main (NameError)
IRB::Command.extract_ruby_args a + b
                               ^
Maybe IRB bug!
```
This is also not a bug.


This pull request improves the error message with less effort.
Note that `IRB::Command::RubyArgsExtractor` is a backward-compatibility layer of command arguments and we are going to reduce using it.


