### PR TITLE
[lib/irb] Explicitly join on "" so $, does not change error message outputs

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -430,7 +430,7 @@ module IRB
           end
         end
         lines = lines.reverse if order == :bottom
-        lines.map{ |l| l + "\n" }.join
+        lines.map{ |l| l + "\n" }.join('')
       }
       # The "<top (required)>" in "(irb)" may be the top level of IRB so imitate the main object.
       message = message.gsub(/\(irb\):(?<num>\d+):in (?<open_quote>[`'])<(?<frame>top \(required\))>'/) { "(irb):#{$~[:num]}:in #{$~[:open_quote]}<main>'" }


### PR DESCRIPTION
This PR does a minor change to `lib/irb.rb` so that the `.join` done on error messages doesn't use `$,`. I use `$,` occasionally when debugging some older scripts, and having IRB's error messages use it is a bit annoying.

I've made [another PR](https://github.com/ruby/reline/pull/866/files) to `reline` which solves a much more egregious problem (it does this joining when printing chars out in prompts!)

# Before
```
% irb
irb(main):001> def (Reline::Unicode).escape_for_print(str) # required until my PR for reline is merged
irb(main):002*   str.chars.map! { |gr|
irb(main):003*     case gr
irb(main):004*     when -"\n"
irb(main):005*       gr
irb(main):006*     when -"\t"
irb(main):007*       -'  '
irb(main):008*     else
irb(main):009*       Reline::Unicode::EscapedPairs[gr.ord] || gr
irb(main):010*     end
irb(main):011*   }.join('')
irb(main):012* end
=> :escape_for_print
irb(main):013> $, = '|'
=> "|"
irb(main):014> fail "oops"
(irb):14:in '<main>': oops (RuntimeError)
  from <internal:kernel>:168:in 'Kernel#loop'
| from /Users/me/.rbenv/versions/3.5.0-preview1/lib/ruby/gems/3.5.0+0/gems/irb-1.15.2/exe/irb:9:in '<top (required)>'
| from /Users/me/.rbenv/versions/3.5.0-preview1/bin/irb:25:in 'Kernel#load'
| from /Users/me/.rbenv/versions/3.5.0-preview1/bin/irb:25:in '<main>'
```

# After
```
irb(main):001> def (Reline::Unicode).escape_for_print(str) # required until my PR for reline is merged
irb(main):002*   str.chars.map! { |gr|
irb(main):003*     case gr
irb(main):004*     when -"\n"
irb(main):005*       gr
irb(main):006*     when -"\t"
irb(main):007*       -'  '
irb(main):008*     else
irb(main):009*       Reline::Unicode::EscapedPairs[gr.ord] || gr
irb(main):010*     end
irb(main):011*   }.join('')
irb(main):012* end
=> :escape_for_print
irb(main):013> $, = '|'
=> "|"
irb(main):014> fail "oops"
(irb):14:in '<main>': oops (RuntimeError)
  from <internal:kernel>:168:in 'Kernel#loop'
  from /Users/me/.rbenv/versions/3.5.0-preview1/lib/ruby/gems/3.5.0+0/gems/irb-1.15.2/exe/irb:9:in '<top (required)>'
  from /Users/me/.rbenv/versions/3.5.0-preview1/bin/irb:25:in 'Kernel#load'
  from /Users/me/rbenv/versions/3.5.0-preview1/bin/irb:25:in '<main>'
```
