### PR TITLE
Make rendering test faster using updated yamatanooroti

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ is_truffleruby = RUBY_DESCRIPTION =~ /truffleruby/
 
 if is_unix && ENV['WITH_VTERM']
   gem "vterm", github: "ruby/vterm-gem"
-  gem "yamatanooroti", github: "ruby/yamatanooroti", ref: "f6e47192100d6089f70cf64c1de540dcaadf005a"
+  gem "yamatanooroti", github: "ruby/yamatanooroti"
 end
 
 gem "stackprof" if is_unix && !is_truffleruby

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -39,49 +39,44 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
   end
 
   def test_launch
-    write_irbrc <<~'LINES'
-      puts 'start IRB'
-    LINES
-    start_terminal(25, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(25, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     write(<<~EOC)
       'Hello, World!'
     EOC
-    close
     assert_screen(<<~EOC)
-      start IRB
       irb(main):001> 'Hello, World!'
       => "Hello, World!"
       irb(main):002>
     EOC
+    close
   end
 
   def test_configuration_file_is_skipped_with_dash_f
     write_irbrc <<~'LINES'
       puts '.irbrc file should be ignored when -f is used'
     LINES
-    start_terminal(25, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb -f}, startup_message: '')
+    start_terminal(25, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb -f}, startup_message: /irb\(main\)/)
     write(<<~EOC)
       'Hello, World!'
     EOC
-    close
     assert_screen(<<~EOC)
       irb(main):001> 'Hello, World!'
       => "Hello, World!"
       irb(main):002>
     EOC
+    close
   end
 
   def test_configuration_file_is_skipped_with_dash_f_for_nested_sessions
     write_irbrc <<~'LINES'
       puts '.irbrc file should be ignored when -f is used'
     LINES
-    start_terminal(25, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb -f}, startup_message: '')
+    start_terminal(25, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb -f}, startup_message: /irb\(main\)/)
     write(<<~EOC)
       'Hello, World!'
       binding.irb
       exit!
     EOC
-    close
     assert_screen(<<~EOC)
       irb(main):001> 'Hello, World!'
       => "Hello, World!"
@@ -89,13 +84,11 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       irb(main):003> exit!
       irb(main):001>
     EOC
+    close
   end
 
   def test_nomultiline
-    write_irbrc <<~'LINES'
-      puts 'start IRB'
-    LINES
-    start_terminal(25, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb --nomultiline}, startup_message: 'start IRB')
+    start_terminal(25, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb --nomultiline}, startup_message: /irb\(main\)/)
     write(<<~EOC)
       if true
       if false
@@ -105,9 +98,7 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       end
       end
     EOC
-    close
     assert_screen(<<~EOC)
-      start IRB
       irb(main):001> if true
       irb(main):002*   if false
       irb(main):003*     a = "hello
@@ -118,13 +109,11 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       => nil
       irb(main):008>
     EOC
+    close
   end
 
   def test_multiline_paste
-    write_irbrc <<~'LINES'
-      puts 'start IRB'
-    LINES
-    start_terminal(25, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(25, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     write(<<~EOC)
       class A
         def inspect; '#<A>'; end
@@ -139,9 +128,7 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
        .b
       .itself
     EOC
-    close
     assert_screen(<<~EOC)
-      start IRB
       irb(main):001* class A
       irb(main):002*   def inspect; '#<A>'; end
       irb(main):003*   def a; self; end
@@ -159,13 +146,11 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       => true
       irb(main):013>
     EOC
+    close
   end
 
   def test_evaluate_each_toplevel_statement_by_multiline_paste
-    write_irbrc <<~'LINES'
-      puts 'start IRB'
-    LINES
-    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     write(<<~EOC)
       class A
         def inspect; '#<A>'; end
@@ -193,9 +178,7 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
         &.b()
       .itself
     EOC
-    close
     assert_screen(<<~EOC)
-      start IRB
       irb(main):001* class A
       irb(main):002*   def inspect; '#<A>'; end
       irb(main):003*   def b; self; end
@@ -230,36 +213,28 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
       => #<A>
       irb(main):026>
     EOC
+    close
   end
 
   def test_symbol_with_backtick
-    write_irbrc <<~'LINES'
-      puts 'start IRB'
-    LINES
-    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     write(<<~EOC)
       :`
     EOC
-    close
     assert_screen(<<~EOC)
-      start IRB
       irb(main):001> :`
       => :`
       irb(main):002>
     EOC
+    close
   end
 
   def test_autocomplete_with_multiple_doc_namespaces
-    write_irbrc <<~'LINES'
-      puts 'start IRB'
-    LINES
-    start_terminal(3, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(3, 50, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     write("{}.__id_")
     write("\C-i")
-    sleep 0.2
+    assert_screen(/irb\(main\):001> {}\.__id__\n                }\.__id__(?:Press )?/)
     close
-    screen = result.join("\n").sub(/\n*\z/, "\n")
-    assert_match(/start\ IRB\nirb\(main\):001> {}\.__id__\n                }\.__id__(?:Press )?/, screen)
   end
 
   def test_autocomplete_with_showdoc_in_gaps_on_narrow_screen_right
@@ -273,31 +248,27 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
         :PROMPT_C => "%03n> "
       }
       IRB.conf[:PROMPT_MODE] = :MY_PROMPT
-      puts 'start IRB'
     LINES
-    start_terminal(4, 19, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(4, 19, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /001>/)
     write("IR")
     write("\C-i")
-    sleep 0.2
-    close
 
     # This is because on macOS we display different shortcut for displaying the full doc
     # 'O' is for 'Option' and 'A' is for 'Alt'
     if RUBY_PLATFORM =~ /darwin/
       assert_screen(<<~EOC)
-        start IRB
         001> IRB
              IRBPress Opti
                 IRB
       EOC
     else
       assert_screen(<<~EOC)
-        start IRB
         001> IRB
              IRBPress Alt+
                 IRB
       EOC
     end
+    close
   end
 
   def test_autocomplete_with_showdoc_in_gaps_on_narrow_screen_left
@@ -311,154 +282,129 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
         :PROMPT_C => "%03n> "
       }
       IRB.conf[:PROMPT_MODE] = :MY_PROMPT
-      puts 'start IRB'
     LINES
-    start_terminal(4, 12, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(4, 12, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /001>/)
     write("IR")
     write("\C-i")
-    sleep 0.2
-    close
     assert_screen(<<~EOC)
-      start IRB
       001> IRB
       PressIRB
       IRB
     EOC
+    close
   end
 
   def test_assignment_expression_truncate
-    write_irbrc <<~'LINES'
-      puts 'start IRB'
-    LINES
-    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     # Assignment expression code that turns into non-assignment expression after evaluation
     code = "a /'/i if false; a=1; x=1000.times.to_a#'.size"
     write(code + "\n")
-    close
     assert_screen(<<~EOC)
-      start IRB
       irb(main):001> #{code}
       =>
       [0,
       ...
       irb(main):002>
     EOC
+    close
   end
 
   def test_ctrl_c_is_handled
-    write_irbrc <<~'LINES'
-      puts 'start IRB'
-    LINES
-    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     # Assignment expression code that turns into non-assignment expression after evaluation
     write("\C-c")
-    close
     assert_screen(<<~EOC)
-      start IRB
       irb(main):001>
       ^C
       irb(main):001>
     EOC
+    close
   end
 
   def test_show_cmds_with_pager_can_quit_with_ctrl_c
-    write_irbrc <<~'LINES'
-      puts 'start IRB'
-    LINES
-    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     write("help\n")
     write("G") # move to the end of the screen
     write("\C-c") # quit pager
     write("'foo' + 'bar'\n") # eval something to make sure IRB resumes
-    close
 
-    screen = result.join("\n").sub(/\n*\z/, "\n")
-    # IRB::Abort should be rescued
-    assert_not_match(/IRB::Abort/, screen)
     # IRB should resume
-    assert_match(/foobar/, screen)
+    assert_screen(/foobar/)
+    # IRB::Abort should be rescued
+    assert_screen(/\A(?!IRB::Abort)/)
+    close
   end
 
   def test_pager_page_content_pages_output_when_it_does_not_fit_in_the_screen_because_of_total_length
     write_irbrc <<~'LINES'
-      puts 'start IRB'
       require "irb/pager"
     LINES
-    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     write("IRB::Pager.page_content('a' * (80 * 8))\n")
     write("'foo' + 'bar'\n") # eval something to make sure IRB resumes
-    close
 
-    screen = result.join("\n").sub(/\n*\z/, "\n")
-    assert_match(/a{80}/, screen)
+    assert_screen(/a{80}/)
     # because pager is invoked, foobar will not be evaluated
-    assert_not_match(/foobar/, screen)
+    assert_screen(/\A(?!foobar)/)
+    close
   end
 
   def test_pager_page_content_pages_output_when_it_does_not_fit_in_the_screen_because_of_screen_height
     write_irbrc <<~'LINES'
-      puts 'start IRB'
       require "irb/pager"
     LINES
-    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     write("IRB::Pager.page_content('a\n' * 8)\n")
     write("'foo' + 'bar'\n") # eval something to make sure IRB resumes
-    close
 
-    screen = result.join("\n").sub(/\n*\z/, "\n")
-    assert_match(/(a\n){8}/, screen)
+    assert_screen(/(a\n){8}/)
     # because pager is invoked, foobar will not be evaluated
-    assert_not_match(/foobar/, screen)
+    assert_screen(/\A(?!foobar)/)
+    close
   end
 
   def test_pager_page_content_doesnt_page_output_when_it_fits_in_the_screen
     write_irbrc <<~'LINES'
-      puts 'start IRB'
       require "irb/pager"
     LINES
-    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     write("IRB::Pager.page_content('a' * (80 * 7))\n")
     write("'foo' + 'bar'\n") # eval something to make sure IRB resumes
-    close
 
-    screen = result.join("\n").sub(/\n*\z/, "\n")
-    assert_match(/a{80}/, screen)
+    assert_screen(/a{80}/)
     # because pager is not invoked, foobar will be evaluated
-    assert_match(/foobar/, screen)
+    assert_screen(/foobar/)
+    close
   end
 
   def test_long_evaluation_output_is_paged
     write_irbrc <<~'LINES'
-      puts 'start IRB'
       require "irb/pager"
     LINES
-    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     write("'a' * 80 * 11\n")
     write("'foo' + 'bar'\n") # eval something to make sure IRB resumes
-    close
 
-    screen = result.join("\n").sub(/\n*\z/, "\n")
-    assert_match(/(a{80}\n){8}/, screen)
+    assert_screen(/(a{80}\n){8}/)
     # because pager is invoked, foobar will not be evaluated
-    assert_not_match(/foobar/, screen)
+    assert_screen(/\A(?!foobar)/)
+    close
   end
 
   def test_long_evaluation_output_is_preserved_after_paging
     write_irbrc <<~'LINES'
-      puts 'start IRB'
       require "irb/pager"
     LINES
-    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: 'start IRB')
+    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     write("'a' * 80 * 11\n")
     write("q") # quit pager
     write("'foo' + 'bar'\n") # eval something to make sure IRB resumes
-    close
 
-    screen = result.join("\n").sub(/\n*\z/, "\n")
     # confirm pager has exited
-    assert_match(/foobar/, screen)
+    assert_screen(/foobar/)
     # confirm output is preserved
-    assert_match(/(a{80}\n){6}/, screen)
+    assert_screen(/(a{80}\n){6}/)
+    close
   end
 
   def test_debug_integration_hints_debugger_commands
@@ -467,21 +413,19 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     LINES
     script = Tempfile.create(["debug", ".rb"])
     script.write <<~RUBY
-      puts 'start IRB'
       binding.irb
     RUBY
     script.close
-    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{script.to_path}}, startup_message: 'start IRB')
+    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{script.to_path}}, startup_message: /irb\(main\)/)
     write("debug\n")
     write("pp 1\n")
     write("pp 1")
-    close
 
-    screen = result.join("\n").sub(/\n*\z/, "\n")
     # submitted input shouldn't contain hint
-    assert_include(screen, "irb:rdbg(main):002> pp 1\n")
+    assert_screen(/irb:rdbg\(main\):002> pp 1\n/)
     # unsubmitted input should contain hint
-    assert_include(screen, "irb:rdbg(main):003> pp 1 # debug command\n")
+    assert_screen(/irb:rdbg\(main\):003> pp 1 # debug command\n/)
+    close
   ensure
     File.unlink(script) if script
   end
@@ -492,17 +436,14 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     LINES
     script = Tempfile.create(["debug", ".rb"])
     script.write <<~RUBY
-      puts 'start IRB'
       binding.irb
     RUBY
     script.close
-    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{script.to_path}}, startup_message: 'start IRB')
+    start_terminal(40, 80, %W{ruby -I#{@pwd}/lib #{script.to_path}}, startup_message: /irb\(main\)/)
     write("debug\n")
     write("foo")
+    assert_screen(/irb:rdbg\(main\):002> foo\n/)
     close
-
-    screen = result.join("\n").sub(/\n*\z/, "\n")
-    assert_include(screen, "irb:rdbg(main):002> foo\n")
   ensure
     File.unlink(script) if script
   end


### PR DESCRIPTION
Makes test_rendering faster. Yamatanooroti's wait time is reduced from 0.1 sec to 0.01 sec
`test_yamatanooroti(vterm-yamatanooroti head)`: 37.58 sec → 10.72 sec


## startup_message
We don't need `puts 'start IRB'`. It does not mean IRB is ready for input. We should check the prompt with `startup_message: /irb\(main\)/`

## close
It does not only close_input but read few bytes and terminates process immediately.
Calling close before assert_screen sometimes terminates process before reading the last output.
