### PR TITLE
Support copy command on windows and wsl

### DIFF
--- a/lib/irb/command/copy.rb
+++ b/lib/irb/command/copy.rb
@@ -72,7 +72,7 @@ module IRB
       end
 
       def clipboard_available?
-        windows? || !!clipboard_program
+        !!clipboard_program
       end
 
       def windows?


### PR DESCRIPTION
Enable the `copy` command on Windows and WSL environments.

The `copy` command now works both on Windows Ruby and on WSL, copying the evaluated result to the system clipboard.

## Examples
### Windows (mingw-ucrt)

```
PS C:\Ruby\repos\irb> ruby -v
ruby 3.4.8 (2025-12-17 revision 995b59f666) +PRISM [x64-mingw-ucrt]
PS C:\Ruby\repos\irb> ruby -Ilib .\exe\irb
irb(main):001> RUBY_PLATFORM
=> "x64-mingw-ucrt"
irb(main):002> copy 2**11
Copied to system clipboard
irb(main):003> 2048 # <- Ctrl-V
=> 2048
```

### WSL

```
hogelog@lenovo:/mnt/c/Ruby/repos/irb$ ruby -Ilib ./exe/irb
irb(main):001> RUBY_PLATFORM
=> "x86_64-linux"
irb(main):002> copy 2**10
Copied to system clipboard
irb(main):003> 1024 # <- Ctrl-V
=> 1024
```


## Windows workaround
On Windows, passing text via stdin does not work reliably in IRB. After calling `IO.popen`, IRB’s input handling becomes unstable, but I have not fully identified the root cause yet.

To work around this, the Windows implementation invokes PowerShell’s `Set-Clipboard` and passes the text via command-line arguments instead of stdin:

```
powershell.exe -NoProfile -Command Set-Clipboard -Value <text>
```

This approach works reliably on native Windows Ruby.

This issue is likely not limited to the `copy` command, and there may be other cases where IRB does not behave correctly. If this problem can be resolved, it should be possible to simply call `clip.exe` even on Windows. I plan to investigate this separately.