### PR TITLE
Fix methods defined with invalid encoding are not displayed in completion

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -193,13 +193,11 @@ module IRB
 
       # It doesn't make sense to propose commands with other preposing
       commands = [] unless preposing.empty?
-      @encoding_warning_shown ||= false
 
       completion_data = retrieve_completion_data(target, bind: bind, doc_namespace: false).compact.map do |i|
         i.encode(Encoding.default_external)
       rescue Encoding::UndefinedConversionError
-        warn "Warning: Invalid encoding in method name '#{i}'. can't be converted to the locale #{Encoding.default_external}." unless @encoding_warning_shown
-        @encoding_warning_shown = true
+        # If the string cannot be converted, we just ignore it
         nil
       end.compact
       commands | completion_data

--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -193,8 +193,15 @@ module IRB
 
       # It doesn't make sense to propose commands with other preposing
       commands = [] unless preposing.empty?
+      @encoding_warning_shown ||= false
 
-      completion_data = retrieve_completion_data(target, bind: bind, doc_namespace: false).compact.map{ |i| i.encode(Encoding.default_external) }
+      completion_data = retrieve_completion_data(target, bind: bind, doc_namespace: false).compact.map do |i|
+        i.encode(Encoding.default_external)
+      rescue Encoding::UndefinedConversionError
+        warn "Warning: Invalid encoding in method name '#{i}'. can't be converted to the locale #{Encoding.default_external}." unless @encoding_warning_shown
+        @encoding_warning_shown = true
+        nil
+      end.compact
       commands | completion_data
     end
 

--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -201,12 +201,12 @@ module IRB
       # It doesn't make sense to propose commands with other preposing
       commands = [] unless preposing.empty?
 
-      completion_data = retrieve_completion_data(target, bind: bind, doc_namespace: false).compact.map do |i|
+      completion_data = retrieve_completion_data(target, bind: bind, doc_namespace: false).compact.filter_map do |i|
         i.encode(Encoding.default_external)
       rescue Encoding::UndefinedConversionError
         # If the string cannot be converted, we just ignore it
         nil
-      end.compact
+      end
       commands | completion_data
     end
 

--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -107,7 +107,14 @@ module IRB
 
       return commands unless result
 
-      commands | result.completion_candidates.map { target + _1 }
+      encoded_candidates = result.completion_candidates.filter_map do |i|
+        encoded = i.encode(Encoding.default_external)
+        target + encoded
+      rescue Encoding::UndefinedConversionError
+        # If the string cannot be converted, we just ignore it
+        nil
+      end
+      commands | encoded_candidates
     end
 
     def doc_namespace(preposing, matched, _postposing, bind:)

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -314,4 +314,47 @@ module TestIRB
       assert_equal(IRB::InputCompletor.retrieve_completion_data('a.abs', bind: bind, doc_namespace: true), 'Integer.abs')
     end
   end
+
+  class InvalidEncodingMethodTest < TestCase
+    def test_invalid_encoding_method_warning
+      if RUBY_ENGINE == 'truffleruby'
+        omit "TruffleRuby does not support invalid encoding methods."
+      end
+
+      invalid_method_name = "b\xff".force_encoding(Encoding::ASCII_8BIT)
+
+      test_obj = Object.new
+      test_obj.define_singleton_method(invalid_method_name) {}
+      test_bind = test_obj.instance_eval { binding }
+
+      original_stderr = $stderr
+      original_encoding = Encoding.default_external
+      original_verbose = $VERBOSE
+
+      begin
+        stderr_buffer = StringIO.new
+        $stderr = stderr_buffer
+        $VERBOSE = nil
+        Encoding.default_external = Encoding::UTF_8
+        $VERBOSE = original_verbose
+
+        completor = IRB::RegexpCompletor.new
+        result = completor.completion_candidates('', 'b', '', bind: test_bind)
+
+        assert_equal("Warning: Invalid encoding in method name 'b\xff'. can't be converted to the locale UTF-8.\n".force_encoding(Encoding::ASCII_8BIT), stderr_buffer.string.force_encoding(Encoding::ASCII_8BIT))
+        assert_not_include(result, nil)
+
+        stderr_buffer.truncate(0)
+        stderr_buffer.rewind
+        stderr_buffer = StringIO.new
+
+        completor.completion_candidates('', 'b', '', bind: test_bind)
+        assert_empty(stderr_buffer.string)
+      ensure
+        $stderr = original_stderr
+        Encoding.default_external = original_encoding
+        $VERBOSE = original_verbose
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This PR fixes a crash in IRB's method completion when a completion candidate contains characters that cannot be converted to `Encoding.default_external`.（#900）

## Problem

Currently, if a method or variable name includes characters incompatible with `Encoding.default_external`, triggering method completion results in an `Encoding::UndefinedConversionError`, which crashes the entire IRB session. This leads to a poor user experience, as the session terminates unexpectedly and work can be lost.

## Solution

Instead of allowing the exception to crash the session, this change catches the encoding error and prints a warning message to stderr. To avoid flooding the console, this warning is displayed only once per session upon the first occurrence of the error.

This approach is preferable because it informs the user about the underlying encoding issue without abruptly ending their workflow.

### Behavior Change

-   **Before:** IRB crashes when method completion is triggered with an incompatible character.
-   **After:** A warning is printed once, and the IRB session continues to run.