### PR TITLE
Change platform mswin to nil

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "test-unit-ruby-core"
 gem "rubocop"
 
 gem "tracer" if !is_truffleruby
-gem "debug", github: "ruby/debug", platforms: [:mri, :mswin]
+gem "debug", github: "ruby/debug"
 
 gem "rdoc", ">= 6.11.0"
 


### PR DESCRIPTION
Avoid this error when `bundle install` runs on Ruby HEAD.

```
[REMOVED] Platform :mswin has been removed. Please use platform :windows instead.
```