### PR TITLE
Use EnvUtil.rubybin instead of "ruby" in copy command test

### DIFF
--- a/test/irb/command/test_copy.rb
+++ b/test/irb/command/test_copy.rb
@@ -8,7 +8,7 @@ module TestIRB
   class CopyTest < IntegrationTestCase
     def setup
       super
-      @envs['IRB_COPY_COMMAND'] = "ruby -e \"puts 'foo' + STDIN.read\""
+      @envs['IRB_COPY_COMMAND'] = "#{EnvUtil.rubybin} -e \"puts 'foo' + STDIN.read\""
     end
 
     def test_copy_with_pbcopy


### PR DESCRIPTION
`ruby` is not always available. Using `EnvUtil.rubybin` is better.