### PR TITLE
Suppress warning when loading rdoc

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -288,9 +288,12 @@ module IRB
 
       if IRB.conf[:USE_AUTOCOMPLETE]
         begin
+          verbose, $VERBOSE = $VERBOSE, nil
           require 'rdoc'
           Reline.add_dialog_proc(:show_doc, show_doc_dialog_proc, Reline::DEFAULT_DIALOG_CONTEXT)
         rescue LoadError
+        ensure
+          $VERBOSE = verbose
         end
       end
     end
@@ -321,6 +324,7 @@ module IRB
       return @rdoc_ri_driver if defined?(@rdoc_ri_driver)
 
       begin
+        verbose, $VERBOSE = $VERBOSE, nil
         require 'rdoc'
       rescue LoadError
         @rdoc_ri_driver = nil
@@ -328,6 +332,8 @@ module IRB
         options = {}
         options[:extra_doc_dirs] = IRB.conf[:EXTRA_DOC_DIRS] unless IRB.conf[:EXTRA_DOC_DIRS].empty?
         @rdoc_ri_driver = RDoc::RI::Driver.new(options)
+      ensure
+        $VERBOSE = verbose
       end
     end
 


### PR DESCRIPTION
This actually starts to warn on Ruby 3.3.5 now because that was backported. Just rescuing the LoadError is not enough, since the warning is emitted anyways.

This is not ideal, see https://bugs.ruby-lang.org/issues/20714#note-2, but I'm not aware of a different solution.
`reline` does the same thing for `fiddle`: https://github.com/ruby/reline/blob/c90f08f7e308d2f1cdd7cfaf9939fe45ce546fd2/lib/reline/terminfo.rb#L1-L15

Without this, a simple `bundle exec irb` on Ruby 3.3.5 shows this:
> rdoc was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
> You can add rdoc to your Gemfile or gemspec to silence this warning.