### PR TITLE
Add IRB `fix` command to rerun with corrected spelling (references ruby/did_you_mean#179)

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -234,7 +234,8 @@ module IRB
             end
             handle_exception(exc)
             if Command::Fix.fixable?
-              puts "\e[2mType `fix` to rerun with the correction.\e[0m"
+              hint = Command::Fix::HINT
+              puts Color.colorable? ? Color.colorize(hint, [:BOLD]) : hint
             end
             @context.workspace.local_variable_set(:_, exc)
           end

--- a/lib/irb/command/fix.rb
+++ b/lib/irb/command/fix.rb
@@ -9,7 +9,13 @@
 module IRB
   module Command
     class Fix < Base
+      # Maximum Levenshtein distance for accepting a correction (did_you_mean default).
       MAX_EDIT_DISTANCE = 2
+
+      HINT = "Type `fix` to rerun with the correction."
+      MSG_NO_PREVIOUS_ERROR = "No previous error with Did you mean? suggestions. Try making a typo first, e.g. 1.zeor?"
+      MSG_NOT_CORRECTABLE = "Last error is not correctable. The fix command only works with NoMethodError, NameError, KeyError, etc."
+      MSG_RERUNNING = "Rerunning with: %s"
 
       category "did_you_mean"
       description "Rerun the previous command with corrected spelling from Did you mean?"
@@ -19,12 +25,12 @@ module IRB
         exception = LastError.last_exception
 
         if code.nil? || exception.nil?
-          puts "No previous error with Did you mean? suggestions. Try making a typo first, e.g. 1.zeor?"
+          puts MSG_NO_PREVIOUS_ERROR
           return
         end
 
         unless correctable?(exception)
-          puts "Last error is not correctable. The fix command only works with NoMethodError, NameError, KeyError, etc."
+          puts MSG_NOT_CORRECTABLE
           return
         end
 
@@ -34,8 +40,8 @@ module IRB
         corrected_code = apply_correction(code, wrong_str, correction)
         return unless corrected_code
 
-        puts "Rerunning with: #{corrected_code}"
-        eval_path = @irb_context.instance_variable_get(:@eval_path) || "(irb)"
+        puts format(MSG_RERUNNING, corrected_code)
+        eval_path = @irb_context.eval_path || "(irb)"
         result = @irb_context.workspace.evaluate(corrected_code, eval_path, LastError.last_line_no)
         @irb_context.set_last_value(result)
         @irb_context.irb.output_value if @irb_context.echo?
@@ -44,88 +50,97 @@ module IRB
 
       class << self
         def fixable?
-          return false if LastError.last_code.nil? || LastError.last_exception.nil?
-          cmd = allocate
-          cmd.instance_variable_set(:@irb_context, nil)
-          return false unless cmd.send(:correctable?, LastError.last_exception)
-          wrong_str, correction = cmd.send(:extract_correction, LastError.last_exception)
+          code = LastError.last_code
+          exception = LastError.last_exception
+          return false if code.nil? || exception.nil?
+          return false unless fix_correctable?(exception)
+          wrong_str, correction = fix_extract_correction(exception)
           return false if correction.nil?
-          !cmd.send(:apply_correction, LastError.last_code, wrong_str, correction).nil?
+          !fix_apply_correction(code, wrong_str, correction).nil?
+        end
+
+        private
+
+        def fix_correctable?(exception)
+          exception.respond_to?(:corrections) && exception.is_a?(Exception)
+        end
+
+        def fix_extract_correction(exception)
+          corrections = exception.corrections
+          return [nil, nil] if corrections.nil? || corrections.empty?
+
+          wrong_str = fix_wrong_string_from(exception)
+          return [nil, nil] if wrong_str.nil? || wrong_str.to_s.empty?
+
+          filtered = if defined?(DidYouMean::Levenshtein)
+            corrections.select do |c|
+              c_str = c.is_a?(Array) ? c.first.to_s : c.to_s
+              DidYouMean::Levenshtein.distance(fix_normalize(wrong_str), fix_normalize(c_str)) <= MAX_EDIT_DISTANCE
+            end
+          else
+            corrections
+          end
+
+          return [nil, nil] unless filtered.size == 1
+
+          correction = filtered.first
+          correction_str = correction.is_a?(Array) ? correction.first : correction
+          [wrong_str.to_s, correction_str]
+        end
+
+        def fix_wrong_string_from(exception)
+          case exception
+          when NoMethodError then exception.name.to_s
+          when NameError then exception.name.to_s
+          when KeyError then exception.key.to_s
+          when LoadError then exception.message[/cannot load such file -- (.+)/, 1]
+          else
+            if defined?(NoMatchingPatternKeyError) && exception.is_a?(NoMatchingPatternKeyError)
+              exception.key.to_s
+            end
+          end
+        end
+
+        def fix_normalize(str)
+          str.to_s.downcase
+        end
+
+        # Replaces wrong_str with correction in code. Uses gsub to fix all occurrences
+        # (e.g. "foo.zeor? && bar.zeor?" both get corrected).
+        def fix_apply_correction(code, wrong_str, correction_str)
+          correction_display = correction_str.to_s
+          patterns = [
+            [wrong_str, correction_display],
+            [":#{wrong_str}", ":#{correction_display}"],
+            ["\"#{wrong_str}\"", "\"#{correction_display}\""],
+            ["'#{wrong_str}'", "'#{correction_display}'"],
+          ]
+          patterns.each do |wrong_pattern, correct_pattern|
+            escaped = Regexp.escape(wrong_pattern)
+            new_code = code.gsub(/#{escaped}/, correct_pattern)
+            return new_code if new_code != code
+          end
+          nil
         end
       end
 
       private
 
       def correctable?(exception)
-        exception.respond_to?(:corrections) && exception.is_a?(Exception)
+        self.class.send(:fix_correctable?, exception)
       end
 
       def extract_correction(exception)
-        corrections = exception.corrections
-        return [nil, nil] if corrections.nil? || corrections.empty?
-
-        wrong_str = wrong_string_from(exception)
-        return [nil, nil] if wrong_str.nil? || wrong_str.to_s.empty?
-
-        # Use did_you_mean's Levenshtein when available
-        filtered = if defined?(DidYouMean::Levenshtein)
-          corrections.select do |c|
-            correction_str = c.is_a?(Array) ? c.first.to_s : c.to_s
-            DidYouMean::Levenshtein.distance(normalize(wrong_str), normalize(correction_str)) <= MAX_EDIT_DISTANCE
-          end
-        else
-          corrections
-        end
-
-        return [nil, nil] unless filtered.size == 1
-
-        correction = filtered.first
-        correction_str = correction.is_a?(Array) ? correction.first : correction
-        [wrong_str.to_s, correction_str]
-      end
-
-      def wrong_string_from(exception)
-        case exception
-        when NoMethodError
-          exception.name.to_s
-        when NameError
-          exception.name.to_s
-        when KeyError
-          exception.key.to_s
-        when defined?(NoMatchingPatternKeyError) && NoMatchingPatternKeyError
-          exception.key.to_s
-        when LoadError
-          exception.message[/cannot load such file -- (.+)/, 1]
-        else
-          nil
-        end
-      end
-
-      def normalize(str)
-        str.to_s.downcase
+        self.class.send(:fix_extract_correction, exception)
       end
 
       def apply_correction(code, wrong_str, correction_str)
-        correction_display = correction_str.to_s
-
-        patterns = [
-          [wrong_str, correction_display],
-          [":#{wrong_str}", ":#{correction_display}"],
-          ["\"#{wrong_str}\"", "\"#{correction_display}\""],
-          ["'#{wrong_str}'", "'#{correction_display}'"],
-        ]
-
-        patterns.each do |wrong_pattern, correct_pattern|
-          escaped = Regexp.escape(wrong_pattern)
-          new_code = code.sub(/#{escaped}/, correct_pattern)
-          return new_code if new_code != code
-        end
-
-        nil
+        self.class.send(:fix_apply_correction, code, wrong_str, correction_str)
       end
     end
 
-    # Stores the last failed code and exception for the fix command
+    # Stores the last failed code and exception for the fix command.
+    # Not thread-safe; intended for single-threaded IRB sessions.
     module LastError
       @last_code = nil
       @last_exception = nil

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -235,6 +235,10 @@ module IRB
     # - the file path of the current IRB context in a binding.irb session
     attr_reader :irb_path
 
+    # Path used for evaluating code (e.g. in backtraces). Same as irb_path for
+    # non-file contexts; for file paths, includes IRB name postfix.
+    attr_reader :eval_path
+
     # Sets @irb_path to the given +path+ as well as @eval_path
     # @eval_path is used for evaluating code in the context of IRB session
     # It's the same as irb_path, but with the IRB name postfix

--- a/lib/irb/default_commands.rb
+++ b/lib/irb/default_commands.rb
@@ -253,7 +253,7 @@ module IRB
 
     _register_with_aliases(:irb_fix, Command::Fix,
       [:fix, NO_OVERRIDE],
-      [:dym, NO_OVERRIDE]
+      [:retry, NO_OVERRIDE]
     )
 
     register(:cd, Command::CD)

--- a/test/irb/command/test_fix.rb
+++ b/test/irb/command/test_fix.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "irb"
+require_relative "../helper"
+
+module TestIRB
+  class FixCommandTest < TestCase
+    def setup
+      IRB::Command::LastError.clear
+    end
+
+    def teardown
+      IRB::Command::LastError.clear
+    end
+
+    def test_fix_command_shows_hint_on_did_you_mean_error
+      pend "did_you_mean is disabled" unless did_you_mean_available?
+
+      out, err = execute_lines("1.zeor?", "fix")
+
+      assert_match(/Did you mean\?\s+zero\?/, out)
+      assert_match(/Type `fix` to rerun with the correction\./, out)
+      assert_match(/Rerunning with: 1\.zero\?/, out)
+      assert_match(/=> (true|false)/, out)
+      assert_empty(err)
+    end
+
+    def test_fix_command_reruns_with_correction
+      pend "did_you_mean is disabled" unless did_you_mean_available?
+
+      out, err = execute_lines("1.zeor?", "fix")
+
+      assert_match(/Rerunning with: 1\.zero\?/, out)
+      assert_empty(err)
+    end
+
+    def test_fix_command_without_previous_error
+      out, err = execute_lines("fix")
+
+      assert_match(/No previous error with Did you mean\? suggestions/, out)
+      assert_empty(err)
+    end
+
+    def test_fix_command_clears_after_success
+      pend "did_you_mean is disabled" unless did_you_mean_available?
+
+      execute_lines("1.zeor?", "fix")
+      out, err = execute_lines("fix")
+
+      assert_match(/No previous error with Did you mean\? suggestions/, out)
+      assert_empty(err)
+    end
+
+    def test_retry_alias_works
+      pend "did_you_mean is disabled" unless did_you_mean_available?
+
+      out, err = execute_lines("1.zeor?", "retry")
+
+      assert_match(/Rerunning with: 1\.zero\?/, out)
+      assert_empty(err)
+    end
+
+    def test_last_error_stored_on_correctable_exception
+      pend "did_you_mean is disabled" unless did_you_mean_available?
+
+      execute_lines("1.zeor?")
+
+      assert_not_nil(IRB::Command::LastError.last_code)
+      assert_not_nil(IRB::Command::LastError.last_exception)
+      assert_equal("1.zeor?", IRB::Command::LastError.last_code)
+    end
+
+    def test_last_error_cleared_on_uncorrectable_exception
+      execute_lines("raise 'oops'")
+
+      assert_nil(IRB::Command::LastError.last_code)
+      assert_nil(IRB::Command::LastError.last_exception)
+    end
+
+    private
+
+    def did_you_mean_available?
+      return false unless defined?(DidYouMean)
+      1.zeor?
+    rescue NoMethodError => e
+      e.respond_to?(:corrections) && !e.corrections.to_a.empty?
+    end
+  end
+end


### PR DESCRIPTION
# Add IRB `fix` command to rerun with corrected spelling (references ruby/did_you_mean#179)

## Summary

Adds a native `fix` command to IRB that reruns the previous command with corrected spelling when a "Did you mean?" error occurs. This implements the feature requested in [ruby/did_you_mean#179](https://github.com/ruby/did_you_mean/issues/179).

## Example

```ruby
irb(main):001> ac
# => NameError (undefined local variable or method 'ac' for main)
#    Did you mean?  acc
#    Type `fix` to rerun with the correction.

irb(main):002> fix
# Rerunning with: acc
# => ...
```

```ruby
irb(main):001> 1.zeor?
# => NoMethodError (undefined method `zeor?' for 1:Integer)
#    Did you mean?  zero?
#    Type `fix` to rerun with the correction.

irb(main):002> fix
# Rerunning with: 1.zero?
# => true
```

## Why This Change in IRB (Not did_you_mean)?

### The Problem

The `fix` command was originally implemented as an extension in the `did_you_mean` gem via PR ruby/did_you_mean#204 ([https://github.com/ruby/did_you_mean](https://github.com/ruby/did_you_mean)). However, this implementation introduced a load order problem.


- `did_you_mean` is a default gem—Ruby loads it at boot, before any application code
- IRB loads later (e.g., when running `rails console` or `irb`)
- When `did_you_mean` loads, IRB isn't defined yet, so the extension never loads
- Result: The fix command didn't work in Rails console or when IRB loads after app initialization

### Why IRB Should Own This Feature

1. **It's a REPL feature** – The fix command is an IRB command (like `exit`, `load`, `help`). It belongs in the REPL layer.

2. **IRB has the context** – IRB already has the eval loop, exception handling, and access to the last executed code. It's the natural place for this logic.

3. **did_you_mean provides the API** – The [did_you_mean](https://github.com/ruby/did_you_mean) gem adds `#corrections` to exceptions (NameError, NoMethodError, KeyError, etc.). IRB simply uses this public API—no patching or extension loading required.

4. **No load order issues** – When IRB runs, both IRB and did_you_mean are loaded. IRB can check `exception.respond_to?(:corrections)` and use the fix command natively.

5. **Clean separation of concerns** – did_you_mean = spell-checking. IRB = REPL behavior. Each gem does one thing well.

### What IRB Gets from did_you_mean

IRB uses only the **public API** that did_you_mean provides:

- `exception.respond_to?(:corrections)` – Check if the exception has suggestions
- `exception.corrections` – Get the suggested corrections (e.g., `["zero?"]`)
- `DidYouMean::Levenshtein.distance` – Optional; used for edit-distance filtering when available. If did_you_mean isn't loaded (e.g., `--disable-did_you_mean`), the fix command still works but skips the distance filter.

No internal APIs, no patching, no extension loading.

## Implementation Details

### Files Changed

- **`lib/irb/command/fix.rb`** (new) – Fix command and LastError storage
- **`lib/irb.rb`** – Store last correctable exception, show discoverability hint
- **`lib/irb/default_commands.rb`** – Register `fix` and `dym` commands

### Supported Error Types

NoMethodError, NameError, KeyError, NoMatchingPatternKeyError, LoadError

### Correction Logic

- Single suggestion only (edit distance ≤ 2 when did_you_mean is available)
- Replacement patterns: identifiers, symbols, strings
- `dym` alias for users who use `fix` as a variable

### Discoverability

When a fix is available, IRB shows: `Type \`fix\` to rerun with the correction.`

## References

- [ruby/did_you_mean#179](https://github.com/ruby/did_you_mean/issues/179) – Original feature request
- [thefuck](https://github.com/nvbn/thefuck) – Similar concept for shell commands
