### PR TITLE
Fix broken rdoc-ref caused by a typo

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -75,7 +75,7 @@ require_relative "irb/pager"
 # 2.  Constructs the initial session context from [hash
 #     IRB.conf](rdoc-ref:IRB@Hash+IRB.conf) and from default values; the hash
 #     content may have been affected by [command-line
-#     options](rdoc-ref:IB@Command-Line+Options), and by direct assignments in
+#     options](rdoc-ref:IRB@Command-Line+Options), and by direct assignments in
 #     the configuration file.
 # 3.  Assigns the context to variable `conf`.
 # 4.  Assigns command-line arguments to variable `ARGV`.


### PR DESCRIPTION
Detected through https://github.com/ruby/rdoc/pull/1241