### PR TITLE
Update Ruby::Box context-mode test for per-box RubyGems

### DIFF
--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -994,6 +994,11 @@ module TestIRB
     def test_context_mode_ruby_box
       omit if RUBY_VERSION < "4.0.0"
       @envs['RUBY_BOX'] = '1'
+      # Ruby::Box now initializes RubyGems per box upstream. Avoid loading bundler context into test execution context.
+      %w[BUNDLER_SETUP BUNDLER_VERSION BUNDLE_BIN_PATH BUNDLE_GEMFILE RUBYOPT].each do |env|
+        @envs[env] = nil
+      end
+      @envs['RUBYLIB'] = Gem.loaded_specs.fetch('reline').full_require_paths.join(File::PATH_SEPARATOR)
 
       write_rc <<~'RUBY'
         IRB.conf[:CONTEXT_MODE] = 5


### PR DESCRIPTION
## Problem

Ruby upstream changed Ruby::Box so RubyGems state is separated per box; the upstream commit says each box has its own RubyGems copy ([ruby/ruby@276f0d9](https://github.com/ruby/ruby/commit/276f0d9b3efbabe46e74510e5e3585924b37772c)). On Ruby head, `TestIRB::ContextModeTest#test_context_mode_ruby_box` failed because inherited Bundler setup evaluated `irb.gemspec` inside the box and raised `uninitialized constant Gem::Specification` ([failed job](https://github.com/ruby/irb/actions/runs/26458147236/job/77898023298)).

The latest-reline matrix resolves `reline` from `ruby/reline` when `WITH_LATEST_RELINE=true` ([Gemfile](https://github.com/ruby/irb/blob/4c10b967fad98882d4d56587374292647aa60423/Gemfile#L15)). Clearing Bundler setup without preserving the resolved require path made the Ruby 4.0/head latest-reline jobs fail to load `reline` ([4.0 job](https://github.com/ruby/irb/actions/runs/26723778267/job/78755416280), [head job](https://github.com/ruby/irb/actions/runs/26723778267/job/78755416305)).

## Solution

Clear the inherited Bundler environment for this Ruby::Box integration test while passing the resolved `reline` require path through `RUBYLIB` ([commit](https://github.com/ruby/irb/commit/4c10b967fad98882d4d56587374292647aa60423)). This keeps the existing context-mode isolation assertions focused on `Integer#+` behavior ([commit](https://github.com/ruby/irb/commit/4c10b967fad98882d4d56587374292647aa60423)).
