### PR TITLE
Fix history saving when directory writability is unreliable

### DIFF
--- a/lib/irb/history.rb
+++ b/lib/irb/history.rb
@@ -64,13 +64,6 @@ module IRB
     def save_history
       return unless History.save_history?
       return unless (history_file = History.history_file)
-      unless ensure_history_file_writable(history_file)
-        warn <<~WARN
-          Can't write history to #{History.history_file.inspect} due to insufficient permissions.
-          Please verify the value of `IRB.conf[:HISTORY_FILE]`. Ensure the folder exists and that both the folder and file (if it exists) are writable.
-        WARN
-        return
-      end
 
       history = self.class::HISTORY.to_a
 
@@ -80,36 +73,43 @@ module IRB
         append_history = true
       end
 
-      File.open(history_file, (append_history ? "a" : "w"), 0o600, encoding: IRB.conf[:LC_MESSAGES]&.encoding) do |f|
-        hist = history.map { |l| l.scrub.split("\n").join("\\\n") }
+      begin
+        ensure_history_file_permissions(history_file)
 
-        unless append_history || History.infinite?
-          # Check size before slicing because array.last(huge_number) raises RangeError.
-          hist = hist.last(History.save_history) if hist.size > History.save_history
+        File.open(history_file, (append_history ? "a" : "w"), 0o600, encoding: IRB.conf[:LC_MESSAGES]&.encoding) do |f|
+          hist = history.map { |l| l.scrub.split("\n").join("\\\n") }
+
+          unless append_history || History.infinite?
+            # Check size before slicing because array.last(huge_number) raises RangeError.
+            hist = hist.last(History.save_history) if hist.size > History.save_history
+          end
+
+          f.puts(hist)
         end
-
-        f.puts(hist)
+      rescue Errno::ENOENT
+        warn <<~WARN
+          Can't write history to #{History.history_file.inspect} because the folder does not exist.
+          Please verify the value of `IRB.conf[:HISTORY_FILE]`. Ensure the folder exists.
+        WARN
+      rescue Errno::EACCES, Errno::EPERM
+        warn <<~WARN
+          Can't write history to #{History.history_file.inspect} due to insufficient permissions.
+          Please verify the value of `IRB.conf[:HISTORY_FILE]`. Ensure the folder exists and that both the folder and file (if it exists) are writable.
+        WARN
       end
     end
 
     private
 
-    # Returns boolean whether writing to +history_file+ will be possible.
     # Permissions of already existing +history_file+ are changed to
     # owner-only-readable if necessary [BUG #7694].
-    def ensure_history_file_writable(history_file)
+    def ensure_history_file_permissions(history_file)
       history_file = Pathname.new(history_file)
 
-      return false unless history_file.dirname.writable?
-      return true unless history_file.exist?
+      return unless history_file.exist?
 
-      begin
-        if history_file.stat.mode & 0o66 != 0
-          history_file.chmod 0o600
-        end
-        true
-      rescue Errno::EPERM # no permissions
-        false
+      if history_file.stat.mode & 0o66 != 0
+        history_file.chmod 0o600
       end
     end
   end

--- a/test/irb/history_test_case.rb
+++ b/test/irb/history_test_case.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: false
+require "irb"
+require "fileutils"
+require "tmpdir"
+
+require_relative "helper"
+
+module TestIRB
+  class HistoryTestCase < TestCase
+    def setup
+      @conf_backup = IRB.conf.dup
+      @original_verbose, $VERBOSE = $VERBOSE, nil
+      @tmpdir = Dir.mktmpdir("test_irb_history_")
+      setup_envs(home: @tmpdir)
+      IRB.conf[:LC_MESSAGES] = IRB::Locale.new
+      save_encodings
+      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
+    end
+
+    def teardown
+      IRB.conf.replace(@conf_backup)
+      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
+      teardown_envs
+      restore_encodings
+      $VERBOSE = @original_verbose
+      FileUtils.rm_rf(@tmpdir)
+    end
+  end
+end

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: false
-require 'irb'
 require "tempfile"
 
-require_relative "helper"
+require_relative "history_test_case"
 
 return if RUBY_PLATFORM.match?(/solaris|mswin|mingw/i)
 
@@ -14,26 +13,7 @@ module TestIRB
     Readline = ::Reline
   end
 
-  class HistoryTest < TestCase
-    def setup
-      @conf_backup = IRB.conf.dup
-      @original_verbose, $VERBOSE = $VERBOSE, nil
-      @tmpdir = Dir.mktmpdir("test_irb_history_")
-      setup_envs(home: @tmpdir)
-      IRB.conf[:LC_MESSAGES] = IRB::Locale.new
-      save_encodings
-      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
-    end
-
-    def teardown
-      IRB.conf.replace(@conf_backup)
-      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
-      teardown_envs
-      restore_encodings
-      $VERBOSE = @original_verbose
-      FileUtils.rm_rf(@tmpdir)
-    end
-
+  class HistoryTest < HistoryTestCase
     class TestInputMethodWithRelineHistory < TestInputMethod
       # When IRB.conf[:USE_MULTILINE] is true, IRB::RelineInputMethod uses Reline::History
       HISTORY = Reline::History.new(Reline.core.config)

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -169,6 +169,33 @@ module TestIRB
       assert_equal(%w"line0 line1 line2", File.read(history_file).split)
     end
 
+    def test_history_save_uses_actual_write_result_not_directory_writable_predicate
+      IRB.conf[:SAVE_HISTORY] = 1
+      io = TestInputMethodWithRelineHistory.new
+      io.class::HISTORY.clear
+      io.class::HISTORY << "line1"
+
+      history_file = IRB.rc_file("_history")
+      FileUtils.rm_f(history_file)
+
+      original_writable = Pathname.instance_method(:writable?)
+      Pathname.class_eval do
+        define_method(:writable?) { false }
+      end
+
+      assert_warn("") do
+        io.save_history
+      end
+
+      assert_equal("line1\n", File.read(history_file))
+    ensure
+      if original_writable
+        Pathname.class_eval do
+          define_method(:writable?, original_writable)
+        end
+      end
+    end
+
     def test_history_different_encodings
       IRB.conf[:SAVE_HISTORY] = 2
       IRB.conf[:LC_MESSAGES] = IRB::Locale.new("en_US.ASCII")

--- a/test/irb/test_history.rb
+++ b/test/irb/test_history.rb
@@ -169,33 +169,6 @@ module TestIRB
       assert_equal(%w"line0 line1 line2", File.read(history_file).split)
     end
 
-    def test_history_save_uses_actual_write_result_not_directory_writable_predicate
-      IRB.conf[:SAVE_HISTORY] = 1
-      io = TestInputMethodWithRelineHistory.new
-      io.class::HISTORY.clear
-      io.class::HISTORY << "line1"
-
-      history_file = IRB.rc_file("_history")
-      FileUtils.rm_f(history_file)
-
-      original_writable = Pathname.instance_method(:writable?)
-      Pathname.class_eval do
-        define_method(:writable?) { false }
-      end
-
-      assert_warn("") do
-        io.save_history
-      end
-
-      assert_equal("line1\n", File.read(history_file))
-    ensure
-      if original_writable
-        Pathname.class_eval do
-          define_method(:writable?, original_writable)
-        end
-      end
-    end
-
     def test_history_different_encodings
       IRB.conf[:SAVE_HISTORY] = 2
       IRB.conf[:LC_MESSAGES] = IRB::Locale.new("en_US.ASCII")

--- a/test/irb/test_history_windows.rb
+++ b/test/irb/test_history_windows.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: false
-require "irb"
-require "fileutils"
-require "tmpdir"
-
-require_relative "helper"
+require_relative "history_test_case"
 
 module TestIRB
-  class HistoryWindowsTest < TestCase
+  class HistoryWindowsTest < HistoryTestCase
     class TestInputMethodWithHistory < TestInputMethod
       HISTORY = []
 
@@ -19,42 +15,27 @@ module TestIRB
       end
     end
 
-    def setup
-      @conf_backup = IRB.conf.dup
-      @original_verbose, $VERBOSE = $VERBOSE, nil
-      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
-    end
-
-    def teardown
-      IRB.conf.replace(@conf_backup)
-      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
-      TestInputMethodWithHistory::HISTORY.clear
-      $VERBOSE = @original_verbose
-    end
-
     def test_history_is_saved_in_readonly_attributed_directory
       omit "Windows-only" unless windows?
 
-      Dir.mktmpdir("test_irb_history_windows_") do |tmpdir|
-        history_dir = File.join(tmpdir, "history")
-        history_file = File.join(history_dir, "irb_history")
-        FileUtils.mkdir_p(history_dir)
+      history_dir = File.join(@tmpdir, "history")
+      history_file = File.join(history_dir, "irb_history")
+      FileUtils.mkdir_p(history_dir)
 
-        with_readonly_attribute(history_dir) do
-          assert_nothing_raised do
-            File.write(File.join(history_dir, "manual_write"), "ok")
-          end
-
-          _output, warning = capture_output do
-            run_irb_with_history(history_file)
-          end
-
-          assert_equal("", warning)
-          assert_equal(<<~HISTORY, File.read(history_file))
-            puts 'history_entry'
-            exit
-          HISTORY
+      with_readonly_attribute(history_dir) do
+        assert_nothing_raised do
+          File.write(File.join(history_dir, "manual_write"), "ok")
         end
+
+        _output, warning = capture_output do
+          run_irb_with_history(history_file)
+        end
+
+        assert_equal("", warning)
+        assert_equal(<<~HISTORY, File.read(history_file))
+          puts 'history_entry'
+          exit
+        HISTORY
       end
     end
 

--- a/test/irb/test_history_windows.rb
+++ b/test/irb/test_history_windows.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: false
+require "irb"
+require "fileutils"
+require "tmpdir"
+
+require_relative "helper"
+
+module TestIRB
+  class HistoryWindowsTest < TestCase
+    class TestInputMethodWithHistory < TestInputMethod
+      HISTORY = []
+
+      include IRB::HistorySavingAbility
+
+      def gets
+        super&.tap do |line|
+          HISTORY << line unless line.empty?
+        end
+      end
+    end
+
+    def setup
+      @conf_backup = IRB.conf.dup
+      @original_verbose, $VERBOSE = $VERBOSE, nil
+      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
+    end
+
+    def teardown
+      IRB.conf.replace(@conf_backup)
+      IRB.instance_variable_set(:@existing_rc_name_generators, nil)
+      TestInputMethodWithHistory::HISTORY.clear
+      $VERBOSE = @original_verbose
+    end
+
+    def test_history_is_saved_in_readonly_attributed_directory
+      omit "Windows-only" unless windows?
+
+      Dir.mktmpdir("test_irb_history_windows_") do |tmpdir|
+        history_dir = File.join(tmpdir, "history")
+        history_file = File.join(history_dir, "irb_history")
+        FileUtils.mkdir_p(history_dir)
+
+        with_readonly_attribute(history_dir) do
+          assert_nothing_raised do
+            File.write(File.join(history_dir, "manual_write"), "ok")
+          end
+
+          _output, warning = capture_output do
+            run_irb_with_history(history_file)
+          end
+
+          assert_equal("", warning)
+          assert_equal(<<~HISTORY, File.read(history_file))
+            puts 'history_entry'
+            exit
+          HISTORY
+        end
+      end
+    end
+
+    private
+
+    def with_readonly_attribute(path)
+      assert(system("attrib", "+R", windows_path(path)), "failed to set read-only attribute on #{path}")
+      yield
+    ensure
+      system("attrib", "-R", windows_path(path)) if path && File.directory?(path)
+    end
+
+    def windows_path(path)
+      return path unless File::ALT_SEPARATOR
+
+      path.tr(File::SEPARATOR, File::ALT_SEPARATOR)
+    end
+
+    def run_irb_with_history(history_file)
+      IRB.init_config(nil)
+      IRB.init_error
+      IRB.conf[:PROMPT_MODE] = :SIMPLE
+      IRB.conf[:SAVE_HISTORY] = 100
+      IRB.conf[:HISTORY_FILE] = history_file
+      IRB.conf[:USE_PAGER] = false
+
+      input = TestInputMethodWithHistory.new(["puts 'history_entry'", "exit"])
+      irb = IRB::Irb.new(IRB::WorkSpace.new(Object.new), input)
+      irb.context.return_format = "=> %s\n"
+      irb.run(IRB.conf)
+    ensure
+      TestInputMethodWithHistory::HISTORY.clear
+    end
+  end
+end


### PR DESCRIPTION
## Problem

- [Issue #1219](https://github.com/ruby/irb/issues/1219) reports that IRB on Windows can warn `Can't write history ... due to insufficient permissions` on exit even though writing the same history file manually succeeds.
- The failing preflight came from [`IRB::HistorySavingAbility#ensure_history_file_writable`](https://github.com/ruby/irb/blob/b140bfcf2aadc848630af17177fcad4f0059f5bc/lib/irb/history.rb#L64-L104), which checked `history_file.dirname.writable?` before attempting the history write.
- On Windows, Ruby's [`w32_access`](https://github.com/ruby/ruby/blob/12c8599ffa3c0a0b8df7741e06ae352e52cb463e/win32/win32.c#L5986-L5999) checks synthetic Unix-style mode bits derived from [Windows file attributes](https://github.com/ruby/ruby/blob/12c8599ffa3c0a0b8df7741e06ae352e52cb463e/win32/win32.c#L5649-L5657); that path can disagree with the actual write operation for directories.
- Microsoft documents that the [read-only attribute is not honored on directories](https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants), so a directory-level writable predicate is the wrong source of truth for whether IRB can create or update a history file.

## Solution

- This changes history saving to normalize permissions only for an existing history file, then attempt the real `File.open` write and report `ENOENT`, `EACCES`, or `EPERM` from [that operation](https://github.com/ruby/irb/blob/d52a03298c623f1c7daa7c280351e893d8a77944/lib/irb/history.rb#L64-L99).
- This keeps the existing [owner-only permission normalization behavior](https://github.com/ruby/irb/blob/d52a03298c623f1c7daa7c280351e893d8a77944/lib/irb/history.rb#L104-L113) for existing history files while removing the parent directory `writable?` gate.
- This adds a Windows-only regression test that sets a temporary history directory read-only with [`attrib +R`](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/attrib), verifies that a normal file write still succeeds, runs an IRB session, and asserts that the history file is saved without warnings in [`test_history_windows.rb`](https://github.com/ruby/irb/blob/d52a03298c623f1c7daa7c280351e893d8a77944/test/irb/test_history_windows.rb#L18-L38).
- This shares the history test fixture through [`HistoryTestCase`](https://github.com/ruby/irb/blob/d52a03298c623f1c7daa7c280351e893d8a77944/test/irb/history_test_case.rb#L9-L27), so [`HistoryTest`](https://github.com/ruby/irb/blob/d52a03298c623f1c7daa7c280351e893d8a77944/test/irb/test_history.rb#L16-L17) and [`HistoryWindowsTest`](https://github.com/ruby/irb/blob/d52a03298c623f1c7daa7c280351e893d8a77944/test/irb/test_history_windows.rb#L4-L5) use the same setup without making the Windows regression inherit the full non-Windows test suite.
- The new file is included by the repository's [`test/irb/**/test_*.rb`](https://github.com/ruby/irb/blob/d52a03298c623f1c7daa7c280351e893d8a77944/Rakefile#L5-L10) test pattern, while its own [`windows?` guard](https://github.com/ruby/irb/blob/d52a03298c623f1c7daa7c280351e893d8a77944/test/irb/test_history_windows.rb#L18-L19) omits the case on non-Windows platforms.