### PR TITLE
Revert " Pin power_assert to v2 for Ruby 2.7 (v3 requires 3.1+)"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "reline", github: "ruby/reline" if ENV["WITH_LATEST_RELINE"] == "true"
 gem "rake"
 gem "test-unit"
 gem "test-unit-ruby-core"
-gem "power_assert", "~> 2.0" if RUBY_VERSION < '3.0' # https://github.com/ruby/power_assert/pull/61
 
 gem "rubocop"
 


### PR DESCRIPTION
power_assert v3.0.1 has been released, so ruby/irb#1135 has been reverted.

The falling truffleruby test may not be related.