### PR TITLE
Fix nil error on debugger prompt

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -613,9 +613,11 @@ module IRB
           @context.irb_name
         when "m"
           main_str = @context.safe_method_call_on_main(:to_s) rescue "!#{$!.class}"
+          main_str = main_str || "!#{@context.safe_method_call_on_main(:class)}"
           truncate_prompt_main(main_str)
         when "M"
           main_str = @context.safe_method_call_on_main(:inspect) rescue "!#{$!.class}"
+          main_str = main_str || "!#{@context.safe_method_call_on_main(:class)}"
           truncate_prompt_main(main_str)
         when "l"
           ltype

--- a/test/irb/test_debugger_integration.rb
+++ b/test/irb/test_debugger_integration.rb
@@ -51,6 +51,56 @@ module TestIRB
       assert_match(/=>   2\| puts "hello"/, output)
     end
 
+    def test_debug_class_to_s_return_string
+      write_ruby <<~'ruby'
+        class ToSReturnsString
+          def to_s
+            'ok'
+          end
+
+          def do_something
+            binding.irb
+          end
+        end
+
+        ToSReturnsString.new.do_something
+      ruby
+
+      output = run_ruby_file do
+        type "debug"
+        type "next"
+        type "continue"
+      end
+
+      assert_match(/irb\(ok\):001> debug/, output)
+      assert_match(/irb:rdbg\(ok\):002> next/, output)
+    end
+
+    def test_debug_class_to_s_return_nil
+      write_ruby <<~'ruby'
+        class ToSReturnsNil
+          def to_s
+            nil
+          end
+
+          def do_something
+            binding.irb
+          end
+        end
+
+        ToSReturnsNil.new.do_something
+      ruby
+
+      output = run_ruby_file do
+        type "debug"
+        type "next"
+        type "continue"
+      end
+
+      assert_match(/irb\(!ToSReturnsNil\):001> debug/, output)
+      assert_match(/irb:rdbg\(!ToSReturnsNil\):002> next/, output)
+    end
+
     def test_debug_command_only_runs_once
       write_ruby <<~'ruby'
         binding.irb


### PR DESCRIPTION
Fix ruby/irb#1089

This change ensures that when a class's to_s method returns nil, it is handled in the same way as if to_s had raised an error.