### PR TITLE
Sort remaining completion candidates in RegexpCompletor

### DIFF
--- a/lib/irb/completion.rb
+++ b/lib/irb/completion.rb
@@ -302,7 +302,7 @@ module IRB
           rescue EncodingError
             # ignore
           end
-          candidates.grep(/^#{Regexp.quote(sym)}/)
+          candidates.grep(/^#{Regexp.quote(sym)}/).sort
         end
       when /^::([A-Z][^:\.\(\)]*)$/
         # Absolute Constant or class methods
@@ -313,7 +313,7 @@ module IRB
         if doc_namespace
           candidates.find { |i| i == receiver }
         else
-          candidates.grep(/^#{Regexp.quote(receiver)}/).collect{|e| "::" + e}
+          candidates.grep(/^#{Regexp.quote(receiver)}/).sort.collect{|e| "::" + e}
         end
 
       when /^([A-Z].*)::([^:.]*)$/
@@ -331,7 +331,7 @@ module IRB
             candidates = []
           end
 
-          select_message(receiver, message, candidates.sort, "::")
+          select_message(receiver, message, candidates, "::")
         end
 
       when /^(:[^:.]+)(\.|::)([^.]*)$/
@@ -400,7 +400,7 @@ module IRB
         if doc_namespace
           all_gvars.find{ |i| i == gvar }
         else
-          all_gvars.grep(Regexp.new(Regexp.quote(gvar)))
+          all_gvars.grep(Regexp.new(Regexp.quote(gvar))).sort
         end
 
       when /^([^.:"].*)(\.|::)([^.]*)$/
@@ -452,7 +452,7 @@ module IRB
         if doc_namespace
           "String.#{candidates.find{ |i| i == message }}"
         else
-          select_message(receiver, message, candidates.sort)
+          select_message(receiver, message, candidates)
         end
       when /^\s*$/
         # empty input
@@ -491,7 +491,11 @@ module IRB
     Operators = %w[% & * ** + - / < << <= <=> == === =~ > >= >> [] []= ^ ! != !~]
 
     def select_message(receiver, message, candidates, sep = ".")
-      candidates.grep(/^#{Regexp.quote(message)}/).collect do |e|
+      sorted_candidates = candidates.grep(/^#{Regexp.quote(message)}/).sort_by do |e|
+        # Alphabetical order, but internal methods (leading underscore) last
+        [e.start_with?('_') ? 1 : 0, e]
+      end
+      sorted_candidates.collect do |e|
         case e
         when /^[a-zA-Z_]/
           receiver + sep + e

--- a/test/irb/test_completion.rb
+++ b/test/irb/test_completion.rb
@@ -95,6 +95,17 @@ module TestIRB
         assert_include(completion_candidates("String.ne", binding), "String.new")
         assert_equal("String.new", doc_namespace("String.new", binding))
       end
+
+      def test_complete_methods_are_sorted
+        u = ''
+        u.clear
+
+        candidates = completion_candidates("u.", binding)
+        assert_include(candidates, "u.__id__")
+        underscore, regular = candidates.partition { |c| c.start_with?("u._") }
+        # Alphabetical order, internal methods (leading underscore) last
+        assert_equal(regular.sort + underscore.sort, candidates)
+      end
     end
 
     class RequireComepletionTest < CompletionTest
@@ -215,6 +226,11 @@ module TestIRB
         candidates = completion_candidates("xz", binding)
         assert_equal(%w[xzy xzy2 xzy_1], candidates)
       end
+
+      def test_complete_sort_global_variables
+        candidates = completion_candidates("$std", binding)
+        assert_equal(%w[$stderr $stdin $stdout], candidates)
+      end
     end
 
     class ConstantCompletionTest < CompletionTest
@@ -253,6 +269,18 @@ module TestIRB
       assert_empty(completion_candidates(":irb_unknown_symbol_abcdefg", binding))
       # Do not complete empty symbol for performance reason
       assert_empty(completion_candidates(":", binding))
+    end
+
+    def test_complete_symbols_are_sorted
+      candidates = completion_candidates(":a", binding)
+      refute_empty(candidates)
+      assert_equal(candidates.sort, candidates)
+    end
+
+    def test_complete_absolute_constants_are_sorted
+      candidates = completion_candidates("::S", binding)
+      refute_empty(candidates)
+      assert_equal(candidates.sort, candidates)
     end
 
     def test_complete_invalid_three_colons


### PR DESCRIPTION
#379 sorted local variables and string method candidates (fixing #349), but `receiver.method` completion — the most common case — still returns candidates in method table order, which looks random. Same for symbols, global variables and `::` constants. With an ActiveRecord model, `u.email_address` is listed below all its generated variants:

```
u.email_address_before_last_save
u.email_address_change_to_be_saved
u.email_address=
...
u.email_address
```

This sorts candidates in `select_message` (making the two pre-sorted call sites redundant) and in the symbol/gvar/absolute constant branches.

One detail: candidates starting with `_` are sorted last, otherwise completing `u.` would begin with `__id__`, `__send__`, `_run_commit_callbacks` and similar internals instead of regular methods. Same change for TypeCompletor is proposed in ruby/repl_type_completor#78.