### PR TITLE
Gemfile: add github dependency on rbs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,5 +25,6 @@ gem "debug", github: "ruby/debug", platforms: [:mri, :mswin]
 gem "rdoc", ">= 6.11.0"
 
 if RUBY_VERSION >= "3.0.0" && !is_truffleruby
+  gem "rbs", github: "ruby/rbs" if RUBY_VERSION >= "3.2"
   gem "repl_type_completor"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "debug", github: "ruby/debug", platforms: [:mri, :mswin]
 gem "rdoc", ">= 6.11.0"
 
 if RUBY_VERSION >= "3.0.0" && !is_truffleruby
+  # TODO: Remove this after rbs is released with tsort in its dependencies
   gem "rbs", github: "ruby/rbs" if RUBY_VERSION >= "3.2"
   gem "repl_type_completor"
 end


### PR DESCRIPTION
...until https://github.com/ruby/rbs/commit/14fd824ebde3a5c2403126fa2df11394d3b9b98f is in a release.

"Add explicit dependency on the tsort gem"

See https://github.com/ruby/reline/pull/847