### PR TITLE
Reset IOGate.set_winch_handler when dancing ruby easter-egg terminates

### DIFF
--- a/lib/irb/easter-egg.rb
+++ b/lib/irb/easter-egg.rb
@@ -121,6 +121,7 @@ module IRB
           interrupted = false
           prev_trap = trap("SIGINT") { interrupted = true }
           canvas = Canvas.new(Reline.get_screen_size)
+          otio = Reline::IOGate.prep
           Reline::IOGate.set_winch_handler do
             canvas = Canvas.new(Reline.get_screen_size)
           end
@@ -139,6 +140,7 @@ module IRB
           end
         rescue Interrupt
         ensure
+          Reline::IOGate.deprep(otio)
           print "\e[?25h" # show cursor
           trap("SIGINT", prev_trap)
         end


### PR DESCRIPTION
Fix this SystemStackError
```
irb(main):001> IRB.send(:easter_egg, :dancing)
(CTRL-c)
=> nil
irb(main):002> IRB.send(:easter_egg, :dancing)
(Resize window)
stack level too deep (SystemStackError)
lib/reline/io/ansi.rb:289:in 'block in Reline::ANSI#set_winch_handler'
lib/reline/io/ansi.rb:289:in 'block in Reline::ANSI#set_winch_handler'
lib/reline/io/ansi.rb:289:in 'block in Reline::ANSI#set_winch_handler'
...
```

`IOGate.set_winch_handler` needs cleanup: `IOGate.deprep(otio)` and `otio` should be a return value of `IOGate.prep`.
Currently, otio is always nil but may change in the future.