### PR TITLE
Load history when starting a direct debug session

### DIFF
--- a/lib/irb/debug.rb
+++ b/lib/irb/debug.rb
@@ -81,6 +81,7 @@ module IRB
         IRB.instance_variable_set(:@debugger_irb, irb)
         irb.context.with_debugger = true
         irb.context.irb_name += ":rdbg"
+        irb.context.io.load_history
       end
 
       module SkipPathHelperForIRB

--- a/lib/irb/debug.rb
+++ b/lib/irb/debug.rb
@@ -81,7 +81,7 @@ module IRB
         IRB.instance_variable_set(:@debugger_irb, irb)
         irb.context.with_debugger = true
         irb.context.irb_name += ":rdbg"
-        irb.context.io.load_history
+        irb.context.io.load_history if irb.context.io.class < HistorySavingAbility
       end
 
       module SkipPathHelperForIRB

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -504,10 +504,18 @@ module TestIRB
 
       output = run_ruby_file do
         type "history"
+        type "puts 'foo'"
+        type "history"
         type "exit!"
       end
 
-      assert_include(output, "old_history_3")
+      assert_include(output, "irb:rdbg(main):002") # assert that we're in an irb:rdbg session
+      assert_include(output, "5: history")
+      assert_include(output, "4: puts 'foo'")
+      assert_include(output, "3: history")
+      assert_include(output, "2: old_history_3")
+      assert_include(output, "1: old_history_2")
+      assert_include(output, "0: old_history_1")
     end
 
     private

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -488,6 +488,28 @@ module TestIRB
       HISTORY
     end
 
+    def test_direct_debug_session_loads_history
+      @envs['RUBY_DEBUG_IRB_CONSOLE'] = "1"
+      write_history <<~HISTORY
+        old_history_1
+        old_history_2
+        old_history_3
+      HISTORY
+
+      write_ruby <<~'RUBY'
+        require 'debug'
+        debugger
+        binding.irb # needed to satisfy run_ruby_file
+      RUBY
+
+      output = run_ruby_file do
+        type "history"
+        type "exit!"
+      end
+
+      assert_include(output, "old_history_3")
+    end
+
     private
 
     def write_history(history)


### PR DESCRIPTION
When starting a debug session directly with RUBY_DEBUG_IRB_CONSOLE=1 and `require 'debug'; debugger`, IRB's history wasn't loaded. This commit ensures history is loaded in this case by calling `load_history` when configuring IRB for the debugger.

Fixes ruby/irb#975