### PR TITLE
Clear ENV["XDG_CONFIG_HOME"] to avoid loading user-defined irbrc in test

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -49,6 +49,19 @@ module TestIRB
       !Pathname(__dir__).join("../../", "irb.gemspec").exist?
     end
 
+    def setup_envs(home:)
+      @backup_home = ENV["HOME"]
+      ENV["HOME"] = home
+      @backup_xdg_config_home = ENV.delete("XDG_CONFIG_HOME")
+      @backup_irbrc = ENV.delete("IRBRC")
+    end
+
+    def teardown_envs
+      ENV["HOME"] = @backup_home
+      ENV["XDG_CONFIG_HOME"] = @backup_xdg_config_home
+      ENV["IRBRC"] = @backup_irbrc
+    end
+
     def save_encodings
       @default_encoding = [Encoding.default_external, Encoding.default_internal]
       @stdio_encodings = [STDIN, STDOUT, STDERR].map {|io| [io.external_encoding, io.internal_encoding] }

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -15,9 +15,7 @@ module TestIRB
         Dir.mkdir(@tmpdir)
       end
       Dir.chdir(@tmpdir)
-      @home_backup = ENV["HOME"]
-      ENV["HOME"] = @tmpdir
-      @xdg_config_home_backup = ENV.delete("XDG_CONFIG_HOME")
+      setup_envs(home: @tmpdir)
       save_encodings
       IRB.instance_variable_get(:@CONF).clear
       IRB.instance_variable_set(:@existing_rc_name_generators, nil)
@@ -25,8 +23,7 @@ module TestIRB
     end
 
     def teardown
-      ENV["XDG_CONFIG_HOME"] = @xdg_config_home_backup
-      ENV["HOME"] = @home_backup
+      teardown_envs
       Dir.chdir(@pwd)
       FileUtils.rm_rf(@tmpdir)
       restore_encodings

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -12,19 +12,14 @@ module TestIRB
     def setup
       @original_verbose, $VERBOSE = $VERBOSE, nil
       @tmpdir = Dir.mktmpdir("test_irb_history_")
-      @backup_home = ENV["HOME"]
-      @backup_xdg_config_home = ENV.delete("XDG_CONFIG_HOME")
-      @backup_irbrc = ENV.delete("IRBRC")
+      setup_envs(home: @tmpdir)
       @backup_default_external = Encoding.default_external
-      ENV["HOME"] = @tmpdir
       IRB.instance_variable_set(:@existing_rc_name_generators, nil)
     end
 
     def teardown
       IRB.instance_variable_set(:@existing_rc_name_generators, nil)
-      ENV["HOME"] = @backup_home
-      ENV["XDG_CONFIG_HOME"] = @backup_xdg_config_home
-      ENV["IRBRC"] = @backup_irbrc
+      teardown_envs
       Encoding.default_external = @backup_default_external
       $VERBOSE = @original_verbose
       FileUtils.rm_rf(@tmpdir)

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -270,17 +270,15 @@ module TestIRB
 
   class ConfigValidationTest < TestCase
     def setup
-      @original_home = ENV["HOME"]
-      @original_irbrc = ENV["IRBRC"]
       # To prevent the test from using the user's .irbrc file
-      ENV["HOME"] = @home = Dir.mktmpdir
+      @home = Dir.mktmpdir
+      setup_envs(home: @home)
       super
     end
 
     def teardown
       super
-      ENV["IRBRC"] = @original_irbrc
-      ENV["HOME"] = @original_home
+      teardown_envs
       File.unlink(@irbrc)
       Dir.rmdir(@home)
       IRB.instance_variable_set(:@existing_rc_name_generators, nil)


### PR DESCRIPTION
`TestIRB::ConfigValidationTest#setup` forgot to clear `ENV['XDG_CONFIG_HOME']`

With these environment variables, `rake test` fails.
```sh
echo "puts 'IRBRC'; exit" > /path/to/dummy_home/env_irbrc
echo "puts 'HOME'; exit" > /path/to/dummy_home/.irbrc
echo "puts 'XDG'; exit" > /path/to/dummy_home/.config/irb/irbrc
IRBRC=/path/to/dummy_home/env_irbrc HOME=/path/to/dummy_home/ XDG_CONFIG_HOME=/path/to/dummy_home/.config rake test
```

Test passes with normal irbrc content maybe with `Error loading RC file` warning message, but it's better not to read user-defined irbrc file.