### PR TITLE
Easter-egg Use endless range instead of step

### DIFF
--- a/lib/irb/easter-egg.rb
+++ b/lib/irb/easter-egg.rb
@@ -126,7 +126,7 @@ module IRB
           end
           ruby_model = RubyModel.new
           print "\e[?25l" # hide cursor
-          0.step do |i| # TODO (0..).each needs Ruby 2.6 or later
+          (0..).each do |i|
             buff = canvas.draw do
               ruby_model.render_frame(i) do |p1, p2|
                 canvas.line(p1, p2)


### PR DESCRIPTION
Clean up TODO comment mentioning the usage of ruby endless range after ruby 2.6. Since irb now requires 2.7+ this should be safe to change