### PR TITLE
Fix debug command in nomultiline mode

### DIFF
--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -649,7 +649,7 @@ module IRB
       end
     end
 
-    def colorize_code(input, complete:)
+    def colorize_input(input, complete:)
       if IRB.conf[:USE_COLORIZE] && IRB::Color.colorable?
         lvars = local_variables || []
         if parse_command(input)

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -649,6 +649,21 @@ module IRB
       end
     end
 
+    def colorize_code(input, complete:)
+      if IRB.conf[:USE_COLORIZE] && IRB::Color.colorable?
+        lvars = local_variables || []
+        if parse_command(input)
+          name, sep, arg = input.split(/(\s+)/, 2)
+          arg = IRB::Color.colorize_code(arg, complete: complete, local_variables: lvars)
+          "#{IRB::Color.colorize(name, [:BOLD])}\e[m#{sep}#{arg}"
+        else
+          IRB::Color.colorize_code(input, complete: complete, local_variables: lvars)
+        end
+      else
+        Reline::Unicode.escape_for_print(input)
+      end
+    end
+
     def inspect_last_value # :nodoc:
       @inspect_method.inspect_value(@last_value)
     end

--- a/lib/irb/debug.rb
+++ b/lib/irb/debug.rb
@@ -57,20 +57,18 @@ module IRB
           DEBUGGER__::ThreadClient.prepend(SkipPathHelperForIRB)
         end
 
-        if !@output_modifier_defined && !DEBUGGER__::CONFIG[:no_hint] && irb.context.io.is_a?(RelineInputMethod)
-          Reline.output_modifier_proc = proc do |output, complete:|
-            unless output.strip.empty?
-              cmd = output.split(/\s/, 2).first
+        if !DEBUGGER__::CONFIG[:no_hint] && irb.context.io.is_a?(RelineInputMethod)
+          Reline.output_modifier_proc = proc do |input, complete:|
+            unless input.strip.empty?
+              cmd = input.split(/\s/, 2).first
 
               if !complete && DEBUGGER__.commands.key?(cmd)
-                output = output.sub(/\n$/, " # debug command\n")
+                input = input.sub(/\n$/, " # debug command\n")
               end
             end
 
-            IRB.CurrentContext.colorize_code(output, complete: complete)
+            irb.context.colorize_input(input, complete: complete)
           end
-
-          @output_modifier_defined = true
         end
 
         true

--- a/lib/irb/debug.rb
+++ b/lib/irb/debug.rb
@@ -57,9 +57,7 @@ module IRB
           DEBUGGER__::ThreadClient.prepend(SkipPathHelperForIRB)
         end
 
-        if !@output_modifier_defined && !DEBUGGER__::CONFIG[:no_hint]
-          irb_output_modifier_proc = Reline.output_modifier_proc
-
+        if !@output_modifier_defined && !DEBUGGER__::CONFIG[:no_hint] && irb.context.io.is_a?(RelineInputMethod)
           Reline.output_modifier_proc = proc do |output, complete:|
             unless output.strip.empty?
               cmd = output.split(/\s/, 2).first
@@ -69,7 +67,7 @@ module IRB
               end
             end
 
-            irb_output_modifier_proc.call(output, complete: complete)
+            IRB.CurrentContext.colorize_code(output, complete: complete)
           end
 
           @output_modifier_defined = true

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -265,8 +265,8 @@ module IRB
         @completion_params = [preposing, target, postposing, bind]
         @completor.completion_candidates(preposing, target, postposing, bind: bind)
       }
-      Reline.output_modifier_proc = proc do |output, complete:|
-        IRB.CurrentContext.colorize_code(output, complete: complete)
+      Reline.output_modifier_proc = proc do |input, complete:|
+        IRB.CurrentContext.colorize_input(input, complete: complete)
       end
       Reline.dig_perfect_match_proc = ->(matched) { display_document(matched) }
       Reline.autocompletion = IRB.conf[:USE_AUTOCOMPLETE]

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -265,24 +265,9 @@ module IRB
         @completion_params = [preposing, target, postposing, bind]
         @completor.completion_candidates(preposing, target, postposing, bind: bind)
       }
-      Reline.output_modifier_proc =
-        if IRB.conf[:USE_COLORIZE]
-          proc do |output, complete: |
-            next unless IRB::Color.colorable?
-            lvars = IRB.CurrentContext&.local_variables || []
-            if IRB.CurrentContext&.parse_command(output)
-              name, sep, arg = output.split(/(\s+)/, 2)
-              arg = IRB::Color.colorize_code(arg, complete: complete, local_variables: lvars)
-              "#{IRB::Color.colorize(name, [:BOLD])}\e[m#{sep}#{arg}"
-            else
-              IRB::Color.colorize_code(output, complete: complete, local_variables: lvars)
-            end
-          end
-        else
-          proc do |output|
-            Reline::Unicode.escape_for_print(output)
-          end
-        end
+      Reline.output_modifier_proc = proc do |output, complete:|
+        IRB.CurrentContext.colorize_code(output, complete: complete)
+      end
       Reline.dig_perfect_match_proc = ->(matched) { display_document(matched) }
       Reline.autocompletion = IRB.conf[:USE_AUTOCOMPLETE]
 


### PR DESCRIPTION
Fixes #909 and #1003

Fix this bug
```ruby
% irb --readline
irb(main):001> binding.irb
irb(main):001> debug
/Users/tomoya.ishida/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/irb-1.14.0/lib/irb/debug.rb:72:in `block in setup': undefined method `call' for nil (NoMethodError)

            irb_output_modifier_proc.call(output, complete: complete)
                                    ^^^^^
```

rendering test conflicts with #1001

