### PR TITLE
Skip show_doc tests if RDoc is not available

### DIFF
--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -765,7 +765,7 @@ module TestIRB
     ensure
       # this is the only way to reset the redefined method without coupling the test with its implementation
       EnvUtil.suppress_warning { load "irb/command/help.rb" }
-    end
+    end if defined?(RDoc)
 
     def test_show_doc_without_rdoc
       _, err = without_rdoc do

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: false
 
 require "irb"
-require "rdoc"
+begin
+  require "rdoc"
+rescue LoadError
+end
 require_relative "helper"
 
 module TestIRB
@@ -188,4 +191,4 @@ module TestIRB
       File.exist?(RDoc::RI::Paths::BASE)
     end
   end
-end
+end if defined?(RDoc)


### PR DESCRIPTION
RDoc will become bundled gems at Ruby 3.5. We should make RDoc related feature and tests to optional.