### PR TITLE
Change debug test workaround to use ENV RUBY_DEBUG_TEST_UI

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -67,7 +67,9 @@ module IRB
     #
     # See IO#gets for more information.
     def gets
-      puts if @stdout.tty? # workaround for debug compatibility test
+      # Workaround for debug compatibility test https://github.com/ruby/debug/pull/1100
+      puts if ENV['RUBY_DEBUG_TEST_UI']
+
       print @prompt
       line = @stdin.gets
       @line[@line_no += 1] = line


### PR DESCRIPTION
Fixes #990
Use `ENV['RUBY_DEBUG_TEST_UI']` for test-only workaround.