### PR TITLE
Gracefully handle incorrect command aliases

### DIFF
--- a/test/irb/command/test_command_aliasing.rb
+++ b/test/irb/command/test_command_aliasing.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "tempfile"
+require_relative "../helper"
+
+module TestIRB
+  class CommandAliasingTest < IntegrationTestCase
+    def setup
+      super
+      write_rc <<~RUBY
+        IRB.conf[:COMMAND_ALIASES] = {
+          :c => :conf, # alias to helper method
+          :f => :foo
+        }
+      RUBY
+
+      write_ruby <<~'RUBY'
+        binding.irb
+      RUBY
+    end
+
+    def test_aliasing_to_helper_method_triggers_warning
+      out = run_ruby_file do
+        type "c"
+        type "exit"
+      end
+      assert_include(out, "Using command alias for helper method 'conf' is not supported")
+      assert_not_include(out, "Maybe IRB bug!")
+    end
+
+    def test_incorrect_alias_triggers_warning
+      out = run_ruby_file do
+        type "f"
+        type "exit"
+      end
+      assert_include(out, "Command 'foo' does not exist")
+      assert_not_include(out, "Maybe IRB bug!")
+    end
+  end
+end


### PR DESCRIPTION
Even if the aliased target is a helper method or does not exist, IRB should not crash.

This commit warns users in such cases and treat the input as normal expression.

Fixes #992