### PR TITLE
 Pin power_assert to v2 for Ruby 2.7 (v3 requires 3.1+)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "reline", github: "ruby/reline" if ENV["WITH_LATEST_RELINE"] == "true"
 gem "rake"
 gem "test-unit"
 gem "test-unit-ruby-core"
+gem "power_assert", "~> 2.0" if RUBY_VERSION < '3.0' # https://github.com/ruby/power_assert/pull/61
 
 gem "rubocop"
 


### PR DESCRIPTION
The CI build is failing on Ruby 2.7 because power_assert v3.0.0 dropped support for Ruby versions below 3.1.

While we should probably consider dropping support for Ruby 2.7 soon, this PR prioritizes restoring the CI build. It pins the power_assert version for Ruby 2.7.

Since the CI is still passing on Ruby 3.0, this version constraint is applied only to Ruby 2.7.

- Ref: https://github.com/ruby/power_assert/pull/57
- Ref: https://github.com/ruby/power_assert/pull/61