### PR TITLE
Remove temporary eval history configuration

### DIFF
--- a/lib/irb/ext/eval_history.rb
+++ b/lib/irb/ext/eval_history.rb
@@ -50,7 +50,7 @@ module IRB # :nodoc:
           @eval_history_values = EvalHistory.new(no)
           IRB.conf[:__TMP__EHV__] = @eval_history_values
           workspace.evaluate("__ = IRB.conf[:__TMP__EHV__]")
-          IRB.conf.delete(:__TMP_EHV__)
+          IRB.conf.delete(:__TMP__EHV__)
         end
       else
         @eval_history_values = nil


### PR DESCRIPTION
## Summary

Delete the same temporary configuration key that eval-history initialization inserts.

## Reproduction

Initialization writes `IRB.conf[:__TMP__EHV__]` but deletes the mistyped `:__TMP_EHV__`, leaving the history object in global configuration after the workspace binding is established.

## Verification

- current and cumulative candidate suites: 402 tests / 2,488 assertions, zero failures/errors and three omissions
- all 111 Ruby files pass syntax
- RuboCop checks 113 files with no offenses
- RDoc and Rails 8.1.3.1 loading pass

## Compatibility

Removes only an internal temporary key after its intended one-shot use. Prepared with AI-assisted source review; no repository tests were changed.
