### PR TITLE
Extract truffleruby workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
-      engine: cruby-truffleruby
+      engine: cruby
       min_version: 2.7
   lint:
     runs-on: ubuntu-latest
@@ -30,8 +30,6 @@ jobs:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         with_latest_reline: [true, false]
-        exclude:
-          - ruby: truffleruby
       fail-fast: false
     runs-on: ubuntu-latest
     env:
@@ -80,9 +78,6 @@ jobs:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         with_latest_reline: [true, false]
-        exclude:
-          - ruby: truffleruby
-          - ruby: truffleruby-head
       fail-fast: false
     env:
       WITH_LATEST_RELINE: ${{matrix.with_latest_reline}}

--- a/.github/workflows/truffle-ruby-test.yml
+++ b/.github/workflows/truffle-ruby-test.yml
@@ -1,0 +1,30 @@
+name: build-with-truffleruby-head
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "30 14 * * *"
+
+jobs:
+  irb:
+    name: rake test truffleruby-head ${{ matrix.with_latest_reline && '(latest reline)' || '' }}
+    strategy:
+      matrix:
+        with_latest_reline: [true, false]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    env:
+      WITH_LATEST_RELINE: ${{matrix.with_latest_reline}}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: truffleruby-head
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake test
+      - name: Run tests in isolation
+        run: bundle exec rake test_in_isolation


### PR DESCRIPTION
Background: #1032

I understand that constantly testing IRB with TruffleRuby-head is important to help the project cache issues early, but the failed build leads to a lot of noise in the CI workflow.

So in this PR, I hope to achieve 2 things by having a dedicated build configuration for TruffleRuby head:

1. We can very simply disable the CI runs through GH Actions' UI when there's a known issue, and re-enable it easily later, all without changing code.
2. Since TruffleRuby doesn't run most of the steps in the original `build` configuration, extracting it out makes the steps it DOES run more obvious.