### PR TITLE
Colorize command input

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -270,7 +270,13 @@ module IRB
           proc do |output, complete: |
             next unless IRB::Color.colorable?
             lvars = IRB.CurrentContext&.local_variables || []
-            IRB::Color.colorize_code(output, complete: complete, local_variables: lvars)
+            if IRB.CurrentContext&.parse_command(output)
+              name, sep, arg = output.split(/(\s+)/, 2)
+              arg = IRB::Color.colorize_code(arg, complete: complete, local_variables: lvars)
+              "#{IRB::Color.colorize(name, [:BOLD])}\e[m#{sep}#{arg}"
+            else
+              IRB::Color.colorize_code(output, complete: complete, local_variables: lvars)
+            end
           end
         else
           proc do |output|


### PR DESCRIPTION
Command colorization for `$`, alias of show_source was not good.
This pull request improves it.

- command name part: bold
- command arg part: colorized as ruby code


## before and after
![command_color](https://github.com/user-attachments/assets/89d87a7c-7273-4534-b0e0-f9b307fcd5a5)


Colorization for some command that uses `extract_ruby_args` mostly for backward compatibility gets worse, but we're going to reduce using extract_ruby_args like #962.
![command_color_cons](https://github.com/user-attachments/assets/6d91c779-a71c-40cc-acef-9114ea44d395)

