### PR TITLE
Specify commit hash of yamatanooroti

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ is_truffleruby = RUBY_DESCRIPTION =~ /truffleruby/
 
 if is_unix && ENV['WITH_VTERM']
   gem "vterm", github: "ruby/vterm-gem"
-  gem "yamatanooroti", github: "ruby/yamatanooroti"
+  gem "yamatanooroti", github: "ruby/yamatanooroti", ref: "f6e47192100d6089f70cf64c1de540dcaadf005a"
 end
 
 gem "stackprof" if is_unix && !is_truffleruby


### PR DESCRIPTION
We need to specify the commit hash to update yamatanooroti because `test_rendering.rb` depends on yamatanooroti's implicit sleep that should be fixed in the future.