### PR TITLE
Fix broken `history` command with `-g`

### DIFF
--- a/lib/irb/command/history.rb
+++ b/lib/irb/command/history.rb
@@ -14,7 +14,7 @@ module IRB
 
       def execute(arg)
 
-        if (match = arg&.match(/(-g|-G)\s+(?<grep>.+)\s*\n\z/))
+        if (match = arg&.match(/(-g|-G)\s+(?<grep>.+)\s*\z/))
           grep = Regexp.new(match[:grep])
         end
 

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -972,6 +972,12 @@ module TestIRB
              puts x
            ...
       EOF
+      assert_not_include(out, <<~EOF)
+        foo
+      EOF
+      assert_not_include(out, <<~EOF)
+        bar
+      EOF
       assert_empty err
     end
 


### PR DESCRIPTION
The `-g` option of `history` command was not working, so I fixed it. Local variable `grep` was always nil because the regular expression parsing options contained an unnecessary `\n`. `test_history_grep` did not detect this bug because it only asserted what was included in the output.