### PR TITLE
Make colorize test pass with NO_COLOR env set

### DIFF
--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -35,6 +35,7 @@ module TestIRB
     end
 
     def test_colorize
+      IRB.conf[:USE_COLORIZE] = true
       original_colorable = IRB::Color.method(:colorable?)
       IRB::Color.instance_eval { undef :colorable? }
       IRB::Color.define_singleton_method(:colorable?) { true }


### PR DESCRIPTION
Fix `NO_COLOR=1 rake test TEST=test/irb/test_input_method.rb` failing