### PR TITLE
Bump integration test's timeout on CI to 30s

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -114,7 +114,7 @@ module TestIRB
 
   class IntegrationTestCase < TestCase
     LIB = File.expand_path("../../lib", __dir__)
-    TIMEOUT_SEC = 3
+    TIMEOUT_SEC = ENV["CI"] ? 30 : 3
 
     def setup
       @envs = {}


### PR DESCRIPTION
This is to allow ZJIT test against bundled gems on CI.

I don't see the same error locally so I'm not touching the default timeout yet.