### PR TITLE
Do not save consecutive duplicate commands to history

### DIFF
--- a/lib/irb/input-method.rb
+++ b/lib/irb/input-method.rb
@@ -223,7 +223,7 @@ module IRB
       Readline.input = @stdin
       Readline.output = @stdout
       if l = Readline.readline(@prompt, false)
-        Readline::HISTORY.push(l) if !l.empty?
+        Readline::HISTORY.push(l) if !l.empty? && l != Readline::HISTORY.last
         @line[@line_no += 1] = l + "\n"
       else
         @eof = true
@@ -480,7 +480,7 @@ module IRB
       Reline.prompt_proc = @prompt_proc
       Reline.auto_indent_proc = @auto_indent_proc if @auto_indent_proc
       if l = Reline.readmultiline(@prompt, false, &@check_termination_proc)
-        Reline::HISTORY.push(l) if !l.empty?
+        Reline::HISTORY.push(l) if !l.empty? && l != Reline::HISTORY.last
         @line[@line_no += 1] = l + "\n"
       else
         @eof = true


### PR DESCRIPTION
Emulates `HISTCONTROL=ignoredups` from Bash and partly addresses https://github.com/ruby/irb/issues/355.

IRB will not add a command to history if it's the same as the immediate previous command; it won't look further back in the history list. This is also the default behavior in Pry.

It might be safer to expose this as a config flag but I can't personally see the value in consecutive duplicate entries. Open to discussion, of course!

