### PR TITLE
Suppress irb_info measures ambiguous_width in command test

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -91,6 +91,25 @@ module TestIRB
         ::Kernel.undef_method :irb_original_require
       }
     end
+
+    def execute_lines(*lines, conf: {}, main: self, irb_path: nil)
+      # To suppress irb_info measure ambiguous_width with escape sequences
+      Reline.core.instance_variable_set(:@ambiguous_width, 1)
+
+      IRB.init_config(nil)
+      IRB.conf[:VERBOSE] = false
+      IRB.conf[:PROMPT_MODE] = :SIMPLE
+      IRB.conf.merge!(conf)
+      input = TestInputMethod.new(lines)
+      irb = IRB::Irb.new(IRB::WorkSpace.new(main), input)
+      irb.context.return_format = "=> %s\n"
+      irb.context.irb_path = irb_path if irb_path
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+      IRB.conf[:USE_PAGER] = false
+      capture_output do
+        irb.eval_input
+      end
+    end
   end
 
   class IntegrationTestCase < TestCase

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -37,22 +37,6 @@ module TestIRB
       FileUtils.rm_rf(@tmpdir)
       restore_encodings
     end
-
-    def execute_lines(*lines, conf: {}, main: self, irb_path: nil)
-      capture_output do
-        IRB.init_config(nil)
-        IRB.conf[:VERBOSE] = false
-        IRB.conf[:PROMPT_MODE] = :SIMPLE
-        IRB.conf[:USE_PAGER] = false
-        IRB.conf.merge!(conf)
-        input = TestInputMethod.new(lines)
-        irb = IRB::Irb.new(IRB::WorkSpace.new(main), input)
-        irb.context.return_format = "=> %s\n"
-        irb.context.irb_path = irb_path if irb_path
-        IRB.conf[:MAIN_CONTEXT] = irb.context
-        irb.eval_input
-      end
-    end
   end
 
   class FrozenObjectTest < CommandTestCase

--- a/test/irb/test_eval_history.rb
+++ b/test/irb/test_eval_history.rb
@@ -14,22 +14,6 @@ module TestIRB
       restore_encodings
     end
 
-    def execute_lines(*lines, conf: {}, main: self, irb_path: nil)
-      IRB.init_config(nil)
-      IRB.conf[:VERBOSE] = false
-      IRB.conf[:PROMPT_MODE] = :SIMPLE
-      IRB.conf[:USE_PAGER] = false
-      IRB.conf.merge!(conf)
-      input = TestInputMethod.new(lines)
-      irb = IRB::Irb.new(IRB::WorkSpace.new(main), input)
-      irb.context.return_format = "=> %s\n"
-      irb.context.irb_path = irb_path if irb_path
-      IRB.conf[:MAIN_CONTEXT] = irb.context
-      capture_output do
-        irb.eval_input
-      end
-    end
-
     def test_eval_history_is_disabled_by_default
       out, err = execute_lines(
         "a = 1",

--- a/test/irb/test_helper_method.rb
+++ b/test/irb/test_helper_method.rb
@@ -16,22 +16,6 @@ module TestIRB
       $VERBOSE = @verbosity
       restore_encodings
     end
-
-    def execute_lines(*lines, conf: {}, main: self, irb_path: nil)
-      IRB.init_config(nil)
-      IRB.conf[:VERBOSE] = false
-      IRB.conf[:PROMPT_MODE] = :SIMPLE
-      IRB.conf.merge!(conf)
-      input = TestInputMethod.new(lines)
-      irb = IRB::Irb.new(IRB::WorkSpace.new(main), input)
-      irb.context.return_format = "=> %s\n"
-      irb.context.irb_path = irb_path if irb_path
-      IRB.conf[:MAIN_CONTEXT] = irb.context
-      IRB.conf[:USE_PAGER] = false
-      capture_output do
-        irb.eval_input
-      end
-    end
   end
 
   module TestHelperMethod


### PR DESCRIPTION
Some test in `test/irb/test_command.rb`, `irb_info` measures ambiguous width by unicode character `"\u{25bd}"` and escape sequence `"\e[6n"`.

It is used here.
```
irb(main):001> irb_info
...
East Asian Ambiguous Width: [To show this value]
```

This pull request suppresses it.

## Actual problem

When running `rake test` through this command, `▽^[3;1R` will be displayed in terminal screen for about 0.5 second.
```ruby
ruby -rpty -e "PTY.spawn('rake test'){|r,w|loop{STDOUT.write r.readpartial(10) rescue break}}"
```

When running `rake test` through this command in tty terminal, test hangs up with `▽` displayed in terminal screen.
This is because `STDIN.raw` hangs up for unknown reason.
```ruby
ruby -e "Process.waitpid spawn('rake test', pgroup: true)"
```

The latter one that uses `spawn` with `pgroup: true` was used in `ruby/ruby`'s `tool/test-bundled-gems.rb`.
https://github.com/ruby/ruby/blob/dd863714bf377b044645ea12b4db48920d49694e/tool/test-bundled-gems.rb#L82
It looks like ci passes because it runs in non-tty environment. (Reline::IOGate is Reline::Dumb)