### PR TITLE
Use correct binding in debug mode

### DIFF
--- a/lib/irb/debug/ui.rb
+++ b/lib/irb/debug/ui.rb
@@ -56,7 +56,7 @@ module IRB
       def readline _
         setup_interrupt do
           tc = DEBUGGER__::SESSION.instance_variable_get(:@tc)
-          cmd = @irb.debug_readline(tc.current_frame.binding || TOPLEVEL_BINDING)
+          cmd = @irb.debug_readline(tc.current_frame.eval_binding || TOPLEVEL_BINDING)
 
           case cmd
           when nil # when user types C-d

--- a/test/irb/test_debugger_integration.rb
+++ b/test/irb/test_debugger_integration.rb
@@ -365,6 +365,23 @@ module TestIRB
       assert_include(output, "InputMethod: RelineInputMethod")
     end
 
+    def test_irb_command_can_check_local_variables
+      write_ruby <<~'ruby'
+        binding.irb
+      ruby
+
+      output = run_ruby_file do
+        type "debug"
+        type 'foobar = IRB'
+        type "show_source foobar.start"
+        type "show_source = 'Foo'"
+        type "show_source + 'Bar'"
+        type "continue"
+      end
+      assert_include(output, "def start(ap_path = nil)")
+      assert_include(output, '"FooBar"')
+    end
+
     def test_help_command_is_delegated_to_the_debugger
       write_ruby <<~'ruby'
         binding.irb


### PR DESCRIPTION
Debug evaluates code in `frame.eval_binding`, not `frame.binding`
```ruby
irb(main):001> debug
irb:rdbg(main):002> tc = DEBUGGER__::SESSION.instance_variable_get(:@tc)
#<DBG:TC 1:running@a.rb:1:in `<main>'>
irb:rdbg(main):003> foobar = 1
1
irb:rdbg(main):004> tc.current_frame.binding.local_variables
[:_]
irb:rdbg(main):005> tc.current_frame.eval_binding.local_variables
[:foobar, :tc, :_]
```

Fixes this command and colorization bug. (left: master branch, right: this pull request)
![debug_binding_before_after](https://github.com/user-attachments/assets/c99a3c35-5cc5-4367-9362-f037883cd0dc)


`eval_binding` is added in debug-1.0.0.rc1 https://github.com/ruby/debug/commit/4c873939864ef650cd135ba1fb1bd7fe123f27ac, 
