### PR TITLE
History refactors

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1004,9 +1004,10 @@ module IRB
       prev_context = conf[:MAIN_CONTEXT]
       conf[:MAIN_CONTEXT] = context
 
-      save_history = !in_nested_session && History.save_history? && context.io.support_history_saving?
+      load_history = !in_nested_session && context.io.support_history_saving?
+      save_history = load_history && History.save_history?
 
-      if save_history
+      if load_history
         context.io.load_history
       end
 

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -14,6 +14,7 @@ require_relative "irb/default_commands"
 
 require_relative "irb/ruby-lex"
 require_relative "irb/statement"
+require_relative "irb/history"
 require_relative "irb/input-method"
 require_relative "irb/locale"
 require_relative "irb/color"
@@ -972,7 +973,7 @@ module IRB
       # debugger.
       input = nil
       forced_exit = catch(:IRB_EXIT) do
-        if IRB.conf[:SAVE_HISTORY] && context.io.support_history_saving?
+        if History.save_history? && context.io.support_history_saving?
           # Previous IRB session's history has been saved when `Irb#run` is exited We need
           # to make sure the saved history is not saved again by resetting the counter
           context.io.reset_history_counter
@@ -1003,7 +1004,7 @@ module IRB
       prev_context = conf[:MAIN_CONTEXT]
       conf[:MAIN_CONTEXT] = context
 
-      save_history = !in_nested_session && conf[:SAVE_HISTORY] && context.io.support_history_saving?
+      save_history = !in_nested_session && History.save_history? && context.io.support_history_saving?
 
       if save_history
         context.io.load_history

--- a/lib/irb/history.rb
+++ b/lib/irb/history.rb
@@ -19,6 +19,15 @@ module IRB
         save_history.negative?
       end
 
+      # Might be nil when HOME and XDG_CONFIG_HOME are not available.
+      def history_file
+        if (history_file = IRB.conf[:HISTORY_FILE])
+          File.expand_path(history_file)
+        else
+          IRB.rc_file("_history")
+        end
+      end
+
       private
 
       def save_history_max
@@ -38,74 +47,74 @@ module IRB
     end
 
     def load_history
+      history_file = History.history_file
+      return unless File.exist?(history_file.to_s)
+
       history = self.class::HISTORY
 
-      if history_file = IRB.conf[:HISTORY_FILE]
-        history_file = File.expand_path(history_file)
+      File.open(history_file, "r:#{IRB.conf[:LC_MESSAGES].encoding}") do |f|
+        f.each { |l|
+          l = l.chomp
+          if self.class == RelineInputMethod and history.last&.end_with?("\\")
+            history.last.delete_suffix!("\\")
+            history.last << "\n" << l
+          else
+            history << l
+          end
+        }
       end
-      history_file = IRB.rc_file("_history") unless history_file
-      if history_file && File.exist?(history_file)
-        File.open(history_file, "r:#{IRB.conf[:LC_MESSAGES].encoding}") do |f|
-          f.each { |l|
-            l = l.chomp
-            if self.class == RelineInputMethod and history.last&.end_with?("\\")
-              history.last.delete_suffix!("\\")
-              history.last << "\n" << l
-            else
-              history << l
-            end
-          }
-        end
-        @loaded_history_lines = history.size
-        @loaded_history_mtime = File.mtime(history_file)
-      end
+      @loaded_history_lines = history.size
+      @loaded_history_mtime = File.mtime(history_file)
     end
 
     def save_history
+      return unless History.save_history?
+      return unless (history_file = History.history_file)
+      unless ensure_history_file_writable(history_file)
+        warn <<~WARN
+          Can't write history to #{History.history_file.inspect} due to insufficient permissions.
+          Please verify the value of `IRB.conf[:HISTORY_FILE]`. Ensure the folder exists and that both the folder and file (if it exists) are writable.
+        WARN
+        return
+      end
+
       history = self.class::HISTORY.to_a
 
-      if History.save_history?
-        if history_file = IRB.conf[:HISTORY_FILE]
-          history_file = File.expand_path(history_file)
-        end
-        history_file = IRB.rc_file("_history") unless history_file
+      if File.exist?(history_file) &&
+          File.mtime(history_file) != @loaded_history_mtime
+        history = history[@loaded_history_lines..-1] if @loaded_history_lines
+        append_history = true
+      end
 
-        # When HOME and XDG_CONFIG_HOME are not available, history_file might be nil
-        return unless history_file
+      File.open(history_file, (append_history ? "a" : "w"), 0o600, encoding: IRB.conf[:LC_MESSAGES]&.encoding) do |f|
+        hist = history.map { |l| l.scrub.split("\n").join("\\\n") }
 
-        # Change the permission of a file that already exists[BUG #7694]
-        begin
-          if File.stat(history_file).mode & 066 != 0
-            File.chmod(0600, history_file)
-          end
-        rescue Errno::ENOENT
-        rescue Errno::EPERM
-          return
-        rescue
-          raise
+        unless append_history || History.infinite?
+          hist = hist.last(History.save_history)
         end
 
-        if File.exist?(history_file) &&
-           File.mtime(history_file) != @loaded_history_mtime
-          history = history[@loaded_history_lines..-1] if @loaded_history_lines
-          append_history = true
+        f.puts(hist)
+      end
+    end
+
+    private
+
+    # Returns boolean whether writing to +history_file+ will be possible.
+    # Permissions of already existing +history_file+ are changed to
+    # owner-only-readable if necessary [BUG #7694].
+    def ensure_history_file_writable(history_file)
+      history_file = Pathname.new(history_file)
+
+      return false unless history_file.dirname.writable?
+      return true unless history_file.exist?
+
+      begin
+        if history_file.stat.mode & 0o66 != 0
+          history_file.chmod 0o600
         end
-
-        pathname = Pathname.new(history_file)
-        unless Dir.exist?(pathname.dirname)
-          warn "Warning: The directory to save IRB's history file does not exist. Please double check `IRB.conf[:HISTORY_FILE]`'s value."
-          return
-        end
-
-        File.open(history_file, (append_history ? 'a' : 'w'), 0o600, encoding: IRB.conf[:LC_MESSAGES]&.encoding) do |f|
-          hist = history.map{ |l| l.scrub.split("\n").join("\\\n") }
-
-          unless append_history || History.infinite?
-            hist = hist.last(History.save_history)
-          end
-
-          f.puts(hist)
-        end
+        true
+      rescue Errno::EPERM # no permissions
+        false
       end
     end
   end

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -39,6 +39,21 @@ module TestIRB
       include IRB::HistorySavingAbility
     end
 
+    def test_history_dont_save
+      omit "Skip Editline" if /EditLine/n.match(Readline::VERSION)
+      IRB.conf[:SAVE_HISTORY] = nil
+      assert_history(<<~EXPECTED_HISTORY, <<~INITIAL_HISTORY, <<~INPUT)
+        1
+        2
+      EXPECTED_HISTORY
+        1
+        2
+      INITIAL_HISTORY
+        3
+        exit
+      INPUT
+    end
+
     def test_history_save_1
       omit "Skip Editline" if /EditLine/n.match(Readline::VERSION)
       IRB.conf[:SAVE_HISTORY] = 1

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -181,7 +181,7 @@ module TestIRB
       IRB.conf[:HISTORY_FILE] = "fake/fake/fake/history_file"
       io = TestInputMethodWithRelineHistory.new
 
-      assert_warn(/history file does not exist/) do
+      assert_warn(/ensure the folder exists/i) do
         io.save_history
       end
 


### PR DESCRIPTION
As part of #1012 I started looking into history some more and came up with some refactors around saving/loading history and the settings `SAVE_HISTORY` and `HISTORY_FILE`.

The main change is that this PR bundles history logic in a separate module `IRB::History`, with helpers like `save_history` (`IRB.conf[:SAVE_HISTORY]` as an int), `save_history?`, `infinite?` and `history_file`. Logic that currently is duplicated and/or not explicitly named as such.  
Furthermore, `IRB::HistorySavingAbility.save_history` is currently quite complex in that there's multiple returns - these are now all in the top of the method with more descriptive names.

### Changes in functionality

- permissions
  Anything that might prevent the file from being saved (folder doesn't exist, lacking permissions to folder or file), now results in a warning.  
  Currently, there's only a warning when the folder does not exist. Lacking folder-permissions (to write a new file) will result in an exception. Lacking folder/file permissions for an existing file currently result in silently not saving.

I did quite some git spelunking to see what issues lay behind the current code, and tested locally different scenarios to ensure that nothing gets deleted.

The PR is split into 2 commits  (save_history and history_file resp. changes) to aid reviewing. Let me know what's preferred for additional changes (additional commits or amending these commits, the latter can be noisy and hard to review). 

### (open) Issues

- should `conf.save_history`. and `conf.history_file` be 'aliases' for resp. `IRB::History.save_history` and `IRB::History.history_file`?   
  Pro: This way a user can more easily inspect what IRB will do, e.g. settings like `IRB.conf[:SAVE_HISTORY] = nil` are turned into `conf.save_history #=> 0`, and showing a clear path when `IRB.conf[:HISTORY_FILE] = nil`.
  Downside is that it might confuse as it's not what a user 'configged'.


PS I saw the hacktoberfest-label on the repo, this PR is not part of that, I'm not participating.

