### PR TITLE
Avoid generating documentation pages for internal components

### DIFF
--- a/.document
+++ b/.document
@@ -1,4 +1,8 @@
 LICENSE.txt
 README.md
+EXTEND_IRB.md
+COMPARED_WITH_PRY.md
 doc/irb/indexes.md
-lib/**/*.rb
+lib/irb.rb
+lib/irb/context.rb
+lib/irb/command/base.rb

--- a/Rakefile
+++ b/Rakefile
@@ -46,8 +46,6 @@ task :default => :test
 
 RDoc::Task.new do |rdoc|
   rdoc.title = "IRB"
-  rdoc.rdoc_files.include("*.md", "lib/**/*.rb")
-  rdoc.rdoc_files.exclude("lib/irb/xmp.rb")
   rdoc.rdoc_dir = "docs"
   rdoc.main = "README.md"
   rdoc.options.push("--copy-files", "LICENSE.txt")

--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -879,7 +879,7 @@ require_relative "irb/pager"
 module IRB
 
   # An exception raised by IRB.irb_abort
-  class Abort < Exception;end
+  class Abort < Exception;end # :nodoc:
 
   class << self
     # The current IRB::Context of the session, see IRB.conf

--- a/lib/irb/command/base.rb
+++ b/lib/irb/command/base.rb
@@ -5,13 +5,11 @@
 #
 
 module IRB
-  # :stopdoc:
-
   module Command
-    class CommandArgumentError < StandardError; end
+    class CommandArgumentError < StandardError; end # :nodoc:
 
     class << self
-      def extract_ruby_args(*args, **kwargs)
+      def extract_ruby_args(*args, **kwargs) # :nodoc:
         throw :EXTRACT_RUBY_ARGS, [args, kwargs]
       end
     end
@@ -57,8 +55,6 @@ module IRB
       end
     end
 
-    Nop = Base
+    Nop = Base # :nodoc:
   end
-
-  # :startdoc:
 end


### PR DESCRIPTION
Currently, the documentation website lists most of IRB's internal classes/modules...etc.

<img width="30%" alt="Screenshot 2024-12-12 at 23 00 38" src="https://github.com/user-attachments/assets/cb76d499-8613-49ae-b83e-dc9f9918d60b" />

They're not helpful to end users and are mostly undocumented anyway. Therefore, we should avoid generating documentation for them.

Result:
<img width="50%" alt="Screenshot 2024-12-12 at 23 02 18" src="https://github.com/user-attachments/assets/69a71935-f719-4991-9223-7a282e64612b" />
