### PR TITLE
Cleanup irbrc generator cache always at teardown

### DIFF
--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -274,7 +274,6 @@ module TestIRB
       @original_irbrc = ENV["IRBRC"]
       # To prevent the test from using the user's .irbrc file
       ENV["HOME"] = @home = Dir.mktmpdir
-      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
       super
     end
 
@@ -284,6 +283,7 @@ module TestIRB
       ENV["HOME"] = @original_home
       File.unlink(@irbrc)
       Dir.rmdir(@home)
+      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
     end
 
     def test_irb_name_converts_non_string_values_to_string


### PR DESCRIPTION
Fix this `Error loading RC file` message shown while running test_init.rb

```
$ rake test TEST=test/irb/test_init.rb 
Error loading RC file '/var/folders/zj/fs39x31j7s9b2lp7jydtmxgr0000gq/T/irbrc20240612-98621-vgoozc':
/Users/tomoya.ishida/github/ruby/irb/lib/irb/init.rb:400:in `load': cannot load such file -- /var/folders/zj/fs39x31j7s9b2lp7jydtmxgr0000gq/T/irbrc20240612-98621-vgoozc (LoadError)
	from /Users/tomoya.ishida/github/ruby/irb/lib/irb/init.rb:400:in `block in run_config'
	from /Users/tomoya.ishida/github/ruby/irb/lib/irb/init.rb:399:in `each'
	from /Users/tomoya.ishida/github/ruby/irb/lib/irb/init.rb:399:in `run_config'
	from /Users/tomoya.ishida/github/ruby/irb/lib/irb/init.rb:54:in `setup'
	from /Users/tomoya.ishida/github/ruby/irb/test/irb/test_init.rb:171:in `test_completor_environment_variable'
	from /Users/tomoya.ishida/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/test-unit-3.6.1/lib/test/unit/testcase.rb:871:in `run_test'
	...
```

