### PR TITLE
Fix easter_egg run without RDoc, fix input-method test run without RDoc

### DIFF
--- a/lib/irb/easter-egg.rb
+++ b/lib/irb/easter-egg.rb
@@ -107,13 +107,14 @@ module IRB
     end
 
     private def easter_egg(type = nil)
+      print "\e[?1049h"
       type ||= [:logo, :dancing].sample
       case type
       when :logo
-        require "rdoc"
-        RDoc::RI::Driver.new.page do |io|
-          type = STDOUT.external_encoding == Encoding::UTF_8 ? :unicode_large : :ascii_large
-          io.write easter_egg_logo(type)
+        Pager.page do |io|
+          logo_type = STDOUT.external_encoding == Encoding::UTF_8 ? :unicode_large : :ascii_large
+          io.write easter_egg_logo(logo_type)
+          STDIN.raw { STDIN.getc } if io == STDOUT
         end
       when :dancing
         STDOUT.cooked do
@@ -138,10 +139,11 @@ module IRB
           end
         rescue Interrupt
         ensure
-          print "\e[0m\e[?1049l"
           trap("SIGINT", prev_trap)
         end
       end
+    ensure
+      print "\e[0m\e[?1049l"
     end
   end
 end

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -70,6 +70,7 @@ module TestIRB
     end
 
     def test_initialization_with_use_autocomplete
+      omit 'This test requires RDoc' unless defined?(RDoc)
       original_show_doc_proc = Reline.dialog_proc(:show_doc)&.dialog_proc
       empty_proc = Proc.new {}
       Reline.add_dialog_proc(:show_doc, empty_proc)
@@ -190,5 +191,5 @@ module TestIRB
     def has_rdoc_content?
       File.exist?(RDoc::RI::Paths::BASE)
     end
-  end
-end if defined?(RDoc)
+  end if defined?(RDoc)
+end


### PR DESCRIPTION
RDoc is planned to be a bundled gem, not a default gem in the future.
Even if RDoc is not available, we want to run most of the tests in `test_input_method.rb`.

This pull request will:
- Reduce skipping test with `if defined?(RDoc)`
- Make easter_egg not depend on RDoc

### EasterEgg with no pager
When USE_PAGER is set to false, or no pager command is available, `IRB::Pager.page` will fallback to STDOUT.
We need to `print "\e[?1049h"` to switch to alternate screen and switch back to normal screen after pager is finished because easter_egg is called while rendering document dialog.
We need to `STDIN.raw { STDIN.getc }` wait for more than 0 second  before switch back to normal screen.
