### PR TITLE
Add --nobanner option to suppress startup banner

### DIFF
--- a/lib/irb/init.rb
+++ b/lib/irb/init.rb
@@ -346,6 +346,8 @@ module IRB # :nodoc:
         opt = $1 || argv.shift
         prompt_mode = opt.upcase.tr("-", "_").intern
         @CONF[:PROMPT_MODE] = prompt_mode
+      when "--nobanner"
+        @CONF[:SHOW_BANNER] = false
       when "--noprompt"
         @CONF[:PROMPT_MODE] = :NULL
       when "--script"

--- a/test/irb/test_init.rb
+++ b/test/irb/test_init.rb
@@ -285,6 +285,11 @@ module TestIRB
       assert_equal(true, IRB.conf[:USE_TRACER])
     end
 
+    def test_nobanner
+      IRB.setup(eval("__FILE__"), argv: %w[--nobanner])
+      assert_equal(false, IRB.conf[:SHOW_BANNER])
+    end
+
     private
 
     def with_argv(argv)


### PR DESCRIPTION
Add a `--nobanner` CLI option that suppresses the startup banner introduced in #1183.

Users can already disable it via `IRB.conf[:SHOW_BANNER] = false` in `.irbrc`, but this provides a command-line alternative for scripting and quick one-off usage.

Closes #1196