### PR TITLE
Don't show 'Maybe IRB bug!' in show_source and ls command

### DIFF
--- a/lib/irb/source_finder.rb
+++ b/lib/irb/source_finder.rb
@@ -125,9 +125,8 @@ module IRB
     end
 
     def eval_receiver_or_owner(code)
-      context_binding = @irb_context.workspace.binding
-      eval(code, context_binding)
-    rescue NameError
+      @irb_context.workspace.binding.eval(code)
+    rescue Exception
       raise EvaluationError
     end
 

--- a/test/irb/command/test_show_source.rb
+++ b/test/irb/command/test_show_source.rb
@@ -65,6 +65,19 @@ module TestIRB
       assert_match(%r[Couldn't locate a definition for Foo], out)
     end
 
+    def test_show_source_with_eval_error
+      write_ruby <<~'RUBY'
+        binding.irb
+      RUBY
+
+      out = run_ruby_file do
+        type "show_source raise(Exception).itself"
+        type "exit"
+      end
+
+      assert_match(%r[Couldn't locate a definition for raise\(Exception\)\.itself], out)
+    end
+
     def test_show_source_string
       write_ruby <<~'RUBY'
         binding.irb

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -742,6 +742,19 @@ module TestIRB
       end
     end
 
+    def test_ls_with_eval_error
+      [
+        "ls raise(Exception,'foo')\n",
+        "ls raise(Exception,'foo'), grep: /./\n",
+        "ls Integer, grep: raise(Exception,'foo')\n",
+      ].each do |line|
+        out, err = execute_lines(line)
+        assert_empty err
+        assert_match(/Exception: foo/, out)
+        assert_not_match(/Maybe IRB bug!/, out)
+      end
+    end
+
     def test_ls_with_no_singleton_class
       out, err = execute_lines(
         "ls 42",


### PR DESCRIPTION
`ls` command shows `Maybe IRB bug!` when eval fails.

```
irb(main):001> ls foo
undefined local variable or method `foo' for main (NameError)
[backtraces]
Maybe IRB bug!

irb(main):001> ls raise(Exception)
Exception (Exception)
[backtraces]
Maybe IRB bug!

irb(main):001> ls (1.."a")
bad value for range (ArgumentError)
[backtraces]
Maybe IRB bug!
```

Same for show_source
```
irb(main):001> show_source (1.."a").itself
bad value for range (ArgumentError)
Maybe IRB bug!

irb(main):001> show_source raise(Exception).itself
Exception (Exception)
Maybe IRB bug!
```

This pull request fixes it.
```
irb(main):001> ls foo
NameError: undefined local variable or method `foo' for main
irb(main):002> ls raise(Exception,'aa')
Exception: aa
irb(main):003> ls Integer, grep: /#{raise Exception,'bb'}/
Exception: bb
irb(main):004> show_source raise(Exception,'aa').itself
Error: Couldn't locate a definition for raise(Exception,'aa').itself
```

The use of `args, kwargs = ruby_args(arg)` (in legacy ls format) is also removed.