### PR TITLE
Invalid encoding symbol now raises SyntaxError also in 3.3

### DIFF
--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -61,7 +61,7 @@ module TestIRB
         omit "Remove me after https://github.com/ruby/prism/issues/2129 is addressed and adopted in TruffleRuby"
       end
 
-      if RUBY_VERSION >= "3.4."
+      if RUBY_VERSION >= "3.3."
         omit "Now raises SyntaxError"
       end
 


### PR DESCRIPTION
Fix test failure in Ruby 3.3.3
https://github.com/ruby/irb/actions/runs/9484561027/job/26134345305
