### PR TITLE
Page the output in irb:rdbg sessions too

### DIFF
--- a/lib/irb/debug/ui.rb
+++ b/lib/irb/debug/ui.rb
@@ -45,9 +45,7 @@ module IRB
             $stdout.puts line.chomp
           }
         when String
-          str.each_line{|line|
-            $stdout.puts line.chomp
-          }
+          Pager.page_content(str, retain_content: true)
         when nil
           $stdout.puts
         end


### PR DESCRIPTION
IRB started to page its evaluation output and it became a useful feature for users. However, in `irb:rdbg` sessions, the output is not paged so the sudden change in behavior is surprising and inconvenient.

This commit makes `irb:rdbg` sessions page the output of the debugger too.

Notes:

- I didn't add a test for it as we currently don't have a way to test pager output.
- When printing results from `ThreadClient`, `Debug::UI#puts` will [always receive string](https://github.com/ruby/debug/blob/master/lib/debug/session.rb#L278). So we only need to activate pager in that case. In fact, `debug` most of the time passes string to this method, except for when [printing exception backtrace](https://github.com/ruby/debug/blob/master/lib/debug/session.rb#L1942).