### PR TITLE
Remove useless Reline::Key.new and update wrong comment for alt+d

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -328,10 +328,11 @@ module IRB
       ->() {
         dialog.trap_key = nil
         alt_d = [
-          [Reline::Key.new(nil, 0xE4, true)], # Normal Alt+d.
           [27, 100], # Normal Alt+d when convert-meta isn't used.
-          [195, 164], # The "ä" that appears when Alt+d is pressed on xterm.
-          [226, 136, 130] # The "∂" that appears when Alt+d in pressed on iTerm2.
+          # When option/alt is not configured as a meta key in terminal emulator,
+          # option/alt + d will send a unicode character depend on OS keyboard setting.
+          [195, 164], # "ä" in somewhere (FIXME: environment information is unknown).
+          [226, 136, 130] # "∂" Alt+d on Mac keyboard.
         ]
 
         if just_cursor_moving and completion_journey_data.nil?


### PR DESCRIPTION
IRB sets one of the `dialog.trap_key` to `Reline::Key.new(nil, 0xE4, true)`. This has no meaning.

It only matches to `"\xE4"` when convert-meta is enabled in Reline. But Reline's convert-meta is not working.
https://github.com/ruby/reline/issues/710
Using `Reline::Key.new(nil, 0xE4, true)` might be a blocker for reline refactoring. (Of course Reline still needs to support for a while)


### Alt+d unicodes
`# The "∂" that appears when Alt+d in pressed on iTerm2.` is wrong. `iTerm2` part is wrong.
In mac keyboard, alt+d in many keyboard language source sends `∂` in normal text field in GUI applications. Some keyboard language source sends `ð`. Few qwerty keyboard language source sends other unicode characters.
For the same reason, `# The "ä" that appears when Alt+d is pressed on xterm` should be wrong, but I don't know the about the environment.

