### PR TITLE
Drop ColorPrinter's workaround for BasicObject

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          # Added to make Ruby 2.7 correctly require installed default gems, like `pp`.
+          rubygems: latest
       - name: Run tests
         run: bundle exec rake test
       - name: Run tests in isolation

--- a/irb.gemspec
+++ b/irb.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "reline", ">= 0.4.2"
   spec.add_dependency "rdoc", ">= 4.0.0"
+  spec.add_dependency "pp", ">= 0.6.0"
 end

--- a/lib/irb/color_printer.rb
+++ b/lib/irb/color_printer.rb
@@ -4,9 +4,6 @@ require_relative 'color'
 
 module IRB
   class ColorPrinter < ::PP
-    METHOD_RESPOND_TO = Object.instance_method(:respond_to?)
-    METHOD_INSPECT = Object.instance_method(:inspect)
-
     class << self
       def pp(obj, out = $>, width = screen_width)
         q = ColorPrinter.new(out, width)
@@ -28,8 +25,6 @@ module IRB
       if String === obj
         # Avoid calling Ruby 2.4+ String#pretty_print that splits a string by "\n"
         text(obj.inspect)
-      elsif !METHOD_RESPOND_TO.bind(obj).call(:inspect)
-        text(METHOD_INSPECT.bind(obj).call)
       else
         super
       end


### PR DESCRIPTION
`pp` 0.6.0+ includes https://github.com/ruby/pp/pull/26 to handle BasicObject, so we can drop the workaround.

(`pp` supports Ruby 2.7+ too)