### PR TITLE
Update setup/ruby used in gh-pages workflow because it is failing on ci

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Ruby
-        uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # v1.175.1
+        uses: ruby/setup-ruby@f26937343756480a8cb3ae1f623b9c8d89ed6984 # v1.196.0
         with:
           ruby-version: "3.3"
           bundler-cache: true


### PR DESCRIPTION
Deploy IRB documentation to GitHub Pages is failing from about two weeks ago.

https://github.com/ruby/irb/actions/runs/11311482138
```
Run ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c
  with:
    ruby-version: 3.3
    bundler-cache: true
Error: The current runner (ubuntu-[2](https://github.com/ruby/irb/actions/runs/11311482138/job/31457768381#step:3:2)4.04-x64) was detected as self-hosted because the platform does not match a GitHub-hosted runner image (or that image is deprecated and no longer supported).
```

Updated to latest. I'm not sure this fixes the failure it or not.