### PR TITLE
Remove KEYWORD_ALIASES which handled special alias name of irb_break irb_catch and irb_next command

### DIFF
--- a/lib/irb/command/help.rb
+++ b/lib/irb/command/help.rb
@@ -39,7 +39,7 @@ module IRB
 
         help_cmds = commands_grouped_by_categories.delete("Help")
         no_category_cmds = commands_grouped_by_categories.delete("No category")
-        aliases = irb_context.instance_variable_get(:@user_aliases).map do |alias_name, target|
+        aliases = irb_context.instance_variable_get(:@command_aliases).map do |alias_name, target|
           { display_name: alias_name, description: "Alias for `#{target}`" }
         end
 

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -150,24 +150,13 @@ module IRB
       end
 
       @user_aliases = IRB.conf[:COMMAND_ALIASES].dup
-      @command_aliases = @user_aliases.merge(KEYWORD_ALIASES)
+      @command_aliases = @user_aliases.dup
     end
 
     private def term_interactive?
       return true if ENV['TEST_IRB_FORCE_INTERACTIVE']
       STDIN.tty? && ENV['TERM'] != 'dumb'
     end
-
-    # because all input will eventually be evaluated as Ruby code,
-    # command names that conflict with Ruby keywords need special workaround
-    # we can remove them once we implemented a better command system for IRB
-    KEYWORD_ALIASES = {
-      :break => :irb_break,
-      :catch => :irb_catch,
-      :next => :irb_next,
-    }.freeze
-
-    private_constant :KEYWORD_ALIASES
 
     def use_tracer=(val)
       require_relative "ext/tracer" if val

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -149,8 +149,7 @@ module IRB
         @newline_before_multiline_output = true
       end
 
-      @user_aliases = IRB.conf[:COMMAND_ALIASES].dup
-      @command_aliases = @user_aliases.dup
+      @command_aliases = IRB.conf[:COMMAND_ALIASES].dup
     end
 
     private def term_interactive?

--- a/lib/irb/default_commands.rb
+++ b/lib/irb/default_commands.rb
@@ -181,9 +181,15 @@ module IRB
       [:edit, NO_OVERRIDE]
     )
 
-    _register_with_aliases(:irb_break, Command::Break)
-    _register_with_aliases(:irb_catch, Command::Catch)
-    _register_with_aliases(:irb_next, Command::Next)
+    _register_with_aliases(:irb_break, Command::Break,
+      [:break, OVERRIDE_ALL]
+    )
+    _register_with_aliases(:irb_catch, Command::Catch,
+      [:catch, OVERRIDE_PRIVATE_ONLY]
+    )
+    _register_with_aliases(:irb_next, Command::Next,
+      [:next, OVERRIDE_ALL]
+    )
     _register_with_aliases(:irb_delete, Command::Delete,
       [:delete, NO_OVERRIDE]
     )


### PR DESCRIPTION
This comment is outdated. We don't need KEYWORD_ALIASES anymore.
```ruby
# because all input will eventually be evaluated as Ruby code,
# command names that conflict with Ruby keywords need special workaround
# we can remove them once we implemented a better command system for IRB
KEYWORD_ALIASES = { ... }
```

## [:catch, OVERRIDE_PRIVATE_ONLY]
Just like `exit` and `exit!`, `catch` is already defined as a private method of Object.
IRB's command usually sets OVERRIDE_PRIVATE_ONLY in this case.

## [:next , OVERRIDE_ALL], [:break , OVERRIDE_ALL]
both `next a` `break a` are always syntax error. These input should be always treated as a command even if a method with the same name is defined.