### PR TITLE
Prefer filter_map and map+grep instead of map+compact and select+map

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -40,13 +40,13 @@ module IRB
 
     def retrieve_gem_and_system_load_path
       candidates = (GEM_PATHS | $LOAD_PATH)
-      candidates.map do |p|
+      candidates.filter_map do |p|
         if p.respond_to?(:to_path)
           p.to_path
         else
           String(p) rescue nil
         end
-      end.compact.sort
+      end.sort
     end
 
     def retrieve_files_to_require_from_load_path
@@ -171,16 +171,12 @@ module IRB
 
       case tok.tok
       when 'require'
-        retrieve_files_to_require_from_load_path.select { |path|
-          path.start_with?(actual_target)
-        }.map { |path|
-          quote + path
+        retrieve_files_to_require_from_load_path.filter_map { |path|
+          quote + path if path.start_with?(actual_target)
         }
       when 'require_relative'
-        retrieve_files_to_require_relative_from_current_dir.select { |path|
-          path.start_with?(actual_target)
-        }.map { |path|
-          quote + path
+        retrieve_files_to_require_relative_from_current_dir.filter_map { |path|
+          quote + path if path.start_with?(actual_target)
         }
       end
     end

--- a/lib/irb/inspector.rb
+++ b/lib/irb/inspector.rb
@@ -46,7 +46,7 @@ module IRB # :nodoc:
       # Determines the inspector to use where +inspector+ is one of the keys passed
       # during inspector definition.
       def keys_with_inspector(inspector)
-        INSPECTORS.select{|k, v| v == inspector}.collect{|k, v| k}
+        INSPECTORS.filter_map {|k, v| k if v == inspector}
       end
 
       # Example

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -932,7 +932,7 @@ module TestIRB
       end
 
       assert_match(/irbtest-.*\.rb:2:in (`|'Object#)foo': error \(RuntimeError\)/, output)
-      frame_traces = output.split("\n").filter_map { |line| line.strip if line.strip.match?(/from /) }
+      frame_traces = output.split("\n").map(&:strip).grep(/from /)
 
       expected_traces = [
         /from .*\/irbtest-.*.rb:6:in (`|'Object#)bar'/,

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -877,7 +877,7 @@ module TestIRB
       end
 
       assert_match(/irbtest-.*\.rb:2:in (`|'Object#)foo': error \(RuntimeError\)/, output)
-      frame_traces = output.split("\n").select { |line| line.strip.match?(/from /) }.map(&:strip)
+      frame_traces = output.split("\n").filter_map { |line| line.strip if line.strip.match?(/from /) }
 
       expected_traces = if RUBY_VERSION >= "3.3.0"
         [
@@ -932,7 +932,7 @@ module TestIRB
       end
 
       assert_match(/irbtest-.*\.rb:2:in (`|'Object#)foo': error \(RuntimeError\)/, output)
-      frame_traces = output.split("\n").select { |line| line.strip.match?(/from /) }.map(&:strip)
+      frame_traces = output.split("\n").filter_map { |line| line.strip if line.strip.match?(/from /) }
 
       expected_traces = [
         /from .*\/irbtest-.*.rb:6:in (`|'Object#)bar'/,

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -877,7 +877,7 @@ module TestIRB
       end
 
       assert_match(/irbtest-.*\.rb:2:in (`|'Object#)foo': error \(RuntimeError\)/, output)
-      frame_traces = output.split("\n").filter_map { |line| line.strip if line.strip.match?(/from /) }
+      frame_traces = output.split("\n").map(&:strip).grep(/from /)
 
       expected_traces = if RUBY_VERSION >= "3.3.0"
         [


### PR DESCRIPTION
``Enumerable#filter_map`` is available since Ruby 2.7.