### PR TITLE
Ignore to contain directory to Gem::Specification#files

### DIFF
--- a/irb.gemspec
+++ b/irb.gemspec
@@ -33,7 +33,9 @@ Gem::Specification.new do |spec|
     "exe/irb",
     "irb.gemspec",
     "man/irb.1",
-  ] + Dir.chdir(File.expand_path('..', __FILE__)) { Dir.glob("lib/**/*") }
+  ] + Dir.chdir(File.expand_path('..', __FILE__)) do
+    Dir.glob("lib/**/*").map {|f| f unless File.directory?(f) }.compact
+  end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Fixes https://github.com/ruby/ruby/actions/runs/13000759399/job/36258746468?pr=12648#step:8:160

`Dir.glob` contained directory like `lib/irb`. But `rbinstall.rb` don't handle directory with `Gem::Specification#files`. We should ignore that.