### PR TITLE
fix: remove debug message

### DIFF
--- a/lib/irb/startup_message.rb
+++ b/lib/irb/startup_message.rb
@@ -14,7 +14,6 @@ module IRB
       '"cd object" to navigate into an object',
       '"show_source method" to view source code',
       '"copy expr" to copy the output to clipboard',
-      '"debug" to start integration with the "debug" gem',
       '"history -g pattern" to search history',
     ].freeze
 


### PR DESCRIPTION
closes #1227 

First, I considered updating the startup message to `"debug" to start integration with the "debug" gem if irb started with binding.irb.`
However, as noted in the issue description, adding this text makes the startup banner overly verbose. I went with [removing the message / conditionally displaying it only when binding.irb is present] instead to keep the output clean.