### PR TITLE
Fix implicit node coloring

### DIFF
--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -258,6 +258,11 @@ module IRB # :nodoc:
           super
         end
 
+        def visit_implicit_node(_node)
+          # Label of implicit nodes are colored as LABEL in visit_symbol_node.
+          # We need to prevent value part from being colored with another type.
+        end
+
         def visit_call_node(node)
           if node.call_operator_loc.nil? && OPERATORS.include?(node.name)
             # Operators should not be colored as method call

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -137,6 +137,7 @@ module TestIRB
         'ENV' => "#{BLUE}#{BOLD}#{UNDERLINE}ENV#{CLEAR}",
         'f do end' => "#{CYAN}f#{CLEAR} #{GREEN}do#{CLEAR} #{GREEN}end#{CLEAR}",
         'f true do end' => "#{CYAN}f#{CLEAR} #{CYAN}#{BOLD}true#{CLEAR} #{GREEN}do#{CLEAR} #{GREEN}end#{CLEAR}",
+        '{"foo": 1, bar:, BAZ:}' => "{#{MAGENTA}\"foo\":#{CLEAR} #{BLUE}#{BOLD}1#{CLEAR}, #{MAGENTA}bar:#{CLEAR}, #{MAGENTA}BAZ:#{CLEAR}}",
       }
 
       tests.each do |code, result|


### PR DESCRIPTION
`{ lvar:, meth:, CONST: }` was unintentionally colored as `"lvar:"(magenta)`, `"meth"(cyna) + ":"(no-color)`, `"CONST:"(magenta)`. All three labels should be colored as magenta.

v1.18.0
<img width="991" height="142" alt="image" src="https://github.com/user-attachments/assets/fafe0d82-29aa-4311-b2fd-f04bc4215a46" />

This pull request
<img width="991" height="38" alt="image" src="https://github.com/user-attachments/assets/2a36efd3-c156-461f-9922-d107b4076a8c" />
