### PR TITLE
Surpressing 'unknown command: “Switch to inspect mode.”' message

### DIFF
--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -36,6 +36,7 @@ module TestIRB
 
     def test_colorize
       IRB.conf[:USE_COLORIZE] = true
+      IRB.conf[:VERBOSE] = false
       original_colorable = IRB::Color.method(:colorable?)
       IRB::Color.instance_eval { undef :colorable? }
       IRB::Color.define_singleton_method(:colorable?) { true }


### PR DESCRIPTION
I got the following with `make test-all TESTS='test/irb/test_input_method -j12'` at ruby/ruby repo.

```
(snip)
# Running tests:

unknown command: "Switch to inspect mode."
Finished tests in 0.187577s, 53.3114 tests/s, 239.9015 assertions/s.
10 tests, 45 assertions, 0 failures, 0 errors, 2 skips
```