### PR TITLE
Silence `default_external` warning in tests

### DIFF
--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -76,6 +76,14 @@ module TestIRB
       end
     end
 
+    def with_default_external(encoding)
+      original = Encoding.default_external
+      EnvUtil.suppress_warning { Encoding.default_external = encoding }
+      yield
+    ensure
+      EnvUtil.suppress_warning { Encoding.default_external = original }
+    end
+
     def without_rdoc(&block)
       ::Kernel.send(:alias_method, :irb_original_require, :require)
 

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -327,11 +327,7 @@ module TestIRB
       test_obj.define_singleton_method(invalid_method_name) {}
       test_bind = test_obj.instance_eval { binding }
 
-      original_encoding = Encoding.default_external
-
-      begin
-        Encoding.default_external = Encoding::UTF_8
-
+      with_default_external(Encoding::UTF_8) do
         completor = IRB::RegexpCompletor.new
 
         assert_nothing_raised do
@@ -339,8 +335,6 @@ module TestIRB
           assert_include(result, 'block_given?')
           assert_not_include(result, nil)
         end
-      ensure
-        Encoding.default_external = original_encoding
       end
     end
 

--- a/test/irb/test_type_completor.rb
+++ b/test/irb/test_type_completor.rb
@@ -88,18 +88,12 @@ module TestIRB
       test_obj.define_singleton_method(invalid_method_name) {}
       test_bind = test_obj.instance_eval { binding }
 
-      original_encoding = Encoding.default_external
-
-      begin
-        Encoding.default_external = Encoding::UTF_8
-
+      with_default_external(Encoding::UTF_8) do
         assert_nothing_raised do
           result = @completor.completion_candidates('', 'b', '', bind: test_bind)
           assert_include(result, 'block_given?')
           assert_not_include(result, nil)
         end
-      ensure
-        Encoding.default_external = original_encoding
       end
     end
   end


### PR DESCRIPTION
Some warnings appear in test output because of this pattern