### PR TITLE
Fix show_source command when obj.method is overrided

### DIFF
--- a/lib/irb/source_finder.rb
+++ b/lib/irb/source_finder.rb
@@ -114,7 +114,7 @@ module IRB
       when "owner"
         target_method = owner_receiver.instance_method(method)
       when "receiver"
-        target_method = owner_receiver.method(method)
+        target_method = Kernel.instance_method(:method).bind_call(owner_receiver, method)
       end
       super_level.times do |s|
         target_method = target_method.super_method if target_method

--- a/test/irb/command/test_show_source.rb
+++ b/test/irb/command/test_show_source.rb
@@ -376,6 +376,23 @@ module TestIRB
       assert_match(%r[Defined in binary file:.+io/console], out)
     end
 
+    def test_show_source_method_overrided
+      write_ruby <<~RUBY
+        class Request
+          def method; 'POST'; end
+          def path; '/'; end
+        end
+        request = Request.new
+        binding.irb
+      RUBY
+
+      out = run_ruby_file do
+        type "show_source request.path"
+        type "exit"
+      end
+      assert_match(%r[#{@ruby_file.to_path}:3\s+def path; '/'; end], out)
+    end
+
     def test_show_source_with_constant_lookup
       write_ruby <<~RUBY
         X = 1


### PR DESCRIPTION
`method` method is sometimes overridden.
```ruby
req = Net::HTTP::Post.new('/path')
req.method #=> "POST"
req.path #=> "/path"
```

Fixes this error
```
irb(main):001> require 'net/http'
=> true
irb(main):002> req = Net::HTTP::Post.new('/path')
=> #<Net::HTTP::Post POST>
irb(main):003> $ req.path
lib/irb/source_finder.rb:117:in 'IRB::SourceFinder#method_target': wrong number of arguments (given 1, expected 0) (ArgumentError)

        target_method = owner_receiver.method(method)
                                              ^^^^^^
```
