### PR TITLE
Store method objects in constants

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -137,27 +137,33 @@ module IRB
   end
 
   class RegexpCompletor < BaseCompletor # :nodoc:
+    KERNEL_METHODS = ::Kernel.instance_method(:methods)
+    KERNEL_PRIVATE_METHODS = ::Kernel.instance_method(:private_methods)
+    KERNEL_INSTANCE_VARIABLES = ::Kernel.instance_method(:instance_variables)
+    OBJECT_CLASS_INSTANCE_METHOD = ::Object.instance_method(:class)
+    MODULE_CONSTANTS_INSTANCE_METHOD = ::Module.instance_method(:constants)
+
     using Module.new {
       refine ::Binding do
         def eval_methods
-          ::Kernel.instance_method(:methods).bind(eval("self")).call
+          KERNEL_METHODS.bind_call(receiver)
         end
 
         def eval_private_methods
-          ::Kernel.instance_method(:private_methods).bind(eval("self")).call
+          KERNEL_PRIVATE_METHODS.bind_call(receiver)
         end
 
         def eval_instance_variables
-          ::Kernel.instance_method(:instance_variables).bind(eval("self")).call
+          KERNEL_INSTANCE_VARIABLES.bind_call(receiver)
         end
 
         def eval_global_variables
-          ::Kernel.instance_method(:global_variables).bind(eval("self")).call
+          ::Kernel.global_variables
         end
 
         def eval_class_constants
-          klass = ::Object.instance_method(:class).bind_call(receiver)
-          ::Module.instance_method(:constants).bind_call(klass)
+          klass = OBJECT_CLASS_INSTANCE_METHOD.bind_call(receiver)
+          MODULE_CONSTANTS_INSTANCE_METHOD.bind_call(klass)
         end
       end
     }

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -13,6 +13,9 @@ module IRB
   # A class that wraps the current state of the irb session, including the
   # configuration of IRB.conf.
   class Context
+    KERNEL_PUBLIC_METHOD = ::Kernel.instance_method(:public_method)
+    KERNEL_METHOD = ::Kernel.instance_method(:method)
+
     ASSIGN_OPERATORS_REGEXP = Regexp.union(%w[= += -= *= /= %= **= &= |= &&= ||= ^= <<= >>=])
     # Creates a new IRB context.
     #
@@ -648,8 +651,8 @@ module IRB
       return if local_variables.include?(command)
 
       # Check visibility
-      public_method = !!Kernel.instance_method(:public_method).bind_call(main, command) rescue false
-      private_method = !public_method && !!Kernel.instance_method(:method).bind_call(main, command) rescue false
+      public_method = !!KERNEL_PUBLIC_METHOD.bind_call(main, command) rescue false
+      private_method = !public_method && !!KERNEL_METHOD.bind_call(main, command) rescue false
       if Command.execute_as_command?(command, public_method: public_method, private_method: private_method)
         [command, arg]
       end


### PR DESCRIPTION
It probably won't speed up things significantly, but these are hot paths and we can save a few method calls per completion/input call.