### PR TITLE
Don't use delegator to install helper methods to main object

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -1463,16 +1463,21 @@ module IRB
       end
     end
 
+    def basic_object_safe_main_call(method)
+      main = @context.main
+      Object === main ? main.__send__(method) : Object.instance_method(method).bind_call(main)
+    end
+
     def format_prompt(format, ltype, indent, line_no) # :nodoc:
       format.gsub(/%([0-9]+)?([a-zA-Z%])/) do
         case $2
         when "N"
           @context.irb_name
         when "m"
-          main_str = @context.main.to_s rescue "!#{$!.class}"
+          main_str = basic_object_safe_main_call(:to_s) rescue "!#{$!.class}"
           truncate_prompt_main(main_str)
         when "M"
-          main_str = @context.main.inspect rescue "!#{$!.class}"
+          main_str = basic_object_safe_main_call(:inspect) rescue "!#{$!.class}"
           truncate_prompt_main(main_str)
         when "l"
           ltype

--- a/lib/irb/command/internal_helpers.rb
+++ b/lib/irb/command/internal_helpers.rb
@@ -19,7 +19,7 @@ module IRB
         # Use throw and catch to handle arg that includes `;`
         # For example: "1, kw: (2; 3); 4" will be parsed to [[1], { kw: 3 }]
         catch(:EXTRACT_RUBY_ARGS) do
-          @irb_context.workspace.binding.eval "IRB::Command.extract_ruby_args #{arg}"
+          @irb_context.workspace.binding.eval "::IRB::Command.extract_ruby_args #{arg}"
         end || [[], {}]
       end
     end

--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -156,7 +156,8 @@ module IRB
         end
 
         def eval_class_constants
-          ::Module.instance_method(:constants).bind(eval("self.class")).call
+          klass = ::Object.instance_method(:class).bind_call(receiver)
+          ::Module.instance_method(:constants).bind_call(klass)
         end
       end
     }

--- a/test/irb/command/test_cd.rb
+++ b/test/irb/command/test_cd.rb
@@ -19,6 +19,12 @@ module TestIRB
           end
         end
 
+        class BO < BasicObject
+          def baz
+            "this is baz"
+          end
+        end
+
         binding.irb
       RUBY
     end
@@ -38,6 +44,19 @@ module TestIRB
       assert_match(/irb\(Foo::Bar\):004>/, out)
       assert_match(/Bar#methods: bar/, out)
       assert_match(/irb\(Foo\):006>/, out)
+    end
+
+    def test_cd_basic_object_or_frozen
+      out = run_ruby_file do
+        type "cd BO.new"
+        type "cd 1"
+        type "cd Object.new.freeze"
+        type "exit"
+      end
+
+      assert_match(/irb\(#<BO:.+\):002>/, out)
+      assert_match(/irb\(1\):003>/, out)
+      assert_match(/irb\(#<Object:.+\):004>/, out)
     end
 
     def test_cd_moves_top_level_with_no_args

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -652,6 +652,13 @@ module TestIRB
       assert_equal('irb("aaaaaaaaaaaaaaaaaaaaaaaaaaaa...)>', irb.send(:format_prompt, 'irb(%M)>', nil, 1, 1))
     end
 
+    def test_prompt_main_basic_object
+      main = BasicObject.new
+      irb = IRB::Irb.new(IRB::WorkSpace.new(main), TestInputMethod.new)
+      assert_match(/irb\(#<BasicObject:.+\)/, irb.send(:format_prompt, 'irb(%m)>', nil, 1, 1))
+      assert_match(/irb\(#<BasicObject:.+\)/, irb.send(:format_prompt, 'irb(%M)>', nil, 1, 1))
+    end
+
     def test_prompt_main_raise
       main = Object.new
       def main.to_s; raise TypeError; end


### PR DESCRIPTION
Delegator was needed to install command methods to frozen objects, but we don't do it anymore.

Dropping delegator will fix this weird behavior.
```ruby
irb(main):001> cd 1
irb(1):002> self
=> 1
irb(1):003> frozen?
=> false
irb(1):004> self.class
=> SimpleDelegator
irb(1):005> { self => 1, 1 => 1 }
=> {1=>1, 1=>1}
```

Helper methods will be unavailable on frozen main object. However, I think it makes sense that frozen object can't have helper methods.
(We can change this by adding helper methods to Kernel instead of main object maybe in the future. It will also completely fix helper method polluting main object.)

This pull request also adds minimal support for BasicObject because the original delegator code was checking BasicObject.
```ruby
case @main
when Object
  use_delegator = @main.frozen?
else
  use_delegator = true # main is BasicObject
end
```