### PR TITLE
Cache symbol completion result

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -216,6 +216,7 @@ module IRB
     def gets
       Readline.input = @stdin
       Readline.output = @stdout
+      @completor.clear_symbol_cache
       if l = readline(@prompt, false)
         HISTORY.push(l) if !l.empty?
         @line[@line_no += 1] = l + "\n"
@@ -473,6 +474,7 @@ module IRB
       Reline.output = @stdout
       Reline.prompt_proc = @prompt_proc
       Reline.auto_indent_proc = @auto_indent_proc if @auto_indent_proc
+      @completor.clear_symbol_cache
       if l = Reline.readmultiline(@prompt, false, &@check_termination_proc)
         Reline::HISTORY.push(l) if !l.empty?
         @line[@line_no += 1] = l + "\n"

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -230,13 +230,25 @@ module TestIRB
         "K".force_encoding(enc).to_sym
       rescue
       end
-      symbols += [:aiueo, :"aiu eo"]
-      candidates = completion_candidates(":a", binding)
-      assert_include(candidates, ":aiueo")
-      assert_not_include(candidates, ":aiu eo")
+      symbols += [:irb_test_symbol_aiueo, :"irb_test_symbol_aiu eo"]
+      candidates = completion_candidates(":irb_test_symbol_a", binding)
+      assert_include(candidates, ":irb_test_symbol_aiueo")
+      assert_not_include(candidates, ":irb_test_symbol_aiu eo")
       assert_empty(completion_candidates(":irb_unknown_symbol_abcdefg", binding))
       # Do not complete empty symbol for performance reason
       assert_empty(completion_candidates(":", binding))
+    end
+
+    def test_complete_symbol_limit
+      symbols = 200.times.map { :"irb_test_sym_limit_#{_1}" }.sort
+      assert_equal(11, completion_candidates(":irb_test_sym_limit_9", binding).size)
+      assert_equal([], completion_candidates(":irb_test_sym_nomatch", binding))
+      assert_equal([], completion_candidates(":zzzz", binding))
+
+      limited_candidates = completion_candidates(":irb_test_sym_lim", binding)
+      assert_include(limited_candidates, symbols.first.inspect)
+      assert_include(limited_candidates, symbols.last.inspect)
+      assert_equal(100, limited_candidates.size)
     end
 
     def test_complete_invalid_three_colons

--- a/test/irb/test_type_completor.rb
+++ b/test/irb/test_type_completor.rb
@@ -61,6 +61,14 @@ module TestIRB
       assert_doc_namespace('num.chr.', 'upcase', 'String#upcase', binding: bind)
     end
 
+    def test_complete_symbol_limit
+      symbols = 200.times.map { :"irb_test_sym_limit_#{_1}" }.sort
+      candidates = @completor.completion_candidates('', ':irb_test_sym_lim', '', bind: binding)
+      assert_include(candidates, symbols.first.inspect)
+      assert_include(candidates, symbols.last.inspect)
+      assert_equal(candidates.size, 100)
+    end
+
     def test_inspect
       assert_match(/\AReplTypeCompletor.*\z/, @completor.inspect)
     end


### PR DESCRIPTION
Make symbol completion faster

- Cache `Symbol.all_symbols.sort` and reuse it.
- Restrict the number of symbol candidates to reduce completion/rendering cost in Reline.
- Use bsearch to perform O(logN) search from cached sorted symbol list.

```
irb -f
irb(main):001> s='a';symbols = 100000.times.map{s=s.succ; [s.to_sym, ('a'+s).to_sym]};
irb(main):002> :aaabq
               :aaabk 
               :aaabl 
               :aaabm 
               :aaabn 
               :aaabo 
               :aaabp 
               :aaabq▄
               :azyd █
               :azye ▀
               :azyf  
               :azyg  
               :azyh  
               :azyi  
               :azyj  
               :azyk  
```
Completion candidates of symbol contains first 50 + last 50 symbols matched to the completion target.
