### PR TITLE
Hash#inspect style has changed in ruby 3.4

### DIFF
--- a/test/irb/test_helper_method.rb
+++ b/test/irb/test_helper_method.rb
@@ -76,7 +76,8 @@ module TestIRB
         type "exit"
       end
 
-      assert_include(output, '["required", "optional", ["splat"], "required", "optional", {:a=>1, :b=>2}, "block"]')
+      optional = {a: 1, b: 2}
+      assert_include(output, %[["required", "optional", ["splat"], "required", "optional", #{optional.inspect}, "block"]])
     end
 
     def test_helper_method_injection_can_happen_after_irb_require

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -155,8 +155,8 @@ module TestIRB
         type 'exit'
       end
 
-      assert_include output, '{:context_changed=>true}'
-      assert_include output, '{:context_restored=>true}'
+      assert_include output, {context_changed: true}.inspect
+      assert_include output, {context_restored: true}.inspect
     end
   end
 


### PR DESCRIPTION
[[Bug #20433]](https://bugs.ruby-lang.org/issues/20433)