### PR TITLE
Prevent cursor flickering in dancing ruby

### DIFF
--- a/lib/irb/easter-egg.rb
+++ b/lib/irb/easter-egg.rb
@@ -125,6 +125,7 @@ module IRB
             canvas = Canvas.new(Reline.get_screen_size)
           end
           ruby_model = RubyModel.new
+          print "\e[?25l" # hide cursor
           0.step do |i| # TODO (0..).each needs Ruby 2.6 or later
             buff = canvas.draw do
               ruby_model.render_frame(i) do |p1, p2|
@@ -138,6 +139,7 @@ module IRB
           end
         rescue Interrupt
         ensure
+          print "\e[?25h" # show cursor
           trap("SIGINT", prev_trap)
         end
       end


### PR DESCRIPTION
Before

The cursor appears in the bottom right corner and occasionally flickers.


https://github.com/user-attachments/assets/ba82dbaa-f477-4950-9403-6f2e378a965b


After



https://github.com/user-attachments/assets/9f5ccf72-ff98-4995-8952-8613ea633836



