### PR TITLE
Apply Ruby::Box test env workaround only when running under bundler

### DIFF
--- a/test/irb/test_irb.rb
+++ b/test/irb/test_irb.rb
@@ -994,11 +994,18 @@ module TestIRB
     def test_context_mode_ruby_box
       omit if RUBY_VERSION < "4.0.0"
       @envs['RUBY_BOX'] = '1'
-      # Ruby::Box now initializes RubyGems per box upstream. Avoid loading bundler context into test execution context.
-      %w[BUNDLER_SETUP BUNDLER_VERSION BUNDLE_BIN_PATH BUNDLE_GEMFILE RUBYOPT].each do |env|
-        @envs[env] = nil
+      # bundler/setup loaded via RUBYOPT fails inside Ruby::Box (Ruby::Box
+      # initializes RubyGems per box, and Gem::Specification is not defined when
+      # Bundler evaluates irb.gemspec), so remove the bundler context from the
+      # child process. Keep the env intact when not under bundler: in ruby/ruby's
+      # test-bundled-gems, inherited RUBYOPT/RUBYLIB carry the build-tree load
+      # paths without which the child cannot require prism.
+      if ENV['RUBYOPT']&.include?('bundler/setup')
+        %w[BUNDLER_SETUP BUNDLER_VERSION BUNDLE_BIN_PATH BUNDLE_GEMFILE RUBYOPT].each do |env|
+          @envs[env] = nil
+        end
+        @envs['RUBYLIB'] = Gem.loaded_specs.fetch('reline').full_require_paths.join(File::PATH_SEPARATOR)
       end
-      @envs['RUBYLIB'] = Gem.loaded_specs.fetch('reline').full_require_paths.join(File::PATH_SEPARATOR)
 
       write_rc <<~'RUBY'
         IRB.conf[:CONTEXT_MODE] = 5


### PR DESCRIPTION
The workaround added in ffaf5f1 clears RUBYOPT/RUBYLIB unconditionally. In ruby/ruby's test-bundled-gems, the spawned child needs those variables to locate the build-tree stdlib, so it failed with "cannot load such file -- prism".

Clearing the bundler context is only needed when the test itself runs under bundler, where bundler/setup inherited via RUBYOPT crashes inside Ruby::Box with "uninitialized constant Gem::Specification". Restrict the workaround to that case and keep the env intact otherwise.