### PR TITLE
Fix pager preview with escape sequence and newlines

### DIFF
--- a/test/irb/test_pager.rb
+++ b/test/irb/test_pager.rb
@@ -7,13 +7,21 @@ module TestIRB
   class PagerTest < TestCase
     def test_take_first_page
       assert_equal ['a' * 40, true], IRB::Pager.take_first_page(10, 4) {|io| io.puts 'a' * 41; raise 'should not reach here' }
+      assert_equal ["a\nb\na\nb\n", true], IRB::Pager.take_first_page(10, 4) {|io| 10.times { io.puts "a\nb\n" } }
+      assert_equal ["a\n\n\na\n", true], IRB::Pager.take_first_page(10, 4) {|io| 10.times { io.puts "a\n\n\n" } }
+      assert_equal ["11\n" * 4, true], IRB::Pager.take_first_page(10, 4) {|io| 10.times { io.write 1; io.puts 1 } }
+      assert_equal ["\n" * 4, true], IRB::Pager.take_first_page(10, 4) {|io| 10.times { io.write nil; io.puts nil } }
       assert_equal ['a' * 39, false], IRB::Pager.take_first_page(10, 4) {|io| io.write 'a' * 39 }
       assert_equal ['a' * 39 + 'b', false], IRB::Pager.take_first_page(10, 4) {|io| io.write 'a' * 39 + 'b' }
       assert_equal ['a' * 39 + 'b', true], IRB::Pager.take_first_page(10, 4) {|io| io.write 'a' * 39 + 'bc' }
       assert_equal ["a\nb\nc\nd\n", false], IRB::Pager.take_first_page(10, 4) {|io| io.write "a\nb\nc\nd\n" }
       assert_equal ["a\nb\nc\nd\n", true], IRB::Pager.take_first_page(10, 4) {|io| io.write "a\nb\nc\nd\ne" }
       assert_equal ['a' * 15 + "\n" + 'b' * 20, true], IRB::Pager.take_first_page(10, 4) {|io| io.puts 'a' * 15; io.puts 'b' * 30 }
-      assert_equal ["\e[31mA\e[0m" * 10 + 'x' * 30, true], IRB::Pager.take_first_page(10, 4) {|io| io.puts "\e[31mA\e[0m" * 10 + 'x' * 31; }
+      assert_equal ["\e[31mA\e[0m" * 10 + 'x' * 30, true], IRB::Pager.take_first_page(10, 4) {|io| io.puts "\e[31mA\e[0m" * 10 + 'x' * 31 }
+      text, overflow = IRB::Pager.take_first_page(10, 4) {|io| 41.times { io.write "\e[31mA\e[0m" } }
+      assert_equal ['A' * 40, true], [text.gsub(/\e\[\d+m/, ''), overflow]
+      text, overflow = IRB::Pager.take_first_page(10, 4) {|io| 41.times { io.write "\e[31mAAA\e[0m" } }
+      assert_equal ['A' * 40, true], [text.gsub(/\e\[\d+m/, ''), overflow]
     end
   end
 


### PR DESCRIPTION
Fixes this bug
```
irb(main):001> 100.times.map{[1]*it}
An error occurred when inspecting the object: #<TypeError: no implicit conversion of nil into String>
Result of Kernel#inspect: #<Array:0x0000000129d94778>
=> 
[[],
 [1],
 [1, 1],
 [1, 1, 1],
 [1, 1, 1, 1],
 [1, 1, 1, 1, 1],
 [1, 1, 1, 1, 1, 1],
 [1, 1, 1, 1, 1, 1, 1],
 [1, 1, 1, 1, 1, 1, 1, 1],
 [1, 1, 1, 1, 1, 1, 1, 1, 1],
 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
irb(main):002> 
```


### Non-string
PP doesn't seem to write non-string object, but fix it in case.
```ruby
text = text.to_s unless text.is_a?(String)
```

### Escape sequence
Need to set the second parameter `allow_escape_code` to `Reline::Unicode.calculate_width`
```ruby
Reline::Unicode.calculate_width("\e[31mA\e[m") #=> 11 because length of "^[[31mA^[[m"(escaped for printing) is 11
Reline::Unicode.calculate_width("\e[31mA\e[m", true) #=> 1
```

### Newline
`Reline::Unicode.split_by_width(line.chomp, @width)`
`wrapped_lines` does not include `"\n"` because line is chomp-ed. (`split_by_width` does not work if string contains newline character)
So we need to add `"\n"` if `line` ends with `"\n"`. And the logic had a bug.
PP doesn't seem to write continuous newlines, but found while adding more tests.
