### PR TITLE
On Windows, Process.kill(:TERM) is not supported.

### DIFF
--- a/lib/irb/pager.rb
+++ b/lib/irb/pager.rb
@@ -34,7 +34,12 @@ module IRB
       # So to properly terminate the pager with Ctrl-C, we need to catch `IRB::Abort` and kill the pager process
       rescue IRB::Abort
         begin
-          Process.kill("TERM", pid) if pid
+          begin
+            Process.kill("TERM", pid) if pid
+          rescue Errno::EINVAL
+            # SIGTERM not supported (windows)
+            Process.kill("KILL", pid)
+          end
         rescue Errno::ESRCH
           # Pager process already terminated
         end


### PR DESCRIPTION
Use SIGKILL instead.