### PR TITLE
Fix kill pager pid throwing Errno::ESRCH when pager process already terminated

### DIFF
--- a/lib/irb/pager.rb
+++ b/lib/irb/pager.rb
@@ -33,7 +33,11 @@ module IRB
       # the `IRB::Abort` exception only interrupts IRB's execution but doesn't affect the pager
       # So to properly terminate the pager with Ctrl-C, we need to catch `IRB::Abort` and kill the pager process
       rescue IRB::Abort
-        Process.kill("TERM", pid) if pid
+        begin
+          Process.kill("TERM", pid) if pid
+        rescue Errno::ESRCH
+          # Pager process already terminated
+        end
         nil
       rescue Errno::EPIPE
       end


### PR DESCRIPTION
Fixes https://github.com/ruby/irb/issues/847

In some case, when IRB receives IRB::Abort, pager process might be already terminated.
This can happen with timing or pager's problem.

### Timing problem
When there is a `sleep 1` just after `pager.close`, (press `q` to terminate pager and press \C-c within 1 sec) process might be already terminated. I can't reproduce this without inserting `sleep 1` but it could potentially happen.

### Pager's problem
`Less` somehow does not receive `\C-c` when paging content is large (more than 72KB) and has many lines.
Just after exiting pager by typing `q`, IRB receives the previous `\C-c` and IRB tries to `Process.kill pid` but the process is already terminated.

```
To reproduce:

irb(main):001> `less --version`
=> "less 581.2 (POSIX regular expressions) ...
irb(main):002> Object.new.tap{def _1.inspect; "a\n"*36*1024;end} # > To reproduce with macOS less 581.2
# Press \C-c and then q
lib/irb/pager.rb:36:in `kill': No such process (Errno::ESRCH)
```
