### PR TITLE
Honor explicit AUTO_INDENT false in prompt modes

### DIFF
--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -475,8 +475,8 @@ module IRB
       @prompt_c = pconf[:PROMPT_C]
       @return_format = pconf[:RETURN]
       @return_format = "%s\n" if @return_format == nil
-      if ai = pconf.include?(:AUTO_INDENT)
-        @auto_indent_mode = ai
+      if pconf.include?(:AUTO_INDENT)
+        @auto_indent_mode = pconf[:AUTO_INDENT]
       else
         @auto_indent_mode = IRB.conf[:AUTO_INDENT]
       end


### PR DESCRIPTION
## Summary

Read the prompt mode's `AUTO_INDENT` value after checking key presence, so an explicit `false` disables indentation instead of becoming `true`.

## Reproduction

A prompt configuration containing `AUTO_INDENT: false` currently stores the result of `Hash#include?`, which is `true`. The candidate stores the configured value.

## Verification

- current and cumulative candidate suites: 402 tests / 2,488 assertions, zero failures/errors and three omissions
- all 111 Ruby files pass syntax
- RuboCop checks 113 files with no offenses
- RDoc and Rails 8.1.3.1 loading pass

## Compatibility

Only explicit false prompt configuration changes, to match its documented intent. Prepared with AI-assisted source review; no repository tests were changed.
