### PR TITLE
Avoid using arbitrary puts to print output

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1422,6 +1422,14 @@ module IRB
 
     private
 
+    def puts(...)
+      @context.io.puts(...)
+    end
+
+    def print(...)
+      @context.io.print(...)
+    end
+
     def generate_prompt(opens, continue, line_offset)
       ltype = @scanner.ltype_from_open_tokens(opens)
       indent = @scanner.calc_indent_level(opens)

--- a/lib/irb/command/base.rb
+++ b/lib/irb/command/base.rb
@@ -36,7 +36,7 @@ module IRB
         def execute(irb_context, arg)
           new(irb_context).execute(arg)
         rescue CommandArgumentError => e
-          puts e.message
+          irb_context.io.puts e.message
         end
 
         private
@@ -54,6 +54,16 @@ module IRB
 
       def execute(arg)
         #nop
+      end
+
+      private
+
+      def puts(...)
+        irb_context.io.puts(...)
+      end
+
+      def print(...)
+        irb_context.io.print(...)
       end
     end
 

--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -48,6 +48,14 @@ module IRB
       false
     end
 
+    def puts
+      fail NotImplementedError
+    end
+
+    def print
+      fail NotImplementedError
+    end
+
     # For debug message
     def inspect
       'Abstract InputMethod'
@@ -71,6 +79,14 @@ module IRB
       print @prompt
       line = @stdin.gets
       @line[@line_no += 1] = line
+    end
+
+    def puts(...)
+      @stdout.puts(...)
+    end
+
+    def print(...)
+      @stdout.print(...)
     end
 
     # Whether the end of this input method has been reached, returns +true+ if
@@ -155,6 +171,14 @@ module IRB
       @io.gets
     end
 
+    def puts(...)
+      ::Kernel.puts(...)
+    end
+
+    def print(...)
+      ::Kernel.print(...)
+    end
+
     # The external encoding for standard input.
     def encoding
       @external_encoding
@@ -221,6 +245,14 @@ module IRB
         @eof = true
         l
       end
+    end
+
+    def puts(...)
+      @stdout.puts(...)
+    end
+
+    def print(...)
+      @stdout.format(...)
     end
 
     # Whether the end of this input method has been reached, returns +true+
@@ -472,6 +504,14 @@ module IRB
         @eof = true
         l
       end
+    end
+
+    def puts(...)
+      @stdout.puts(...)
+    end
+
+    def print(...)
+      @stdout.print(...)
     end
 
     # Whether the end of this input method has been reached, returns +true+

--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -32,6 +32,14 @@ module TestIRB
         @list[@line_no]&.tap {@line_no += 1}
       end
 
+      def puts(...)
+        Kernel.puts(...)
+      end
+
+      def print(...)
+        Kernel.print(...)
+      end
+
       def eof?
         @line_no >= @list.size
       end


### PR DESCRIPTION
fix #580 
- Implement `puts` and `print` in `InputMethod` to be overridden by Input methods.
- Change all `Kernel#puts` invocation to `irb_context.io.puts`


