### PR TITLE
Suppress Ruby warnings in certain backtrace filtering tests

### DIFF
--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -825,6 +825,13 @@ module TestIRB
   end
 
   class BacktraceFilteringTest < TestIRB::IntegrationTestCase
+    def setup
+      super
+      # These tests are sensitive to warnings, so we disable them
+      original_rubyopt = [ENV["RUBYOPT"], @envs["RUBYOPT"]].compact.join(" ")
+      @envs["RUBYOPT"] = original_rubyopt + " -W0"
+    end
+
     def test_backtrace_filtering
       write_ruby <<~'RUBY'
         def foo


### PR DESCRIPTION
Since they're sensitive to the warnings, and the warnings are not relevant to the tests, we can suppress them to keep the tests simple.

This should fix the current test failures on master.