### PR TITLE
Prevent a warning: ambiguous `/`

### DIFF
--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -706,7 +706,7 @@ module TestIRB
       verbose, $VERBOSE = $VERBOSE, nil
       original_completor = IRB.conf[:COMPLETOR]
       IRB.conf[:COMPLETOR] = nil
-      assert_match /IRB::(Regexp|Type)Completor/, @context.send(:build_completor).class.name
+      assert_match(/IRB::(Regexp|Type)Completor/, @context.send(:build_completor).class.name)
       IRB.conf[:COMPLETOR] = :regexp
       assert_equal 'IRB::RegexpCompletor', @context.send(:build_completor).class.name
       IRB.conf[:COMPLETOR] = :unknown


### PR DESCRIPTION
Backport from https://github.com/ruby/ruby/commit/6a39e6fc2d0db590ad605f7af9c99d32c64c6a22