### PR TITLE
`IRB.conf[:SAVE_HISTORY]` should handle boolean values

### DIFF
--- a/lib/irb/history.rb
+++ b/lib/irb/history.rb
@@ -2,9 +2,13 @@ require "pathname"
 
 module IRB
   module History
+    DEFAULT_ENTRY_LIMIT = 1000
+
     class << self
       # Integer representation of <code>IRB.conf[:HISTORY_FILE]</code>.
       def save_history
+        return 0 if IRB.conf[:SAVE_HISTORY] == false
+        return DEFAULT_ENTRY_LIMIT if IRB.conf[:SAVE_HISTORY] == true
         IRB.conf[:SAVE_HISTORY].to_i
       end
 

--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -93,7 +93,7 @@ module IRB # :nodoc:
     @CONF[:VERBOSE] = nil
 
     @CONF[:EVAL_HISTORY] = nil
-    @CONF[:SAVE_HISTORY] = 1000
+    @CONF[:SAVE_HISTORY] = History::DEFAULT_ENTRY_LIMIT
 
     @CONF[:BACK_TRACE_LIMIT] = 16
 

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -279,6 +279,47 @@ module TestIRB
   end
 
   class IRBHistoryIntegrationTest < IntegrationTestCase
+    def test_history_saving_can_be_disabled_with_false
+      write_history ""
+      write_rc <<~RUBY
+        IRB.conf[:SAVE_HISTORY] = false
+      RUBY
+
+      write_ruby <<~'RUBY'
+        binding.irb
+      RUBY
+
+      output = run_ruby_file do
+        type "puts 'foo' + 'bar'"
+        type "exit"
+      end
+
+      assert_include(output, "foobar")
+      assert_equal "", @history_file.open.read
+    end
+
+    def test_history_saving_accepts_true
+      write_history ""
+      write_rc <<~RUBY
+        IRB.conf[:SAVE_HISTORY] = true
+      RUBY
+
+      write_ruby <<~'RUBY'
+        binding.irb
+      RUBY
+
+      output = run_ruby_file do
+        type "puts 'foo' + 'bar'"
+        type "exit"
+      end
+
+      assert_include(output, "foobar")
+      assert_equal <<~HISTORY, @history_file.open.read
+        puts 'foo' + 'bar'
+        exit
+      HISTORY
+    end
+
     def test_history_saving_with_debug
       write_history ""
 


### PR DESCRIPTION
Although not documented, `IRB.conf[:SAVE_HISTORY]` used to accept boolean, which now causes `NoMethodError` when used.

This commit changes the behavior to accept boolean values and adds tests for the behavior.

Closes #1058