### PR TITLE
Avoid creating method objects unnecessarily when distinguishing between commands and statements.

### DIFF
--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -632,14 +632,15 @@ module IRB
         command_class = Command.load_command(command)
       end
 
-      # Check visibility
-      public_method = !!KERNEL_PUBLIC_METHOD.bind_call(main, command) rescue false
-      private_method = !public_method && !!KERNEL_METHOD.bind_call(main, command) rescue false
-      if command_class && Command.execute_as_command?(command, public_method: public_method, private_method: private_method)
-        Statement::Command.new(code, command_class, arg)
-      else
-        Statement::Expression.new(code, is_assignment_expression)
+      if command_class
+        # Check whether the command conflicts with existing methods
+        public_method = !!KERNEL_PUBLIC_METHOD.bind_call(main, command) rescue false
+        private_method = !public_method && !!KERNEL_METHOD.bind_call(main, command) rescue false
+        if Command.execute_as_command?(command, public_method: public_method, private_method: private_method)
+          return Statement::Command.new(code, command_class, arg)
+        end
       end
+      Statement::Expression.new(code, is_assignment_expression)
     end
 
     def colorize_input(input, complete:)


### PR DESCRIPTION
It's better not to create method object unnecessarily.

Found by this bug report: https://bugs.ruby-lang.org/issues/21673
Segfaults at `KERNEL_PUBLIC_METHOD.bind_call(main, command)` in `context.rb:636`
```ruby
# Step 1
irb(main):001* module Foo
irb(main):002*   refine Kernel do
irb(main):003*      def puts; end
irb(main):004*   end
irb(main):005> end
=> #<refinement:Kernel@Foo>
# Step 2: Type "puts"
irb(main):006> put/path/to/lib/irb/context.rb:636: [BUG] Segmentation fault at 0x0000000000000030
...
```
