### PR TITLE
(docs) Document the keys for completion

### DIFF
--- a/doc/Index.md
+++ b/doc/Index.md
@@ -266,6 +266,8 @@ During the session, method `conf.ignore_siging?` returns the setting, and method
 
 By default, IRB enables [automatic completion](https://en.wikipedia.org/wiki/Autocomplete#In_command-line_interpreter):
 
+To cycle through the completion suggestions, use the tab key (and shift-tab to reverse).
+
 You can disable it by either of these:
 
 - Adding `IRB.conf[:USE_AUTOCOMPLETE] = false` to the configuration file.


### PR DESCRIPTION
(it's a little unintuitive that the cursor keys can't be used for selecting a suggestion).