### PR TITLE
Disable autocompletions by default

### DIFF
--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -79,7 +79,7 @@ module IRB # :nodoc:
 
     @CONF[:USE_SINGLELINE] = false unless defined?(ReadlineInputMethod)
     @CONF[:USE_COLORIZE] = (nc = ENV['NO_COLOR']).nil? || nc.empty?
-    @CONF[:USE_AUTOCOMPLETE] = ENV.fetch("IRB_USE_AUTOCOMPLETE", "true") != "false"
+    @CONF[:USE_AUTOCOMPLETE] = ENV.fetch("IRB_USE_AUTOCOMPLETE", "false") != "false"
     @CONF[:COMPLETOR] = ENV["IRB_COMPLETOR"]&.to_sym
     @CONF[:INSPECT_MODE] = true
     @CONF[:USE_TRACER] = false

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -215,7 +215,7 @@ module TestIRB
     end
 
     def test_default_config
-      assert_equal(true, @context.use_autocomplete?)
+      assert_equal(false, @context.use_autocomplete?)
     end
 
     def test_echo_on_assignment

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -145,7 +145,7 @@ module TestIRB
 
       ENV['IRB_USE_AUTOCOMPLETE'] = nil
       IRB.setup(__FILE__)
-      assert IRB.conf[:USE_AUTOCOMPLETE]
+      refute IRB.conf[:USE_AUTOCOMPLETE]
 
       ENV['IRB_USE_AUTOCOMPLETE'] = ''
       IRB.setup(__FILE__)

--- a/test/irb/test_type_completor.rb
+++ b/test/irb/test_type_completor.rb
@@ -101,7 +101,6 @@ module TestIRB
         type "puts completor.doc_namespace 'a = n.chr;', 'a.encoding', '', bind: binding"
         type "exit!"
       end
-      assert_match(/Completion: Autocomplete, ReplTypeCompletor/, output)
       assert_match(/a\.bit_length/, output)
       assert_match(/String#encoding/, output)
     end


### PR DESCRIPTION
### Breakdown of the change:

- `ENV.fetch("IRB_USE_AUTOCOMPLETE", "false")`: If the environment variable is **not set**, the default value is now `"false"` instead of `"true"`.
- The comparison `!= "false"` ensures that autocomplete is enabled only when `IRB_USE_AUTOCOMPLETE` is explicitly set to something other than `"false"`.

### Behavior after the change:

- **Autocomplete is disabled by default** unless `IRB_USE_AUTOCOMPLETE` is explicitly set to `"true"` or something other than `"false"`.
  
This way, users won’t need to set the environment variable to disable autocomplete; it will be disabled by default.

### Note:
Users can still run `irb` with extra flags to control autocomplete:

- `--autocomplete`: Enables autocomplete for that session.
- `--noautocomplete`: Disables autocomplete for that session.