### PR TITLE
Remove Ruby version checks

### DIFF
--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -526,9 +526,6 @@ module TestIRB
       end
 
       def test_heredoc_with_indent
-        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
-          pend 'This test needs Ripper::Lexer#scan to take broken tokens'
-        end
         input_with_correct_indents = [
           [%q(<<~Q+<<~R), 0, 2, 1],
           [%q(a), 2, 2, 1],

--- a/test/irb/test_nesting_parser.rb
+++ b/test/irb/test_nesting_parser.rb
@@ -319,9 +319,6 @@ module TestIRB
     end
 
     def test_case_in
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
-        pend 'This test requires ruby version that supports case-in syntax'
-      end
       code = <<~EOS
         case 1
         in 1


### PR DESCRIPTION
Minor cleanup from test files where it's being checked if the Ruby version is lower than 2.7. Since the gem requires 2.7+ by default I'd say these can be removed