### PR TITLE
Fix incorrect dash in startup message

### DIFF
--- a/lib/irb/startup_message.rb
+++ b/lib/irb/startup_message.rb
@@ -48,7 +48,7 @@ module IRB
       end
 
       def build_info_lines
-        version_line = "#{Color.colorize('IRB', [:BOLD])} v#{VERSION} \u2014 Ruby #{RUBY_VERSION}"
+        version_line = "#{Color.colorize('IRB', [:BOLD])} v#{VERSION} - Ruby #{RUBY_VERSION}"
         tip_line = colorize_tip(TIPS.sample)
         dir_line = Color.colorize(short_pwd, [:CYAN])
 


### PR DESCRIPTION
Fixed the error when encoding is not set to utf-8:


```
irb/lib/irb/startup_message.rb:34:in `write': U+2014 from UTF-8 to US-ASCII (Encoding::UndefinedConversionError)
```