### PR TITLE
Use proper locale in history encoding test

### DIFF
--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -149,7 +149,7 @@ module TestIRB
     def test_history_different_encodings
       IRB.conf[:SAVE_HISTORY] = 2
       Encoding.default_external = Encoding::US_ASCII
-      locale = IRB::Locale.new("C")
+      locale = IRB::Locale.new("en_US.ASCII")
       assert_history(<<~EXPECTED_HISTORY.encode(Encoding::US_ASCII), <<~INITIAL_HISTORY.encode(Encoding::UTF_8), <<~INPUT, locale: locale)
         ????
         exit


### PR DESCRIPTION
```ruby
$ LANG=C irb
irb(main):001> IRB.conf[:LC_MESSAGES].encoding
=> "US-ASCII"
```

To emulate this case in history encoding test, (which is the original intention of this test)
`IRB::Locale.new("en_US.ASCII").encoding #=> #<Encoding:US-ASCII>` is better than `IRB::Locale.new("C").encoding #=> #<Encoding:UTF-8>`

This fix will avoid test failure in Reline's un-opened pull request.