### PR TITLE
Fallback to Reline when `require 'readline'` fails

### DIFF
--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: false
 require 'irb'
-require 'readline'
 require "tempfile"
 
 require_relative "helper"
@@ -8,6 +7,13 @@ require_relative "helper"
 return if RUBY_PLATFORM.match?(/solaris|mswin|mingw/i)
 
 module TestIRB
+  begin
+    require 'readline'
+    Readline = ::Readline
+  rescue LoadError
+    Readline = ::Reline
+  end
+
   class HistoryTest < TestCase
     def setup
       @conf_backup = IRB.conf.dup


### PR DESCRIPTION
Require readline may fail because it is a bundled gem in 3.5.0.dev.
