### PR TITLE
Show a quick preview of inspect result before pager launch

### DIFF
--- a/lib/irb/command/copy.rb
+++ b/lib/irb/command/copy.rb
@@ -15,7 +15,7 @@ module IRB
         arg = '_' if arg.to_s.strip.empty?
 
         value = irb_context.workspace.binding.eval(arg)
-        output = irb_context.inspect_method.inspect_value(value, colorize: false)
+        output = irb_context.inspect_method.inspect_value(value, +'', colorize: false).chomp
 
         if clipboard_available?
           copy_to_clipboard(output)

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -658,8 +658,12 @@ module IRB
       end
     end
 
-    def inspect_last_value # :nodoc:
-      @inspect_method.inspect_value(@last_value)
+    def inspect_last_value(output = +'') # :nodoc:
+      @inspect_method.inspect_value(@last_value, output)
+    end
+
+    def inspector_support_stream_output?
+      @inspect_method.support_stream_output?
     end
 
     NOPRINTING_IVARS = ["@last_value"] # :nodoc:

--- a/lib/irb/pager.rb
+++ b/lib/irb/pager.rb
@@ -56,10 +56,11 @@ module IRB
       def page_with_preview(width, height, formatter_proc)
         overflow_callback = ->(lines) do
           modified_output = formatter_proc.call(lines.join, true)
-          content, = take_first_page(width, height - 1) {|o| o.write modified_output }
+          content, = take_first_page(width, [height - 2, 0].max) {|o| o.write modified_output }
           content = content.chomp
           content = "#{content}\e[0m" if Color.colorable?
           $stdout.puts content
+          $stdout.puts 'Inspecting...'
         end
         out = PageOverflowIO.new(width, height, overflow_callback)
         yield out

--- a/lib/irb/pager.rb
+++ b/lib/irb/pager.rb
@@ -60,7 +60,7 @@ module IRB
           content = content.chomp
           content = "#{content}\e[0m" if Color.colorable?
           $stdout.puts content
-          $stdout.puts 'Inspecting...'
+          $stdout.puts 'Preparing full inspection value...'
         end
         out = PageOverflowIO.new(width, height, overflow_callback)
         yield out

--- a/lib/irb/pager.rb
+++ b/lib/irb/pager.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'reline'
+
 module IRB
   # The implementation of this class is borrowed from RDoc's lib/rdoc/ri/driver.rb.
   # Please do NOT use this class directly outside of IRB.
@@ -47,11 +49,40 @@ module IRB
       rescue Errno::EPIPE
       end
 
-      private
-
       def should_page?
         IRB.conf[:USE_PAGER] && STDIN.tty? && (ENV.key?("TERM") && ENV["TERM"] != "dumb")
       end
+
+      def page_with_preview(width, height, formatter_proc)
+        overflow_callback = ->(lines) do
+          modified_output = formatter_proc.call(lines.join, true)
+          content, = take_first_page(width, height - 1) {|o| o.write modified_output }
+          content = content.chomp
+          content = "#{content}\e[0m" if Color.colorable?
+          $stdout.puts content
+        end
+        out = PageOverflowIO.new(width, height, overflow_callback)
+        yield out
+        content = formatter_proc.call(out.string, out.multipage?)
+        if out.multipage?
+          page(retain_content: true) do |io|
+            io.puts content
+          end
+        else
+          $stdout.puts content
+        end
+      end
+
+      def take_first_page(width, height)
+        overflow_callback = proc do |lines|
+          return lines.join, true
+        end
+        out = Pager::PageOverflowIO.new(width, height, overflow_callback)
+        yield out
+        [out.string, false]
+      end
+
+      private
 
       def content_exceeds_screen_height?(content)
         screen_height, screen_width = begin
@@ -62,10 +93,10 @@ module IRB
 
         pageable_height = screen_height - 3 # leave some space for previous and the current prompt
 
-        # If the content has more lines than the pageable height
-        content.lines.count > pageable_height ||
-          # Or if the content is a few long lines
-          pageable_height * screen_width < Reline::Unicode.calculate_width(content, true)
+        return true if content.lines.size > pageable_height
+
+        _, overflow = take_first_page(screen_width, pageable_height) {|out| out.write content }
+        overflow
       end
 
       def setup_pager(retain_content:)
@@ -95,6 +126,72 @@ module IRB
 
         nil
       end
+    end
+
+    # Writable IO that has page overflow callback
+    class PageOverflowIO
+      attr_reader :string
+
+      # Maximum size of a single cell in terminal
+      # Assumed worst case: "\e[1;3;4;9;38;2;255;128;128;48;2;128;128;255mA\e[0m"
+      # bold, italic, underline, crossed_out, RGB forgound, RGB background
+      MAX_CHAR_PER_CELL = 50
+
+      def initialize(width, height, overflow_callback)
+        @lines = []
+        @width = width
+        @height = height
+        @buffer = +''
+        @overflow_callback = overflow_callback
+        @col = 0
+        @string = +''
+        @multipage = false
+      end
+
+      def puts(text = '')
+        write(text)
+        write("\n") unless text.end_with?("\n")
+      end
+
+      def write(text)
+        @string << text
+        return if @multipage
+
+        overflow_size = (@width * (@height - @lines.size) + @width - @col) * MAX_CHAR_PER_CELL
+        if text.size >= overflow_size
+          text = text[0, overflow_size]
+          overflow = true
+        end
+
+        @buffer << text
+        @col += Reline::Unicode.calculate_width(text)
+        if text.include?("\n") || @col >= @width
+          @buffer.lines.each do |line|
+            wrapped_lines = Reline::Unicode.split_by_width(line.chomp, @width).first.compact
+            wrapped_lines.pop if wrapped_lines.last == ''
+            @lines.concat(wrapped_lines)
+            if @lines.empty?
+              @lines << "\n"
+            elsif line.end_with?("\n")
+              @lines[-1] += "\n"
+            end
+          end
+          @buffer.clear
+          @buffer << @lines.pop unless @lines.last.end_with?("\n")
+          @col = Reline::Unicode.calculate_width(@buffer)
+        end
+        if overflow || @lines.size > @height || (@lines.size == @height && @col > 0)
+          @overflow_callback.call(@lines.take(@height))
+          @multipage = true
+        end
+      end
+
+      def multipage?
+        @multipage
+      end
+
+      alias print write
+      alias << write
     end
   end
 end

--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -361,7 +361,7 @@ module TestIRB
           irb.eval_input
         end
         assert_empty err
-        assert_equal("=> #{value_first_line[0..(input.winsize.last - 9)]}...\n=> \n#{value}\n", out)
+        assert_equal("=> \n#{value_first_line[0, input.winsize.last]}...\n=> \n#{value}\n", out)
         irb.context.evaluate_expression('A.remove_method(:inspect)', 0)
 
         input.reset

--- a/test/irb/test_pager.rb
+++ b/test/irb/test_pager.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: false
+require 'irb/pager'
+
+require_relative 'helper'
+
+module TestIRB
+  class PagerTest < TestCase
+    def test_take_first_page
+      assert_equal ['a' * 40, true], IRB::Pager.take_first_page(10, 4) {|io| io.puts 'a' * 41; raise 'should not reach here' }
+      assert_equal ['a' * 39, false], IRB::Pager.take_first_page(10, 4) {|io| io.write 'a' * 39 }
+      assert_equal ['a' * 39 + 'b', false], IRB::Pager.take_first_page(10, 4) {|io| io.write 'a' * 39 + 'b' }
+      assert_equal ['a' * 39 + 'b', true], IRB::Pager.take_first_page(10, 4) {|io| io.write 'a' * 39 + 'bc' }
+      assert_equal ["a\nb\nc\nd\n", false], IRB::Pager.take_first_page(10, 4) {|io| io.write "a\nb\nc\nd\n" }
+      assert_equal ["a\nb\nc\nd\n", true], IRB::Pager.take_first_page(10, 4) {|io| io.write "a\nb\nc\nd\ne" }
+      assert_equal ['a' * 15 + "\n" + 'b' * 20, true], IRB::Pager.take_first_page(10, 4) {|io| io.puts 'a' * 15; io.puts 'b' * 30 }
+      assert_equal ["\e[31mA\e[0m" * 10 + 'x' * 30, true], IRB::Pager.take_first_page(10, 4) {|io| io.puts "\e[31mA\e[0m" * 10 + 'x' * 31; }
+    end
+  end
+
+  class PageOverflowIOTest < TestCase
+    def test_overflow
+      actual_events = []
+      overflow_callback = ->(lines) do
+        actual_events << [:callback_called, lines]
+      end
+      out = IRB::Pager::PageOverflowIO.new(10, 4, overflow_callback)
+      out.puts 'a' * 15
+      out.write  'b' * 15
+
+      actual_events << :before_write
+      out.write 'c' * 1000
+      actual_events << :after_write
+
+      out.puts 'd' * 1000
+      out.write 'e' * 1000
+
+      expected_events = [
+        :before_write,
+        [:callback_called, ['a' * 10, 'a' * 5 + "\n",  'b' * 10, 'b' * 5 + 'c' * 5]],
+        :after_write,
+      ]
+      assert_equal expected_events, actual_events
+
+      expected_whole_content = 'a' * 15 + "\n" + 'b' * 15 + 'c' * 1000 + 'd' * 1000 + "\n" + 'e' * 1000
+      assert_equal expected_whole_content, out.string
+    end
+  end
+end

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -397,9 +397,9 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     LINES
     start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
     write("o1 = Object.new; def o1.inspect; 'INSPECT'; end\n")
-    write("o2 = Object.new; def o2.inspect; sleep 10; end\n")
+    write("o2 = Object.new; def o2.inspect; sleep 0.1; 'SLOW'; end\n")
     # preview should be shown even if pretty_print is not completed.
-    write("[o1] * 20 + [o2]\n")
+    write("[o1] * 20 + [o2] * 100\n")
     assert_screen(/=>\n\[INSPECT,\n( INSPECT,\n){6}Preparing full inspection value\.\.\./)
     write("\C-c") # abort pretty_print
     write("'foo' + 'bar'\n") # eval something to make sure IRB resumes

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -400,7 +400,7 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     write("o2 = Object.new; def o2.inspect; sleep 10; end\n")
     # preview should be shown even if pretty_print is not completed.
     write("[o1] * 20 + [o2]\n")
-    assert_screen(/=>\n\[INSPECT,\n( INSPECT,\n){6}Inspecting.../)
+    assert_screen(/=>\n\[INSPECT,\n( INSPECT,\n){6}Preparing full inspection value\.\.\./)
     write("\C-c") # abort pretty_print
     write("'foo' + 'bar'\n") # eval something to make sure IRB resumes
     assert_screen(/foobar/)

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -400,7 +400,7 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     write("o2 = Object.new; def o2.inspect; sleep 10; end\n")
     # preview should be shown even if pretty_print is not completed.
     write("[o1] * 20 + [o2]\n")
-    assert_screen(/=>\n\[INSPECT,\n( INSPECT,\n){7}/)
+    assert_screen(/=>\n\[INSPECT,\n( INSPECT,\n){6}Inspecting.../)
     write("\C-c") # abort pretty_print
     write("'foo' + 'bar'\n") # eval something to make sure IRB resumes
     assert_screen(/foobar/)

--- a/test/irb/yamatanooroti/test_rendering.rb
+++ b/test/irb/yamatanooroti/test_rendering.rb
@@ -385,9 +385,25 @@ class IRB::RenderingTest < Yamatanooroti::TestCase
     write("'a' * 80 * 11\n")
     write("'foo' + 'bar'\n") # eval something to make sure IRB resumes
 
-    assert_screen(/(a{80}\n){8}/)
+    assert_screen(/"a{79}\n(a{80}\n){7}/)
     # because pager is invoked, foobar will not be evaluated
     assert_screen(/\A(?!foobar)/)
+    close
+  end
+
+  def test_pretty_print_preview_with_slow_inspect
+    write_irbrc <<~'LINES'
+      require "irb/pager"
+    LINES
+    start_terminal(10, 80, %W{ruby -I#{@pwd}/lib #{@pwd}/exe/irb}, startup_message: /irb\(main\)/)
+    write("o1 = Object.new; def o1.inspect; 'INSPECT'; end\n")
+    write("o2 = Object.new; def o2.inspect; sleep 10; end\n")
+    # preview should be shown even if pretty_print is not completed.
+    write("[o1] * 20 + [o2]\n")
+    assert_screen(/=>\n\[INSPECT,\n( INSPECT,\n){7}/)
+    write("\C-c") # abort pretty_print
+    write("'foo' + 'bar'\n") # eval something to make sure IRB resumes
+    assert_screen(/foobar/)
     close
   end
 


### PR DESCRIPTION
IRB takes about 2 seconds to show the result of `200000.times.to_a`.
```ruby
irb(main):001> 200000.times.to_a
```

In this case, creating the full pretty_print content takes time. Fortunately, there is a way to get the first WINDOW_HEIGHT lines of the content quickly.
This pull request will change IRB to show the first page of the pretty_print result quickly even when pretty_print is slow.

![preview_before_pager](https://github.com/user-attachments/assets/3d16fc59-8ab2-4623-94ff-d86189caba9a)
First page is displayed 0.1sec after pressing ENTER key.
After two seconds, the whole pretty_print content is ready and pager launches (`:` on the bottom of the line indicates that).

### newline_before_multiline_output
If the inspect takes more than 0.1 sec and result exceeds screen height, IRB will print the first page of the content immediately.
If the inspect of assignment expression result exceeds 1 line, generating rest of the content will be skipped.
In this case, output will be treated as multiline even if the un-generated whole inspect result does not contain newline.

### Considering pretty_print prints SQL log in Rails console
In rails console, pretty printing ActiveRecord::Relation will print a SQL log.

Here is an example of the terminal buffer with terminal height = 5

```
irb(main):001> [User.where(name: 'foo'), User.where(name: 'bar')]
User Load(9.9ms) SELECT * from users where name="foo"
(and other SQL log while retrieving the first page)
=>
[#<User id: 1>,
 #<User id: 2>,
 #<User id: 3>
User Load(9.9ms) SELECT * from users where name="bar"
(and other SQL log while retrieving the rest of the pretty_print content)
=>
[#<User id: 1>,
 #<User id: 2>,
 #<User id: 3>
:
```

There is a duplicated output in the terminal buffer if pretty_print takes more than 0.1sec. This is the downside of this pull request.

It is possible to erase it by switching to alternate screen with escape sequence `"\e[?1049h", "\e[?1049l"`.
This pull request does not do that because it will also erase the SQL log from the terminal buffer.

### Another simple implementation

This works pretty well in most cases, but I didn't use it in this pull request.
```ruby
IRB::Pager.page(retain_content: true) do |out|
  out.puts '=>'
  @context.inspect_last_value(out)
end
```
When evaluating a code like `[100.times.to_a, User.where(condition)]` or `ClassThatStoresRelationAsInstanceVariable.new(User.where(condition))`, SQL log messes up the pager output.
