### PR TITLE
Remove all internal frames from a backtrace

### DIFF
--- a/lib/irb/debug.rb
+++ b/lib/irb/debug.rb
@@ -49,7 +49,7 @@ module IRB
           def DEBUGGER__.capture_frames(*args)
             frames = capture_frames_without_irb(*args)
             frames.reject! do |frame|
-              frame.realpath&.start_with?(IRB_DIR) || frame.path == "<internal:prelude>"
+              frame.realpath&.start_with?(IRB_DIR) || frame.path.start_with?("<internal:")
             end
             frames
           end

--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -879,7 +879,14 @@ module TestIRB
       assert_match(/irbtest-.*\.rb:2:in (`|'Object#)foo': error \(RuntimeError\)/, output)
       frame_traces = output.split("\n").map(&:strip).grep(/from /)
 
-      expected_traces = if RUBY_VERSION >= "3.3.0"
+      expected_traces = if RUBY_VERSION >= "3.5.0"
+        [
+          /from .*\/irbtest-.*.rb:6:in (`|'Object#)bar'/,
+          /from .*\/irbtest-.*.rb\(irb\):1:in [`']<main>'/,
+          /from .*\/irbtest-.*.rb:9:in (`|'Binding#)irb'/,
+          /from .*\/irbtest-.*.rb:9:in [`']<main>'/
+        ]
+      elsif RUBY_VERSION >= "3.3.0"
         [
           /from .*\/irbtest-.*.rb:6:in (`|'Object#)bar'/,
           /from .*\/irbtest-.*.rb\(irb\):1:in [`']<main>'/,
@@ -934,11 +941,20 @@ module TestIRB
       assert_match(/irbtest-.*\.rb:2:in (`|'Object#)foo': error \(RuntimeError\)/, output)
       frame_traces = output.split("\n").map(&:strip).grep(/from /)
 
-      expected_traces = [
-        /from .*\/irbtest-.*.rb:6:in (`|'Object#)bar'/,
-        /from .*\/irbtest-.*.rb\(irb\):1:in [`']<main>'/,
-        /from .*\/irbtest-.*.rb:9:in [`']<main>'/
-      ]
+      expected_traces = if RUBY_VERSION >= "3.5.0"
+        [
+          /from .*\/irbtest-.*.rb:6:in (`|'Object#)bar'/,
+          /from .*\/irbtest-.*.rb\(irb\):1:in [`']<main>'/,
+          /from .*\/irbtest-.*.rb:9:in (`|'Binding#)irb'/,
+          /from .*\/irbtest-.*.rb:9:in [`']<main>'/
+        ]
+      else
+        [
+          /from .*\/irbtest-.*.rb:6:in (`|'Object#)bar'/,
+          /from .*\/irbtest-.*.rb\(irb\):1:in [`']<main>'/,
+          /from .*\/irbtest-.*.rb:9:in [`']<main>'/
+        ]
+      end
 
       expected_traces.reverse! if RUBY_VERSION < "3.0.0"
 


### PR DESCRIPTION
In Ruby 3.5, the debug inspector API returns a raw backtrace, so irb/debug needs to remove not only `<internal:prelude>` but also all internal frames.