### PR TITLE
Use InstructionSequence#script_lines to get method source

### DIFF
--- a/lib/irb/source_finder.rb
+++ b/lib/irb/source_finder.rb
@@ -100,7 +100,7 @@ module IRB
         Source.new(file, line)
       elsif method
         # Method defined with eval, probably in IRB session
-        source = RubyVM::AbstractSyntaxTree.of(method)&.source rescue nil
+        source = RubyVM::InstructionSequence.of(method)&.script_lines&.join rescue nil
         Source.new(file, line, source)
       end
     rescue EvaluationError


### PR DESCRIPTION
It works with both prism and parse.y

Fixes ci failure
```ruby
irb(main):001* def foo
irb(main):002*   bar
irb(main):003> end
=> :foo
irb(main):004> RubyVM::AbstractSyntaxTree.of(method("foo")).source
cannot get AST for ISEQ compiled by prism (RuntimeError)
irb(main):005> RubyVM::InstructionSequence.of(method("foo")).script_lines
=> ["def foo\n", "  bar\n", "end\n", ""]
irb(main):006> `ruby -v`
=> "ruby 3.4.0dev (2024-09-16T15:53:56Z master 1e52dde82a) +PRISM [x86_64-linux]\n"
```
