### PR TITLE
Accomodate new prism token

### DIFF
--- a/lib/irb/color.rb
+++ b/lib/irb/color.rb
@@ -99,6 +99,7 @@ module IRB # :nodoc:
       REGEXP_BEGIN:       [RED, BOLD],
       REGEXP_END:         [RED, BOLD],
       STRING_BEGIN:       [RED, BOLD],
+      XSTRING_BEGIN:      [RED, BOLD],
       STRING_CONTENT:     [RED],
       STRING_END:         [RED, BOLD],
       __END__:            [GREEN],

--- a/test/irb/test_color.rb
+++ b/test/irb/test_color.rb
@@ -101,6 +101,7 @@ module TestIRB
         "foo %i[bar]" => "#{CYAN}foo#{CLEAR} #{YELLOW}%i[#{CLEAR}#{YELLOW}bar#{CLEAR}#{YELLOW}]#{CLEAR}",
         "foo :@bar, baz, :@@qux, :$quux" => "#{CYAN}foo#{CLEAR} #{YELLOW}:#{CLEAR}#{YELLOW}@bar#{CLEAR}, #{CYAN}baz#{CLEAR}, #{YELLOW}:#{CLEAR}#{YELLOW}@@qux#{CLEAR}, #{YELLOW}:#{CLEAR}#{YELLOW}$quux#{CLEAR}",
         "`echo`" => "#{RED}#{BOLD}`#{CLEAR}#{RED}echo#{CLEAR}#{RED}#{BOLD}`#{CLEAR}",
+        "foo.`(bar)" => "#{CYAN}foo#{CLEAR}.#{CYAN}`#{CLEAR}(#{CYAN}bar#{CLEAR})",
         "\t" => Reline::Unicode.escape_for_print("\t") == '  ' ? '  ' : "\t", # not ^I
         "foo(*%W(bar))" => "#{CYAN}foo#{CLEAR}(*#{RED}#{BOLD}%W(#{CLEAR}#{RED}bar#{CLEAR}#{RED}#{BOLD})#{CLEAR})",
         "$stdout" => "#{GREEN}#{BOLD}$stdout#{CLEAR}",


### PR DESCRIPTION
Changed in https://github.com/ruby/prism/pull/4199.
Other token changes are irrelevant since they are already not used.

cc @kddnewton 