### PR TITLE
Suppress "literal string will be frozen in the future" warning

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1132,7 +1132,7 @@ module IRB
         return Statement::EmptyInput.new
       end
 
-      code.dup.force_encoding(@context.io.encoding)
+      code = code.dup.force_encoding(@context.io.encoding)
       if (command, arg = @context.parse_command(code))
         command_class = Command.load_command(command)
         Statement::Command.new(code, command_class, arg)

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1132,7 +1132,7 @@ module IRB
         return Statement::EmptyInput.new
       end
 
-      code.force_encoding(@context.io.encoding)
+      code.dup.force_encoding(@context.io.encoding)
       if (command, arg = @context.parse_command(code))
         command_class = Command.load_command(command)
         Statement::Command.new(code, command_class, arg)


### PR DESCRIPTION
Before change:

```console
$ ruby -W -I lib -e 'require "irb"; IRB.setup(nil); IRB::Irb.new.build_statement("1 + 2")'
/Users/zzz/src/github.com/ruby/irb/lib/irb.rb:1135: warning: literal string will be frozen in the future
```

After change:

```console
$ ruby -W -I lib -e 'require "irb"; IRB.setup(nil); IRB::Irb.new.build_statement("1 + 2")'
```