### PR TITLE
Change default completor from regexp to type-completor if RUBY_VERSION>=3.4

### DIFF
--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -80,7 +80,7 @@ module IRB # :nodoc:
     @CONF[:USE_SINGLELINE] = false unless defined?(ReadlineInputMethod)
     @CONF[:USE_COLORIZE] = (nc = ENV['NO_COLOR']).nil? || nc.empty?
     @CONF[:USE_AUTOCOMPLETE] = ENV.fetch("IRB_USE_AUTOCOMPLETE", "true") != "false"
-    @CONF[:COMPLETOR] = ENV.fetch("IRB_COMPLETOR", "regexp").to_sym
+    @CONF[:COMPLETOR] = ENV["IRB_COMPLETOR"]&.to_sym
     @CONF[:INSPECT_MODE] = true
     @CONF[:USE_TRACER] = false
     @CONF[:USE_LOADER] = false

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -705,6 +705,8 @@ module TestIRB
     def test_build_completor
       verbose, $VERBOSE = $VERBOSE, nil
       original_completor = IRB.conf[:COMPLETOR]
+      IRB.conf[:COMPLETOR] = nil
+      assert_match /IRB::(Regexp|Type)Completor/, @context.send(:build_completor).class.name
       IRB.conf[:COMPLETOR] = :regexp
       assert_equal 'IRB::RegexpCompletor', @context.send(:build_completor).class.name
       IRB.conf[:COMPLETOR] = :unknown

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -167,9 +167,10 @@ module TestIRB
       orig_use_autocomplete_env = ENV['IRB_COMPLETOR']
       orig_use_autocomplete_conf = IRB.conf[:COMPLETOR]
 
+      # Default value is nil: auto-detect
       ENV['IRB_COMPLETOR'] = nil
       IRB.setup(__FILE__)
-      assert_equal(:regexp, IRB.conf[:COMPLETOR])
+      assert_equal(nil, IRB.conf[:COMPLETOR])
 
       ENV['IRB_COMPLETOR'] = 'regexp'
       IRB.setup(__FILE__)
@@ -193,10 +194,12 @@ module TestIRB
 
     def test_completor_setup_with_argv
       orig_completor_conf = IRB.conf[:COMPLETOR]
+      orig_completor_env = ENV['IRB_COMPLETOR']
+      ENV['IRB_COMPLETOR'] = nil
 
-      # Default is :regexp
+      # Default value is nil: auto-detect
       IRB.setup(__FILE__, argv: [])
-      assert_equal :regexp, IRB.conf[:COMPLETOR]
+      assert_equal nil, IRB.conf[:COMPLETOR]
 
       IRB.setup(__FILE__, argv: ['--type-completor'])
       assert_equal :type, IRB.conf[:COMPLETOR]
@@ -205,6 +208,7 @@ module TestIRB
       assert_equal :regexp, IRB.conf[:COMPLETOR]
     ensure
       IRB.conf[:COMPLETOR] = orig_completor_conf
+      ENV['IRB_COMPLETOR'] = orig_completor_env
     end
 
     def test_noscript

--- a/test/irb/test_type_completor.rb
+++ b/test/irb/test_type_completor.rb
@@ -27,6 +27,22 @@ module TestIRB
       binding
     end
 
+    def test_build_completor
+      IRB.init_config(nil)
+      verbose, $VERBOSE = $VERBOSE, nil
+      original_completor = IRB.conf[:COMPLETOR]
+      workspace = IRB::WorkSpace.new(Object.new)
+      @context = IRB::Context.new(nil, workspace, TestInputMethod.new)
+      IRB.conf[:COMPLETOR] = nil
+      expected_default_completor = RUBY_VERSION >= '3.4' ? 'IRB::TypeCompletor' : 'IRB::RegexpCompletor'
+      assert_equal expected_default_completor, @context.send(:build_completor).class.name
+      IRB.conf[:COMPLETOR] = :type
+      assert_equal 'IRB::TypeCompletor', @context.send(:build_completor).class.name
+    ensure
+      $VERBOSE = verbose
+      IRB.conf[:COMPLETOR] = original_completor
+    end
+
     def assert_completion(preposing, target, binding: empty_binding, include: nil, exclude: nil)
       raise ArgumentError if include.nil? && exclude.nil?
       candidates = @completor.completion_candidates(preposing, target, '', bind: binding)


### PR DESCRIPTION
In Ruby >= 3.4, ReplTypeCompletor is a bundled gem, installed by default.
This pull request changes the default completor to type-completor if `RUBY_VERSION >= 3.4`.
If ReplTypeCompletor is not available (not installed or not added to Gemfile), fallbacks to regexp-baased completion.
The default isstill :regexp if `RUBY_VERSION < 3.4`

## Run with bundler
With bundler and when repl_type_completor is not added to Gemfile, IRB will use regexp-based completion.
IRB shows warning message only If `--type-completor` or `IRB.conf[:COMPLETOR] = :type` is explicitly specified.

```
$ ruby -v
ruby 3.4.0dev

$ irb
irb(main):001> irb_info
(TypeCompletor)

$ echo "gem 'irb', path: 'path/to/irb'" > Gemfile

$ bundle exec irb
(no waarning)
irb(main):001> irb_info
(RegexpCompletor)

$ bundle exec irb --type-completor
TypeCompletor requires `gem repl_type_completor`: cannot load such file -- repl_type_completor
irb(main):001> irb_info
(RegexpCompletor)
```

## Restriction with rdbg

ReplTypeCompletor uses background thread to load RBS type information which could take time. 
Debug gem stops all other threads, so if IRB enters debug mode before loading RBS completes, type completor can't use type information.
Even without type information, type completor can still complete as good or better than regexp-based completion.
