### PR TITLE
Always use alternate sceen on alt-d

### DIFF
--- a/lib/irb/easter-egg.rb
+++ b/lib/irb/easter-egg.rb
@@ -125,7 +125,6 @@ module IRB
             canvas = Canvas.new(Reline.get_screen_size)
           end
           ruby_model = RubyModel.new
-          print "\e[?1049h"
           0.step do |i| # TODO (0..).each needs Ruby 2.6 or later
             buff = canvas.draw do
               ruby_model.render_frame(i) do |p1, p2|

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -361,9 +361,15 @@ module IRB
           if show_easter_egg
             IRB.__send__(:easter_egg)
           else
+            # RDoc::RI::Driver#display_names uses pager command internally.
+            # Some pager command like `more` doesn't use alternate screen
+            # so we need to turn on and off alternate screen manually.
             begin
+              print "\e[?1049h"
               driver.display_names([name])
             rescue RDoc::RI::Driver::NotFoundError
+            ensure
+              print "\e[?1049l"
             end
           end
         end


### PR DESCRIPTION
Fixes screen corruption when `PAGER=more` is used.

When ALT+D is pressed while showing document dialog, document in shown in full screen using pager.
IRB assumes that the pager switches to alternate screen, turns off alternate screen at exit, and restore IRB's screen.

Some pager like `more` does not do that. Screen corrupts. We need to switch to alternate screen manually.

![irb_with_pager_eq_more](https://github.com/user-attachments/assets/8b9ff062-ca99-4e19-951d-d2592eeb0990)
To reproduce:
`PAGER=more irb` (make sure `more` is not aliased to `less`)
`PAGER="sh -c 'cat;sleep 1'" irb`

