### PR TITLE
Revert "Update Ruby::Box context-mode test (#1221)"

### DIFF
--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -994,11 +994,6 @@ module TestIRB
     def test_context_mode_ruby_box
       omit if RUBY_VERSION < "4.0.0"
       @envs['RUBY_BOX'] = '1'
-      # Ruby::Box now initializes RubyGems per box upstream. Avoid loading bundler context into test execution context.
-      %w[BUNDLER_SETUP BUNDLER_VERSION BUNDLE_BIN_PATH BUNDLE_GEMFILE RUBYOPT].each do |env|
-        @envs[env] = nil
-      end
-      @envs['RUBYLIB'] = Gem.loaded_specs.fetch('reline').full_require_paths.join(File::PATH_SEPARATOR)
 
       write_rc <<~'RUBY'
         IRB.conf[:CONTEXT_MODE] = 5


### PR DESCRIPTION
This reverts commit ffaf5f1e01640dae25788fe7f4f67fc6199b752e.

Background:
CI in ruby/ruby seems failing https://github.com/ruby/ruby/pull/18207#issuecomment-5194345591
I hope removing this workaround fixes the problem (if require in box is already fixed).