### PR TITLE
Add tsort to dependencies

### DIFF
--- a/irb.gemspec
+++ b/irb.gemspec
@@ -45,4 +45,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "reline", ">= 0.4.2"
   spec.add_dependency "rdoc", ">= 4.0.0"
   spec.add_dependency "pp", ">= 0.6.0"
+  spec.add_dependency "tsort"
 end


### PR DESCRIPTION
tsort is becoming a bundled gem in Ruby 3.6 and Ruby 3.5 is already printing warnings about it. Since tsort supports Ruby 2.3+, it should be safe to add it to the dependencies.

Fix CI