### PR TITLE
Remove `Gem.try_activate` usage

### DIFF
--- a/lib/irb/locale.rb
+++ b/lib/irb/locale.rb
@@ -118,7 +118,6 @@ module IRB # :nodoc:
           full_path = File.join(libpath, lc_path)
           return full_path if File.readable?(full_path)
         end
-        redo if defined?(Gem) and Gem.try_activate(lc_path)
       end
       nil
     end


### PR DESCRIPTION
This is not meant to be merged as is, just opening it mainly as a question. I read the code and I could not understand the purpose of `Gem.try_activate` here.

The only usage I know of `Gem.try_activate` is internal to RubyGems. It's part of its custom `require` implementation. When standard `require` fails, RubyGems tries to activate a gem including the given path. That way it is added to the `$LOAD_PATH` and `require` can succeed when retried a second time.

In this case, it seems to try to activate some potential gem including IRB localizations. However, that gem is never subsequently required so in particular I'm not sure what the `redo` is for, and not sure either if using `Gem.try_activate` is necessary at all.

Even if it was necessary, it should be probably guarded by `defined?(Bundler::Setup)` or something like that, because I don't think `Gem.try_activate` makes sense in a `bundler/setup` context, since `bundler/setup` eliminates RubyGems discovery mechanism and instead sets up a fixed `$LOAD_PATH` with the gems in your `Gemfile`. So, technically, if using some localization gem, you should add it to your Gemfile.

For what it's worth, I found this while looking into this Bundler issue: https://github.com/rubygems/rubygems/issues/8754.