### PR TITLE
Stop pointing rbs to git source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,5 @@ else
 end
 
 if RUBY_VERSION >= "3.0.0" && !is_truffleruby
-  # TODO: Remove this after rbs is released with tsort in its dependencies
-  gem "rbs", github: "ruby/rbs" if RUBY_VERSION >= "3.2"
   gem "repl_type_completor"
 end


### PR DESCRIPTION
rdoc (a rbs dependency) has added tsort as a dependency. So this is not needed anymore.