### PR TITLE
Remove deprecated toplevel ::RubyLex

### DIFF
--- a/lib/irb/ruby-lex.rb
+++ b/lib/irb/ruby-lex.rb
@@ -496,6 +496,3 @@ module IRB
   end
   # :startdoc:
 end
-
-RubyLex = IRB::RubyLex
-Object.deprecate_constant(:RubyLex)

--- a/test/irb/test_ruby_lex.rb
+++ b/test/irb/test_ruby_lex.rb
@@ -207,15 +207,6 @@ module TestIRB
       refute(ruby_lex.assignment_expression?("", local_variables: [:a]), "empty code should not be an assignment expression")
     end
 
-    def test_initialising_the_old_top_level_ruby_lex
-      libdir = File.expand_path("../../lib", __dir__)
-      reline_libdir = Gem.loaded_specs["reline"].full_gem_path + "/lib"
-      assert_in_out_err(["-I#{libdir}", "-I#{reline_libdir}", "--disable-gems", "-W:deprecated"], <<~RUBY, [], /warning: constant ::RubyLex is deprecated/)
-        require "irb"
-        ::RubyLex.new(nil)
-      RUBY
-    end
-
     private
 
     def assert_indent_level(lines, expected, local_variables: [])


### PR DESCRIPTION
It was deprecated in `v1.8.0`.
Closes #1154