### PR TITLE
Make ls command work for BasicObjects

### DIFF
--- a/lib/irb/command/ls.rb
+++ b/lib/irb/command/ls.rb
@@ -55,11 +55,13 @@ module IRB
 
         o = Output.new(grep: grep)
 
-        klass  = (obj.class == Class || obj.class == Module ? obj : obj.class)
+        klass = Kernel.instance_method(:class).bind(obj).call
+        is_class_or_module = klass == Class || klass == Module
+        klass = is_class_or_module ? obj : klass
 
-        o.dump("constants", obj.constants) if obj.respond_to?(:constants)
+        o.dump("constants", obj.constants) if is_class_or_module
         dump_methods(o, klass, obj)
-        o.dump("instance variables", obj.instance_variables)
+        o.dump("instance variables", Kernel.instance_method(:instance_variables).bind(obj).call)
         o.dump("class variables", klass.class_variables)
         o.dump("locals", locals) if locals
         o.print_result
@@ -67,7 +69,7 @@ module IRB
       end
 
       def dump_methods(o, klass, obj)
-        singleton_class = begin obj.singleton_class; rescue TypeError; nil end
+        singleton_class = begin Kernel.instance_method(:singleton_class).bind(obj).call; rescue TypeError; nil end
         dumped_mods = Array.new
         ancestors = klass.ancestors
         ancestors = ancestors.reject { |c| c >= Object } if klass < Object

--- a/lib/irb/command/ls.rb
+++ b/lib/irb/command/ls.rb
@@ -56,10 +56,10 @@ module IRB
         o = Output.new(grep: grep)
 
         klass = Kernel.instance_method(:class).bind(obj).call
-        is_class_or_module = klass == Class || klass == Module
-        klass = is_class_or_module ? obj : klass
+        obj_is_module = Kernel.instance_method(:is_a?).bind(obj).call(Module) # Class is also a Module
+        klass = obj_is_module ? obj : klass
 
-        o.dump("constants", obj.constants) if is_class_or_module
+        o.dump("constants", obj.constants) if obj_is_module
         dump_methods(o, klass, obj)
         o.dump("instance variables", Kernel.instance_method(:instance_variables).bind(obj).call)
         o.dump("class variables", klass.class_variables)

--- a/lib/irb/command/ls.rb
+++ b/lib/irb/command/ls.rb
@@ -56,10 +56,10 @@ module IRB
         o = Output.new(grep: grep)
 
         klass = Kernel.instance_method(:class).bind(obj).call
-        obj_is_module = Kernel.instance_method(:is_a?).bind(obj).call(Module) # Class is also a Module
-        klass = obj_is_module ? obj : klass
+        obj_is_class_or_module = Module === obj
+        klass = obj_is_class_or_module ? obj : klass
 
-        o.dump("constants", obj.constants) if obj_is_module
+        o.dump("constants", obj.constants) if obj_is_class_or_module
         dump_methods(o, klass, obj)
         o.dump("instance variables", Kernel.instance_method(:instance_variables).bind(obj).call)
         o.dump("class variables", klass.class_variables)

--- a/test/irb/command/test_ls.rb
+++ b/test/irb/command/test_ls.rb
@@ -1,0 +1,71 @@
+require "tempfile"
+require_relative "../helper"
+
+module TestIRB
+  class LSTest < IntegrationTestCase
+    def setup
+      super
+
+      write_ruby <<~'RUBY'
+        class Foo
+          class Bar
+            def bar
+              "this is bar"
+            end
+          end
+
+          def foo
+            "this is foo"
+          end
+        end
+
+        class BO < BasicObject
+          ONE = 1
+          def baz
+            "this is baz"
+          end
+        end
+
+        binding.irb
+      RUBY
+    end
+
+    def test_ls_class
+      out = run_ruby_file do
+        type "ls Foo"
+        type "exit"
+      end
+
+      assert_match(/constants: Bar/, out)
+      assert_match(/Foo#methods: foo/, out)
+    end
+
+    def test_ls_instance
+      out = run_ruby_file do
+        type "ls Foo.new"
+        type "exit"
+      end
+
+      assert_match(/Foo#methods: foo/, out)
+    end
+
+    def test_ls_basic_object
+      out = run_ruby_file do
+        type "ls BO"
+        type "exit"
+      end
+
+      assert_match(/constants:.*ONE/, out)
+      assert_match(/BO#methods: baz/, out)
+    end
+
+    def test_ls_basic_object_instance
+      out = run_ruby_file do
+        type "ls BO.new"
+        type "exit"
+      end
+
+      assert_match(/BO#methods: baz/, out)
+    end
+  end
+end


### PR DESCRIPTION
When working with the `builder` gem I noticed that the irb inspection of the `Builder::XmlMarkup` instances was not working as expected. Upon further investigation it turns out, that the reason is that this class inherits from `BasicObject` directly and not from the more common `Object`. 

You can see the problem here:
```
4.0.1 :001 > ls BasicObject.new
/gems/irb-1.17.0/lib/irb/command/ls.rb:58:in 'IRB::Command::Ls#execute': undefined method 'class' for an instance of BasicObject (NoMethodError)

        klass  = (obj.class == Class || obj.class == Module ? obj : obj.class)
                     ^^^^^^
```

I have also created a new `ls` command test file containing a failing test which you can see below: https://github.com/ruby/irb/actions/runs/22390651625/job/64811518726 

The test is fixed with the second commit of this PR by using a slightly different way to inspect the `class`. `singleton_class` and `instance_variables` of an object. 

PS: The prism-latest test failure is because the syntax of ruby 4.1 allows trailing commas in method definitions and this change is addressed here: https://github.com/ruby/irb/pull/1178