### PR TITLE
Zero winsize bugfix

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -26,10 +26,11 @@ module IRB
 
     def winsize
       if instance_variable_defined?(:@stdout) && @stdout.tty?
-        @stdout.winsize
-      else
-        [24, 80]
+        winsize = @stdout.winsize
+        # If width or height is 0, something is wrong.
+        return winsize unless winsize.include? 0
       end
+      [24, 80]
     end
 
     # Whether this input method is still readable when there is no more data to

--- a/lib/irb/pager.rb
+++ b/lib/irb/pager.rb
@@ -189,7 +189,7 @@ module IRB
             end
           end
           @buffer.clear
-          @buffer << @lines.pop unless @lines.last.end_with?("\n")
+          @buffer << @lines.pop if !@lines.empty? && !@lines.last.end_with?("\n")
           @col = Reline::Unicode.calculate_width(@buffer, true)
         end
         if overflow || @lines.size > @height || (@lines.size == @height && @col > 0)

--- a/test/irb/test_pager.rb
+++ b/test/irb/test_pager.rb
@@ -70,5 +70,17 @@ module TestIRB
       assert_equal 'a' * 1000 + 'bcd', out.string
       assert_equal [:before_delay, [:callback_called, ['a' * 10] * 4], :after_delay], actual_events
     end
+
+    def test_zero_width
+      out = IRB::Pager::PageOverflowIO.new(0, 0, ->*{})
+      100.times { out.write 'a' }
+      assert_equal [true, [], 'a' * 100], [out.multipage?, out.first_page_lines, out.string]
+      out = IRB::Pager::PageOverflowIO.new(10, 0, ->*{})
+      100.times { out.write 'a' }
+      assert_equal [true, [], 'a' * 100], [out.multipage?, out.first_page_lines, out.string]
+      out = IRB::Pager::PageOverflowIO.new(0, 10, ->*{})
+      100.times { out.write 'a' }
+      assert_equal [true, [], 'a' * 100], [out.multipage?, out.first_page_lines, out.string]
+    end
   end
 end


### PR DESCRIPTION
Fixes #1072

Fix Pager page overflow calculation not to raise error when width is zero.
InputMethod#winsize now fallbacks to [24, 80] when the return value of STDIN.winsize is invalid: zero width or zero height.

