### PR TITLE
whereami: support -f to show the full file like pry

### DIFF
--- a/lib/irb/command/whereami.rb
+++ b/lib/irb/command/whereami.rb
@@ -6,10 +6,13 @@ module IRB
   module Command
     class Whereami < Base
       category "Context"
-      description "Show the source code around binding.irb again."
+      description "Show the source code around binding.irb again. `-f` shows the full file."
 
-      def execute(_arg)
-        code = irb_context.workspace.code_around_binding
+      def execute(arg)
+        code = irb_context.workspace.code_around_binding(
+          show_full_file: arg.split.first == "-f"
+        )
+
         if code
           puts code
         else

--- a/lib/irb/workspace.rb
+++ b/lib/irb/workspace.rb
@@ -125,7 +125,7 @@ EOF
       bt
     end
 
-    def code_around_binding
+    def code_around_binding(show_full_file: false)
       file, pos = @binding.source_location
 
       if defined?(::SCRIPT_LINES__[file]) && lines = ::SCRIPT_LINES__[file]
@@ -141,8 +141,13 @@ EOF
       lines = Color.colorize_code(code).lines
       pos -= 1
 
-      start_pos = [pos - 5, 0].max
-      end_pos   = [pos + 5, lines.size - 1].min
+      if show_full_file
+        start_pos = 0
+        end_pos   = lines.size - 1
+      else
+        start_pos = [pos - 5, 0].max
+        end_pos   = [pos + 5, lines.size - 1].min
+      end
 
       line_number_fmt = Color.colorize("%#{end_pos.to_s.length}d", [:BLUE, :BOLD])
       fmt = " %2s #{line_number_fmt}: %s"

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -595,6 +595,14 @@ module TestIRB
       assert_empty err
       assert_match(/^From: .+ @ line \d+ :\n/, out)
     end
+
+    def test_whereami_file
+      out, err = execute_lines(
+        "whereami -f\n",
+      )
+      assert_empty err
+      assert_match(/^From: .+ @ line \d+ :\n\s+1:/, out)
+    end
   end
 
   class LsTest < CommandTestCase


### PR DESCRIPTION
Support passing `-f` to `whereami` to show the full file, like `pry` does.


> [!NOTE]
> I added support for `-f`, but not for `--file`, since the only other IRB command I see that has flags only supports short forms (`history`).
>
> I haven't personally ever used `--file`.

Here's `pry`'s help page for comparison:

```
% pry
[1] pry(main)> help whereami                                                                                     
Usage: whereami [-qn] [LINES]

Describe the current location. If you use `binding.pry` inside a method then
whereami will print out the source for that method.

If a number is passed, then LINES lines before and after the current line will be
shown instead of the method itself.

The `-q` flag can be used to suppress error messages in the case that there's
no code to show. This is used by pry in the default before_session hook to show
you when you arrive at a `binding.pry`.

The `-n` flag can be used to hide line numbers so that code can be copy/pasted
effectively.

When pry was started on an Object and there is no associated method, whereami
will instead output a brief description of the current object.

    -q, --quiet                Don't display anything in case of an error
    -n, --no-line-numbers      Do not display line numbers
    -m, --method               Show the complete source for the current method.
    -c, --class                Show the complete source for the current class or module.
    -f, --file                 Show the complete source for the current file.
    -h, --help                 Show this message.
[2] pry(main)> Pry::VERSION                                                                                      
=> "0.14.2"
```

---

Thanks for IRB, btw!